### PR TITLE
feat(metadata): introduce next update date

### DIFF
--- a/pkg/app.go
+++ b/pkg/app.go
@@ -2,6 +2,7 @@ package pkg
 
 import (
 	"strings"
+	"time"
 
 	"github.com/aquasecurity/trivy-db/pkg/utils"
 
@@ -36,6 +37,12 @@ func NewApp(version string) *cli.App {
 					Name:  "cache-dir",
 					Usage: "cache directory path",
 					Value: utils.CacheDir(),
+				},
+				cli.DurationFlag{
+					Name:   "update-interval",
+					Usage:  "update interval",
+					Value:  24 * time.Hour,
+					EnvVar: "UPDATE_INTERVAL",
 				},
 			},
 		},

--- a/pkg/build.go
+++ b/pkg/build.go
@@ -16,7 +16,8 @@ func build(c *cli.Context) error {
 
 	targets := c.String("only-update")
 	light := c.Bool("light")
-	if err := vulnsrc.Update(strings.Split(targets, ","), cacheDir, light); err != nil {
+	updateInterval := c.Duration("update-interval")
+	if err := vulnsrc.Update(strings.Split(targets, ","), cacheDir, light, updateInterval); err != nil {
 		return err
 	}
 

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -45,9 +45,9 @@ type Operations interface {
 }
 
 type Metadata struct {
-	Version   int
-	Type      Type
-	UpdatedAt time.Time
+	Version    int
+	Type       Type
+	NextUpdate time.Time
 }
 
 type Config struct {

--- a/pkg/vulnsrc/vulnsrc.go
+++ b/pkg/vulnsrc/vulnsrc.go
@@ -61,7 +61,7 @@ func init() {
 	}
 }
 
-func Update(targets []string, cacheDir string, light bool) error {
+func Update(targets []string, cacheDir string, light bool, updateInterval time.Duration) error {
 	log.Println("Updating vulnerability database...")
 
 	for _, distribution := range targets {
@@ -83,9 +83,9 @@ func Update(targets []string, cacheDir string, light bool) error {
 	}
 
 	err := dbc.SetMetadata(db.Metadata{
-		Version:   db.SchemaVersion,
-		Type:      dbType,
-		UpdatedAt: time.Now().UTC(),
+		Version:    db.SchemaVersion,
+		Type:       dbType,
+		NextUpdate: time.Now().UTC().Add(updateInterval),
 	})
 	if err != nil {
 		return xerrors.Errorf("failed to save metadata: %w", err)


### PR DESCRIPTION
Trivy extracts this date from a local DB file. If the current time exceeds this time, Trivy fetches new DB file from GitHub Release. If no, Trivy automatically skips updating.