### PR TITLE
test(github): return an error with 404

### DIFF
--- a/pkg/github/github_test.go
+++ b/pkg/github/github_test.go
@@ -278,10 +278,10 @@ func TestClient_UploadReleaseAsset(t *testing.T) {
 						},
 						response: &github.Response{
 							Response: &http.Response{
-								StatusCode: 404,
+								StatusCode: http.StatusNotFound,
 							},
 						},
-						err: nil,
+						err: errors.New("not found"),
 					},
 				},
 			},


### PR DESCRIPTION
The current tests returns nil as an error with status code 404. Actually, http package returns an error with 404.
Related: https://github.com/aquasecurity/trivy-db/pull/1