### PR TITLE
fix(redhat): ignore an empty package name

### DIFF
--- a/pkg/vulnsrc/redhat/redhat.go
+++ b/pkg/vulnsrc/redhat/redhat.go
@@ -120,6 +120,9 @@ func (vs VulnSrc) save(cves []RedhatCVE) error {
 				advisory := types.Advisory{
 					FixedVersion: version,
 				}
+				if pkgName == "" {
+					continue
+				}
 				if err := vs.dbc.PutAdvisory(tx, platformName, pkgName, cve.Name, advisory); err != nil {
 					return xerrors.Errorf("failed to save Red Hat advisory: %w", err)
 				}


### PR DESCRIPTION
In rare cases, the package name may be empty. I think it is a bug of Red Hat. We need to ignore that case.

https://access.redhat.com/security/cve/CVE-2018-12126

![image](https://user-images.githubusercontent.com/2253692/68088260-d7f7bd00-fe65-11e9-80b2-676b03d1980d.png)
