### PR TITLE
feat(oracle) Add oracle linux oval

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/etcd-io/bbolt v1.3.3
 	github.com/fatih/color v1.7.0
 	github.com/google/go-github/v28 v28.1.1
+	github.com/knqyf263/go-rpm-version v0.0.0-20170716094938-74609b86c936
 	github.com/stretchr/testify v1.4.0
 	github.com/urfave/cli v1.20.0
 	golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421

--- a/go.sum
+++ b/go.sum
@@ -117,6 +117,7 @@ github.com/kevinburke/ssh_config v0.0.0-20180830205328-81db2a75821e/go.mod h1:CT
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/knqyf263/berkeleydb v0.0.0-20190501065933-fafe01fb9662/go.mod h1:bu1CcN4tUtoRcI/B/RFHhxMNKFHVq/c3SV+UTyduoXg=
 github.com/knqyf263/go-deb-version v0.0.0-20190517075300-09fca494f03d/go.mod h1:o8sgWoz3JADecfc/cTYD92/Et1yMqMy0utV1z+VaZao=
+github.com/knqyf263/go-rpm-version v0.0.0-20170716094938-74609b86c936 h1:HDjRqotkViMNcGMGicb7cgxklx8OwnjtCBmyWEqrRvM=
 github.com/knqyf263/go-rpm-version v0.0.0-20170716094938-74609b86c936/go.mod h1:i4sF0l1fFnY1aiw08QQSwVAFxHEm311Me3WsU/X7nL0=
 github.com/knqyf263/go-rpmdb v0.0.0-20190501070121-10a1c42a10dc/go.mod h1:MrSSvdMpTSymaQWk1yFr9sxFSyQmKMj6jkbvGrchBV8=
 github.com/knqyf263/go-version v1.1.1/go.mod h1:0tBvHvOBSf5TqGNcY+/ih9o8qo3R16iZCpB9rP0D3VM=

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 
 	"golang.org/x/xerrors"
 )
@@ -88,4 +89,19 @@ func Exec(command string, args []string) (string, error) {
 		return "", xerrors.Errorf("failed to exec: %w", err)
 	}
 	return stdoutBuf.String(), nil
+}
+
+func Uniq(strings []string) []string {
+	uniqMap := make(map[string]struct{})
+	for _, s := range strings {
+		uniqMap[s] = struct{}{}
+	}
+	keys := []string{}
+	for key := range uniqMap {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		return keys[i] > keys[j]
+	})
+	return keys
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -92,16 +92,18 @@ func Exec(command string, args []string) (string, error) {
 }
 
 func Uniq(strings []string) []string {
-	uniqMap := make(map[string]struct{})
-	for _, s := range strings {
-		uniqMap[s] = struct{}{}
-	}
-	keys := []string{}
-	for key := range uniqMap {
-		keys = append(keys, key)
-	}
-	sort.Slice(keys, func(i, j int) bool {
-		return keys[i] > keys[j]
+	sort.Slice(strings, func(i, j int) bool {
+		return strings[i] < strings[j]
 	})
-	return keys
+
+	ret := []string{}
+	preStr := ""
+	for _, s := range strings {
+		if preStr != s {
+			ret = append(ret, s)
+		}
+		preStr = s
+	}
+
+	return ret
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -5,11 +5,11 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/aquasecurity/trivy/pkg/log"
+	"github.com/stretchr/testify/assert"
 )
 
 func touch(t *testing.T, name string) {
@@ -126,11 +126,9 @@ func TestUniq(t *testing.T) {
 			},
 		},
 	}
-	for i, testCase := range testCases {
+	for _, testCase := range testCases {
 		actualData := Uniq(testCase.inputData)
-		if !reflect.DeepEqual(actualData, testCase.expectData) {
-			t.Errorf("No: %d, name: %s, actual: %+v, expect: %+v", i+1, testCase.name, actualData, testCase.expectData)
-		}
+		assert.Equal(t, actualData, testCase.expectData, testCase.name)
 	}
 
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -81,4 +82,55 @@ func TestFileWalk(t *testing.T) {
 	if string(contentFoo3) != "foo3" {
 		t.Error("The file content is wrong")
 	}
+}
+
+func TestUniq(t *testing.T) {
+	testCases := []struct {
+		name       string
+		inputData  []string
+		expectData []string
+	}{
+		{
+
+			name: "positive test",
+			inputData: []string{
+				"test string 1",
+				"test string 3",
+				"test string 2",
+				"test string 1",
+				"test string 2",
+				"test string 3",
+			},
+			expectData: []string{
+				"test string 1",
+				"test string 2",
+				"test string 3",
+			},
+		},
+		{
+			name:       "positive test input empty",
+			inputData:  []string{},
+			expectData: []string{},
+		},
+		{
+			name: "positive test input uniq",
+			inputData: []string{
+				"test string 1",
+				"test string 3",
+				"test string 2",
+			},
+			expectData: []string{
+				"test string 1",
+				"test string 2",
+				"test string 3",
+			},
+		},
+	}
+	for i, testCase := range testCases {
+		actualData := Uniq(testCase.inputData)
+		if !reflect.DeepEqual(actualData, testCase.expectData) {
+			t.Errorf("No: %d, name: %s, actual: %+v, expect: %+v", i+1, testCase.name, actualData, testCase.expectData)
+		}
+	}
+
 }

--- a/pkg/vulnsrc/oracle-oval/oracle-oval.go
+++ b/pkg/vulnsrc/oracle-oval/oracle-oval.go
@@ -168,20 +168,16 @@ func walkOracle(cri Criteria, osVer string, pkgs []AffectedPackage) []AffectedPa
 	return pkgs
 }
 
-func referencesFromContains(sources []string, matches []string) (references []string) {
-	uniqMap := make(map[string]struct{})
-	for _, m := range matches {
-		uniqMap[m] = struct{}{}
-	}
-
+func referencesFromContains(sources []string, matches []string) []string {
+	references := []string{}
 	for _, s := range sources {
-		for m := range uniqMap {
+		for _, m := range matches {
 			if strings.Contains(s, m) {
 				references = append(references, s)
 			}
 		}
 	}
-	return
+	return utils.Uniq(references)
 }
 
 func severityFromThreat(sev string) types.Severity {

--- a/pkg/vulnsrc/oracle-oval/oracle-oval.go
+++ b/pkg/vulnsrc/oracle-oval/oracle-oval.go
@@ -101,7 +101,7 @@ func (vs VulnSrc) commit(tx *bolt.Tx, ovals []OracleOVAL) error {
 
 			for _, vulnID := range vulnIDs {
 				if err := vs.dbc.PutAdvisory(tx, platformName, affectedPkg.Package.Name, vulnID, advisory); err != nil {
-					return xerrors.Errorf("failed to save Oracle Linux OVAL CVE-ID: %w", err)
+					return xerrors.Errorf("failed to save Oracle Linux OVAL: %w", err)
 				}
 			}
 		}

--- a/pkg/vulnsrc/oracle-oval/oracle-oval.go
+++ b/pkg/vulnsrc/oracle-oval/oracle-oval.go
@@ -1,0 +1,173 @@
+package oracleoval
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"path/filepath"
+	"strings"
+
+	bolt "github.com/etcd-io/bbolt"
+
+	"github.com/aquasecurity/trivy-db/pkg/db"
+	"github.com/aquasecurity/trivy-db/pkg/types"
+	"github.com/aquasecurity/trivy-db/pkg/utils"
+	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/vulnerability"
+	version "github.com/knqyf263/go-rpm-version"
+	"golang.org/x/xerrors"
+)
+
+var (
+	// cat /etc/os-release ORACLE_BUGZILLA_PRODUCT="Oracle Linux 8"
+	platformFormat  = "Oracle Linux %s"
+	targetPlatforms = []string{"Oracle Linux 5", "Oracle Linux 6", "Oracle Linux 7", "Oracle Linux 8"}
+	oracleDir       = filepath.Join("oval", "oracle")
+)
+
+type VulnSrc struct {
+	dbc db.Operations
+}
+
+func NewVulnSrc() VulnSrc {
+	return VulnSrc{
+		dbc: db.Config{},
+	}
+}
+
+func (vs VulnSrc) Update(dir string) error {
+	rootDir := filepath.Join(dir, "vuln-list", oracleDir)
+
+	var cves []OracleOVAL
+	err := utils.FileWalk(rootDir, func(r io.Reader, path string) error {
+		var cve OracleOVAL
+		if err := json.NewDecoder(r).Decode(&cve); err != nil {
+			return xerrors.Errorf("failed to decode Oracle Linux OVAL JSON: %w", err)
+		}
+		cves = append(cves, cve)
+		return nil
+	})
+	if err != nil {
+		return xerrors.Errorf("error in Oracle Linux OVAL walk: %w", err)
+	}
+
+	if err = vs.save(cves); err != nil {
+		return xerrors.Errorf("error in Oracle Linux OVAL save: %w", err)
+	}
+
+	return nil
+}
+
+func (vs VulnSrc) save(cves []OracleOVAL) error {
+	log.Println("Saving Oracle Linux OVAL")
+
+	err := vs.dbc.BatchUpdate(func(tx *bolt.Tx) error {
+		return vs.commit(tx, cves)
+	})
+	if err != nil {
+		return xerrors.Errorf("error in batch update: %w", err)
+	}
+
+	return nil
+
+}
+
+func (vs VulnSrc) commit(tx *bolt.Tx, cves []OracleOVAL) error {
+	for _, cve := range cves {
+		elsaID := strings.TrimLeft(strings.Split(cve.Title, ":")[0], "\n")
+
+		affectedPkgs := walkOracle(cve.Criteria, "", []AffectedPackage{})
+		for _, affectedPkg := range affectedPkgs {
+			advisory := types.Advisory{
+				FixedVersion: affectedPkg.Package.FixedVersion,
+			}
+			if affectedPkg.Package.Name == "" {
+				continue
+			}
+			platformName := fmt.Sprintf(platformFormat, affectedPkg.OSVer)
+			if !utils.StringInSlice(platformName, targetPlatforms) {
+				continue
+			}
+			if err := vs.dbc.PutAdvisory(tx, platformName, affectedPkg.Package.Name, elsaID, advisory); err != nil {
+				return xerrors.Errorf("failed to save Oracle Linux OVAL advisory: %w", err)
+			}
+		}
+
+		var references []string
+		for _, ref := range cve.References {
+			references = append(references, ref.URI)
+		}
+
+		vuln := types.VulnerabilityDetail{
+			Description: cve.Description,
+			References:  references,
+			Title:       strings.TrimLeft(cve.Title, "\n"),
+			Severity:    severityFromThreat(cve.Severity),
+		}
+
+		if err := vs.dbc.PutVulnerabilityDetail(tx, elsaID, vulnerability.OracleOVAL, vuln); err != nil {
+			return xerrors.Errorf("failed to save Oracle Linux OVAL vulnerability: %w", err)
+		}
+
+		// for light DB
+		if err := vs.dbc.PutSeverity(tx, elsaID, types.SeverityUnknown); err != nil {
+			return xerrors.Errorf("failed to save Oracle Linux vulnerability severity: %w", err)
+		}
+	}
+	return nil
+
+}
+
+func (vs VulnSrc) Get(release string, pkgName string) ([]types.Advisory, error) {
+	bucket := fmt.Sprintf(platformFormat, release)
+	advisories, err := vs.dbc.GetAdvisories(bucket, pkgName)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to get Oracle Linux advisories: %w", err)
+	}
+	return advisories, nil
+}
+
+func walkOracle(cri Criteria, osVer string, pkgs []AffectedPackage) []AffectedPackage {
+	for _, c := range cri.Criterions {
+		if strings.HasPrefix(c.Comment, "Oracle Linux ") &&
+			strings.HasSuffix(c.Comment, " is installed") {
+			osVer = strings.TrimSuffix(strings.TrimPrefix(c.Comment, "Oracle Linux "), " is installed")
+		}
+		ss := strings.Split(c.Comment, " is earlier than ")
+		if len(ss) != 2 {
+			continue
+		}
+		if ss[1] == "0" {
+			continue
+		}
+		pkgs = append(pkgs, AffectedPackage{
+			OSVer: osVer,
+			Package: Package{
+				Name:         ss[0],
+				FixedVersion: version.NewVersion(strings.Split(ss[1], " ")[0]).String(),
+			},
+		})
+	}
+
+	if len(cri.Criterias) == 0 {
+		return pkgs
+	}
+	for _, c := range cri.Criterias {
+		pkgs = walkOracle(c, osVer, pkgs)
+	}
+	return pkgs
+}
+
+func severityFromThreat(sev string) types.Severity {
+	switch sev {
+	case "LOW":
+		return types.SeverityLow
+	case "MODERATE":
+		return types.SeverityMedium
+	case "IMPORTANT":
+		return types.SeverityHigh
+	case "CRITICAL":
+		return types.SeverityCritical
+	}
+	return types.SeverityUnknown
+}

--- a/pkg/vulnsrc/oracle-oval/oracle-oval_test.go
+++ b/pkg/vulnsrc/oracle-oval/oracle-oval_test.go
@@ -1,0 +1,711 @@
+package oracleoval
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	bolt "github.com/etcd-io/bbolt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"golang.org/x/xerrors"
+
+	"github.com/aquasecurity/trivy-db/pkg/db"
+	"github.com/aquasecurity/trivy-db/pkg/types"
+	"github.com/aquasecurity/trivy-db/pkg/utils"
+	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/vulnerability"
+)
+
+func TestMain(m *testing.M) {
+	utils.Quiet = true
+	os.Exit(m.Run())
+}
+
+func TestVulnSrc_Update(t *testing.T) {
+	testCases := []struct {
+		name           string
+		cacheDir       string
+		batchUpdateErr error
+		expectedError  error
+		expectedVulns  []types.Advisory
+	}{
+		{
+			name:     "happy path",
+			cacheDir: "testdata",
+		},
+		{
+			name:          "cache dir doesnt exist",
+			cacheDir:      "badpathdoesnotexist",
+			expectedError: errors.New("error in Oracle Linux OVAL walk: error in file walk: lstat badpathdoesnotexist/vuln-list/oval/oracle: no such file or directory"),
+		},
+		{
+			name:           "unable to save oracle linux oval defintions",
+			cacheDir:       "testdata",
+			batchUpdateErr: errors.New("unable to batch update"),
+			expectedError:  errors.New("error in Oracle Linux OVAL save: error in batch update: unable to batch update"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockDBConfig := new(db.MockDBConfig)
+			mockDBConfig.On("BatchUpdate", mock.Anything).Return(tc.batchUpdateErr)
+			ac := VulnSrc{dbc: mockDBConfig}
+
+			err := ac.Update(tc.cacheDir)
+			switch {
+			case tc.expectedError != nil:
+				assert.EqualError(t, err, tc.expectedError.Error(), tc.name)
+			default:
+				assert.NoError(t, err, tc.name)
+			}
+		})
+	}
+}
+
+func TestVulnSrc_Commit(t *testing.T) {
+	type putAdvisoryInput struct {
+		source   string
+		pkgName  string
+		cveID    string
+		advisory types.Advisory
+	}
+	type putAdvisory struct {
+		input  putAdvisoryInput
+		output error
+	}
+
+	type putVulnerabilityDetailInput struct {
+		cveID  string
+		source string
+		vuln   types.VulnerabilityDetail
+	}
+	type putVulnerabilityDetail struct {
+		input  putVulnerabilityDetailInput
+		output error
+	}
+
+	type putSeverityInput struct {
+		cveID    string
+		severity types.Severity
+	}
+	type putSeverity struct {
+		input  putSeverityInput
+		output error
+	}
+	testCases := []struct {
+		name                       string
+		cves                       []OracleOVAL
+		putAdvisoryList            []putAdvisory
+		putVulnerabilityDetailList []putVulnerabilityDetail
+		putSeverityList            []putSeverity
+		expectedErrorMsg           string
+	}{
+		{
+			name: "happy path",
+			cves: []OracleOVAL{
+				{
+					Title:       "\nELSA-2007-0057:  Moderate: bind security update  (MODERATE)\n",
+					Description: "\n [30:9.3.3-8]\n - added fix for #224445 - CVE-2007-0493 BIND might crash after\n   attempting to read free()-ed memory\n - added fix for #225229 - CVE-2007-0494 BIND dnssec denial of service\n - Resolves: rhbz#224445\n - Resolves: rhbz#225229 \n",
+					Platform:    []string{"Oracle Linux 5"},
+					References: []Reference{
+						Reference{
+							Source: "elsa",
+							URI:    "http://linux.oracle.com/errata/ELSA-2007-0057.html",
+							ID:     "ELSA-2007-0057",
+						},
+						Reference{
+							Source: "CVE",
+							URI:    "http://linux.oracle.com/cve/CVE-2007-0493.html",
+							ID:     "CVE-2007-0493",
+						},
+						Reference{
+							Source: "CVE",
+							URI:    "http://linux.oracle.com/cve/CVE-2007-0494.html",
+							ID:     "CVE-2007-0494",
+						},
+					},
+					Criteria: Criteria{
+						Operator: "AND",
+						Criterias: []Criteria{
+							Criteria{
+								Operator: "OR",
+								Criterias: []Criteria{
+									Criteria{
+										Operator:  "AND",
+										Criterias: nil,
+										Criterions: []Criterion{
+											Criterion{
+												Comment: "bind-devel is earlier than 30:9.3.3-8.el5",
+											},
+											Criterion{
+												Comment: "bind-devel is signed with the Oracle Linux 5 key",
+											},
+										},
+									},
+								},
+								Criterions: nil,
+							},
+						},
+						Criterions: []Criterion{
+							Criterion{
+								Comment: "Oracle Linux 5 is installed",
+							},
+						},
+					},
+					Severity: "MODERATE",
+					CVEs: []Cve{
+						Cve{
+							Impact: "",
+							Href:   "http://linux.oracle.com/cve/CVE-2007-0493.html",
+							ID:     "CVE-2007-0493",
+						},
+						Cve{
+							Impact: "",
+							Href:   "http://linux.oracle.com/cve/CVE-2007-0494.html",
+							ID:     "CVE-2007-0494",
+						},
+					},
+				},
+			},
+			putAdvisoryList: []putAdvisory{
+				{
+					input: putAdvisoryInput{
+						source:   "Oracle Linux 5",
+						pkgName:  "bind-devel",
+						cveID:    "ELSA-2007-0057",
+						advisory: types.Advisory{VulnerabilityID: "", FixedVersion: "30:9.3.3-8.el5"},
+					},
+				},
+			},
+			putVulnerabilityDetailList: []putVulnerabilityDetail{
+				{
+					input: putVulnerabilityDetailInput{
+						cveID:  "ELSA-2007-0057",
+						source: vulnerability.OracleOVAL,
+						vuln: types.VulnerabilityDetail{
+							Description: "\n [30:9.3.3-8]\n - added fix for #224445 - CVE-2007-0493 BIND might crash after\n   attempting to read free()-ed memory\n - added fix for #225229 - CVE-2007-0494 BIND dnssec denial of service\n - Resolves: rhbz#224445\n - Resolves: rhbz#225229 \n",
+							References: []string{
+								"http://linux.oracle.com/errata/ELSA-2007-0057.html",
+								"http://linux.oracle.com/cve/CVE-2007-0493.html",
+								"http://linux.oracle.com/cve/CVE-2007-0494.html",
+							},
+							Title:    "ELSA-2007-0057:  Moderate: bind security update  (MODERATE)\n",
+							Severity: types.SeverityMedium,
+						},
+					},
+				},
+			},
+			putSeverityList: []putSeverity{
+				{
+					input: putSeverityInput{
+						cveID:    "ELSA-2007-0057",
+						severity: types.SeverityUnknown,
+					},
+				},
+			},
+		},
+		{
+			name: "happy path epoch 0",
+			cves: []OracleOVAL{
+				{
+					Title:       "\nELSA-2007-0057:  Moderate: bind security update  (MODERATE)\n",
+					Description: "\n [0:9.3.3-8]\n - added fix for #224445 - CVE-2007-0493 BIND might crash after\n   attempting to read free()-ed memory\n - added fix for #225229 - CVE-2007-0494 BIND dnssec denial of service\n - Resolves: rhbz#224445\n - Resolves: rhbz#225229 \n",
+					Platform:    []string{"Oracle Linux 5"},
+					References: []Reference{
+						Reference{
+							Source: "elsa",
+							URI:    "http://linux.oracle.com/errata/ELSA-2007-0057.html",
+							ID:     "ELSA-2007-0057",
+						},
+						Reference{
+							Source: "CVE",
+							URI:    "http://linux.oracle.com/cve/CVE-2007-0493.html",
+							ID:     "CVE-2007-0493",
+						},
+						Reference{
+							Source: "CVE",
+							URI:    "http://linux.oracle.com/cve/CVE-2007-0494.html",
+							ID:     "CVE-2007-0494",
+						},
+					},
+					Criteria: Criteria{
+						Operator: "AND",
+						Criterias: []Criteria{
+							Criteria{
+								Operator: "OR",
+								Criterias: []Criteria{
+									Criteria{
+										Operator:  "AND",
+										Criterias: nil,
+										Criterions: []Criterion{
+											Criterion{
+												Comment: "bind-devel is earlier than 0:9.3.3-8.el5",
+											},
+											Criterion{
+												Comment: "bind-devel is signed with the Oracle Linux 5 key",
+											},
+										},
+									},
+								},
+								Criterions: nil,
+							},
+						},
+						Criterions: []Criterion{
+							Criterion{
+								Comment: "Oracle Linux 5 is installed",
+							},
+						},
+					},
+					Severity: "MODERATE",
+					CVEs: []Cve{
+						Cve{
+							Impact: "",
+							Href:   "http://linux.oracle.com/cve/CVE-2007-0493.html",
+							ID:     "CVE-2007-0493",
+						},
+						Cve{
+							Impact: "",
+							Href:   "http://linux.oracle.com/cve/CVE-2007-0494.html",
+							ID:     "CVE-2007-0494",
+						},
+					},
+				},
+			},
+			putAdvisoryList: []putAdvisory{
+				{
+					input: putAdvisoryInput{
+						source:   "Oracle Linux 5",
+						pkgName:  "bind-devel",
+						cveID:    "ELSA-2007-0057",
+						advisory: types.Advisory{VulnerabilityID: "", FixedVersion: "9.3.3-8.el5"},
+					},
+				},
+			},
+			putVulnerabilityDetailList: []putVulnerabilityDetail{
+				{
+					input: putVulnerabilityDetailInput{
+						cveID:  "ELSA-2007-0057",
+						source: vulnerability.OracleOVAL,
+						vuln: types.VulnerabilityDetail{
+							Description: "\n [0:9.3.3-8]\n - added fix for #224445 - CVE-2007-0493 BIND might crash after\n   attempting to read free()-ed memory\n - added fix for #225229 - CVE-2007-0494 BIND dnssec denial of service\n - Resolves: rhbz#224445\n - Resolves: rhbz#225229 \n",
+							References: []string{
+								"http://linux.oracle.com/errata/ELSA-2007-0057.html",
+								"http://linux.oracle.com/cve/CVE-2007-0493.html",
+								"http://linux.oracle.com/cve/CVE-2007-0494.html",
+							},
+							Title:    "ELSA-2007-0057:  Moderate: bind security update  (MODERATE)\n",
+							Severity: types.SeverityMedium,
+						},
+					},
+				},
+			},
+			putSeverityList: []putSeverity{
+				{
+					input: putSeverityInput{
+						cveID:    "ELSA-2007-0057",
+						severity: types.SeverityUnknown,
+					},
+				},
+			},
+		},
+		{
+			name: "invalid fix version",
+			cves: []OracleOVAL{
+				{
+					Title:       "\nELSA-2007-0057:  Moderate: bind security update  (MODERATE)\n",
+					Description: "\n [0:9.3.3-8]\n - added fix for #224445 - CVE-2007-0493 BIND might crash after\n   attempting to read free()-ed memory\n - added fix for #225229 - CVE-2007-0494 BIND dnssec denial of service\n - Resolves: rhbz#224445\n - Resolves: rhbz#225229 \n",
+					Platform:    []string{"Oracle Linux 5"},
+					References: []Reference{
+						Reference{
+							Source: "elsa",
+							URI:    "http://linux.oracle.com/errata/ELSA-2007-0057.html",
+							ID:     "ELSA-2007-0057",
+						},
+						Reference{
+							Source: "CVE",
+							URI:    "http://linux.oracle.com/cve/CVE-2007-0493.html",
+							ID:     "CVE-2007-0493",
+						},
+						Reference{
+							Source: "CVE",
+							URI:    "http://linux.oracle.com/cve/CVE-2007-0494.html",
+							ID:     "CVE-2007-0494",
+						},
+					},
+					Criteria: Criteria{
+						Operator: "AND",
+						Criterias: []Criteria{
+							Criteria{
+								Operator: "OR",
+								Criterias: []Criteria{
+									Criteria{
+										Operator:  "AND",
+										Criterias: nil,
+										Criterions: []Criterion{
+											Criterion{
+												Comment: "bind-devel is earlier than 0",
+											},
+											Criterion{
+												Comment: "bind-devel is signed with the Oracle Linux 5 key",
+											},
+										},
+									},
+								},
+								Criterions: nil,
+							},
+						},
+						Criterions: []Criterion{
+							Criterion{
+								Comment: "Oracle Linux 5 is installed",
+							},
+						},
+					},
+					Severity: "MODERATE",
+					CVEs: []Cve{
+						Cve{
+							Impact: "",
+							Href:   "http://linux.oracle.com/cve/CVE-2007-0493.html",
+							ID:     "CVE-2007-0493",
+						},
+						Cve{
+							Impact: "",
+							Href:   "http://linux.oracle.com/cve/CVE-2007-0494.html",
+							ID:     "CVE-2007-0494",
+						},
+					},
+				},
+			},
+			putVulnerabilityDetailList: []putVulnerabilityDetail{
+				{
+					input: putVulnerabilityDetailInput{
+						cveID:  "ELSA-2007-0057",
+						source: vulnerability.OracleOVAL,
+						vuln: types.VulnerabilityDetail{
+							Description: "\n [0:9.3.3-8]\n - added fix for #224445 - CVE-2007-0493 BIND might crash after\n   attempting to read free()-ed memory\n - added fix for #225229 - CVE-2007-0494 BIND dnssec denial of service\n - Resolves: rhbz#224445\n - Resolves: rhbz#225229 \n",
+							References: []string{
+								"http://linux.oracle.com/errata/ELSA-2007-0057.html",
+								"http://linux.oracle.com/cve/CVE-2007-0493.html",
+								"http://linux.oracle.com/cve/CVE-2007-0494.html",
+							},
+							Title:    "ELSA-2007-0057:  Moderate: bind security update  (MODERATE)\n",
+							Severity: types.SeverityMedium,
+						},
+					},
+				},
+			},
+			putSeverityList: []putSeverity{
+				{
+					input: putSeverityInput{
+						cveID:    "ELSA-2007-0057",
+						severity: types.SeverityUnknown,
+					},
+				},
+			},
+		},
+		{
+			name: "empty package name",
+			cves: []OracleOVAL{
+				{
+					Title:       "\nELSA-0001-0001:  Moderate: empty security update  (N/A)\n",
+					Description: "\n empty description \n",
+					Platform:    []string{"Oracle Linux 5"},
+					References: []Reference{
+						Reference{
+							Source: "elsa",
+							URI:    "http://linux.oracle.com/errata/ELSA-0001-0001.html",
+							ID:     "ELSA-0001-0001",
+						},
+						Reference{
+							Source: "CVE",
+							URI:    "http://linux.oracle.com/cve/CVE-0001-0001.html",
+							ID:     "CVE-0001-0001",
+						},
+					},
+					Criteria: Criteria{
+						Operator: "AND",
+						Criterias: []Criteria{
+							Criteria{
+								Operator: "OR",
+								Criterias: []Criteria{
+									Criteria{
+										Operator:  "AND",
+										Criterias: nil,
+										Criterions: []Criterion{
+											Criterion{
+												Comment: " is earlier than 30:9.3.3-8.el5",
+											},
+											Criterion{
+												Comment: " is signed with the Oracle Linux 5 key",
+											},
+										},
+									},
+								},
+								Criterions: nil,
+							},
+						},
+						Criterions: []Criterion{
+							Criterion{
+								Comment: "Oracle Linux 5 is installed",
+							},
+						},
+					},
+					Severity: "N/A",
+					CVEs: []Cve{
+						Cve{
+							Impact: "",
+							Href:   "http://linux.oracle.com/cve/CVE-0001-0001.html",
+							ID:     "CVE-0001-0001",
+						},
+					},
+				},
+			},
+			putVulnerabilityDetailList: []putVulnerabilityDetail{
+				{
+					input: putVulnerabilityDetailInput{
+						cveID:  "ELSA-0001-0001",
+						source: vulnerability.OracleOVAL,
+						vuln: types.VulnerabilityDetail{
+							Description: "\n empty description \n",
+							References: []string{
+								"http://linux.oracle.com/errata/ELSA-0001-0001.html",
+								"http://linux.oracle.com/cve/CVE-0001-0001.html",
+							},
+							Title:    "ELSA-0001-0001:  Moderate: empty security update  (N/A)\n",
+							Severity: types.SeverityUnknown,
+						},
+					},
+				},
+			},
+			putSeverityList: []putSeverity{
+				{
+					input: putSeverityInput{
+						cveID:    "ELSA-0001-0001",
+						severity: types.SeverityUnknown,
+					},
+				},
+			},
+		},
+		{
+			name: "unknown platform",
+			cves: []OracleOVAL{
+				{
+					Title:       "\nELSA-0001-0001:  Moderate: unknown security update  (N/A)\n",
+					Description: "\n unknown description \n",
+					Platform:    []string{"Oracle Linux 1"},
+					References: []Reference{
+						Reference{
+							Source: "elsa",
+							URI:    "http://linux.oracle.com/errata/ELSA-0001-0001.html",
+							ID:     "ELSA-0001-0001",
+						},
+						Reference{
+							Source: "CVE",
+							URI:    "http://linux.oracle.com/cve/CVE-0001-0001.html",
+							ID:     "CVE-0001-0001",
+						},
+					},
+					Criteria: Criteria{
+						Operator: "AND",
+						Criterias: []Criteria{
+							Criteria{
+								Operator: "OR",
+								Criterias: []Criteria{
+									Criteria{
+										Operator:  "AND",
+										Criterias: nil,
+										Criterions: []Criterion{
+											Criterion{
+												Comment: "test is earlier than 30:9.3.3-8.el5",
+											},
+											Criterion{
+												Comment: "test is signed with the Oracle Linux 5 key",
+											},
+										},
+									},
+								},
+								Criterions: nil,
+							},
+						},
+						Criterions: []Criterion{
+							Criterion{
+								Comment: "Oracle Linux 1 is installed",
+							},
+						},
+					},
+					Severity: "N/A",
+					CVEs: []Cve{
+						Cve{
+							Impact: "",
+							Href:   "http://linux.oracle.com/cve/CVE-0001-0001.html",
+							ID:     "CVE-0001-0001",
+						},
+					},
+				},
+			},
+			putVulnerabilityDetailList: []putVulnerabilityDetail{
+				{
+					input: putVulnerabilityDetailInput{
+						cveID:  "ELSA-0001-0001",
+						source: vulnerability.OracleOVAL,
+						vuln: types.VulnerabilityDetail{
+							Description: "\n unknown description \n",
+							References: []string{
+								"http://linux.oracle.com/errata/ELSA-0001-0001.html",
+								"http://linux.oracle.com/cve/CVE-0001-0001.html",
+							},
+							Title:    "ELSA-0001-0001:  Moderate: unknown security update  (N/A)\n",
+							Severity: types.SeverityUnknown,
+						},
+					},
+				},
+			},
+			putSeverityList: []putSeverity{
+				{
+					input: putSeverityInput{
+						cveID:    "ELSA-0001-0001",
+						severity: types.SeverityUnknown,
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tx := &bolt.Tx{}
+			mockDBConfig := new(db.MockDBConfig)
+
+			for _, pa := range tc.putAdvisoryList {
+				mockDBConfig.On("PutAdvisory", tx, pa.input.source, pa.input.pkgName,
+					pa.input.cveID, pa.input.advisory).Return(pa.output)
+			}
+			for _, pvd := range tc.putVulnerabilityDetailList {
+				mockDBConfig.On("PutVulnerabilityDetail", tx, pvd.input.cveID,
+					pvd.input.source, pvd.input.vuln).Return(pvd.output)
+			}
+			for _, ps := range tc.putSeverityList {
+				mockDBConfig.On("PutSeverity", tx, ps.input.cveID,
+					ps.input.severity).Return(ps.output)
+			}
+
+			ac := VulnSrc{dbc: mockDBConfig}
+			err := ac.commit(tx, tc.cves)
+
+			switch {
+			case tc.expectedErrorMsg != "":
+				assert.Contains(t, err.Error(), tc.expectedErrorMsg, tc.name)
+			default:
+				assert.NoError(t, err, tc.name)
+			}
+			mockDBConfig.AssertExpectations(t)
+		})
+	}
+}
+
+func TestSeverityFromThreat(t *testing.T) {
+	testCases := map[string]types.Severity{
+		"LOW":       types.SeverityLow,
+		"MODERATE":  types.SeverityMedium,
+		"IMPORTANT": types.SeverityHigh,
+		"CRITICAL":  types.SeverityCritical,
+		"N/A":       types.SeverityUnknown,
+	}
+	for k, v := range testCases {
+		assert.Equal(t, v, severityFromThreat(k))
+	}
+}
+
+func TestVulnSrc_Get(t *testing.T) {
+	type getAdvisoriesInput struct {
+		version string
+		pkgName string
+	}
+	type getAdvisoriesOutput struct {
+		advisories []types.Advisory
+		err        error
+	}
+	type getAdvisories struct {
+		input  getAdvisoriesInput
+		output getAdvisoriesOutput
+	}
+
+	testCases := []struct {
+		name          string
+		version       string
+		pkgName       string
+		getAdvisories getAdvisories
+		expectedError error
+		expectedVulns []types.Advisory
+	}{
+		{
+			name:    "happy path",
+			version: "8",
+			pkgName: "bind",
+			getAdvisories: getAdvisories{
+				input: getAdvisoriesInput{
+					version: "Oracle Linux 8",
+					pkgName: "bind",
+				},
+				output: getAdvisoriesOutput{
+					advisories: []types.Advisory{
+						{VulnerabilityID: "ELSA-2019-1145", FixedVersion: "32:9.11.4-17.P2.el8_0"},
+					},
+					err: nil,
+				},
+			},
+			expectedError: nil,
+			expectedVulns: []types.Advisory{{VulnerabilityID: "ELSA-2019-1145", FixedVersion: "32:9.11.4-17.P2.el8_0"}},
+		},
+		{
+			name:    "no advisories are returned",
+			version: "8",
+			pkgName: "no-package",
+			getAdvisories: getAdvisories{
+				input: getAdvisoriesInput{
+					version: "Oracle Linux 8",
+					pkgName: "no-package",
+				},
+				output: getAdvisoriesOutput{advisories: []types.Advisory{}, err: nil},
+			},
+			expectedError: nil,
+			expectedVulns: []types.Advisory{},
+		},
+		{
+			name: "oracle GetAdvisories return an error",
+			getAdvisories: getAdvisories{
+				input: getAdvisoriesInput{
+					version: mock.Anything,
+					pkgName: mock.Anything,
+				},
+				output: getAdvisoriesOutput{
+					advisories: []types.Advisory{},
+					err:        xerrors.New("unable to get advisories"),
+				},
+			},
+			expectedError: errors.New("failed to get Oracle Linux advisories: unable to get advisories"),
+			expectedVulns: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockDBConfig := new(db.MockDBConfig)
+			mockDBConfig.On("GetAdvisories",
+				tc.getAdvisories.input.version, tc.getAdvisories.input.pkgName).Return(
+				tc.getAdvisories.output.advisories, tc.getAdvisories.output.err,
+			)
+
+			ac := VulnSrc{dbc: mockDBConfig}
+			vuls, err := ac.Get(tc.version, tc.pkgName)
+
+			switch {
+			case tc.expectedError != nil:
+				assert.EqualError(t, err, tc.expectedError.Error(), tc.name)
+			default:
+				assert.NoError(t, err, tc.name)
+			}
+			assert.Equal(t, tc.expectedVulns, vuls, tc.name)
+		})
+	}
+}

--- a/pkg/vulnsrc/oracle-oval/oracle-oval_test.go
+++ b/pkg/vulnsrc/oracle-oval/oracle-oval_test.go
@@ -194,8 +194,8 @@ func TestVulnSrc_Commit(t *testing.T) {
 						vuln: types.VulnerabilityDetail{
 							Description: "[30:9.3.3-8]\n - added fix for #224445 - CVE-2007-0493 BIND might crash after\n   attempting to read free()-ed memory\n - added fix for #225229 - CVE-2007-0494 BIND dnssec denial of service\n - Resolves: rhbz#224445\n - Resolves: rhbz#225229",
 							References: []string{
-								"http://linux.oracle.com/errata/ELSA-2007-0057.html",
 								"http://linux.oracle.com/cve/CVE-2007-0493.html",
+								"http://linux.oracle.com/errata/ELSA-2007-0057.html",
 							},
 							Title:    "ELSA-2007-0057:  Moderate: bind security update  (MODERATE)",
 							Severity: types.SeverityMedium,
@@ -209,8 +209,8 @@ func TestVulnSrc_Commit(t *testing.T) {
 						vuln: types.VulnerabilityDetail{
 							Description: "[30:9.3.3-8]\n - added fix for #224445 - CVE-2007-0493 BIND might crash after\n   attempting to read free()-ed memory\n - added fix for #225229 - CVE-2007-0494 BIND dnssec denial of service\n - Resolves: rhbz#224445\n - Resolves: rhbz#225229",
 							References: []string{
-								"http://linux.oracle.com/errata/ELSA-2007-0057.html",
 								"http://linux.oracle.com/cve/CVE-2007-0494.html",
+								"http://linux.oracle.com/errata/ELSA-2007-0057.html",
 							},
 							Title:    "ELSA-2007-0057:  Moderate: bind security update  (MODERATE)",
 							Severity: types.SeverityMedium,
@@ -331,8 +331,8 @@ func TestVulnSrc_Commit(t *testing.T) {
 						vuln: types.VulnerabilityDetail{
 							Description: "[30:9.3.3-8]\n - added fix for #224445 - CVE-2007-0493 BIND might crash after\n   attempting to read free()-ed memory\n - added fix for #225229 - CVE-2007-0494 BIND dnssec denial of service\n - Resolves: rhbz#224445\n - Resolves: rhbz#225229",
 							References: []string{
-								"http://linux.oracle.com/errata/ELSA-2007-0057.html",
 								"http://linux.oracle.com/cve/CVE-2007-0493.html",
+								"http://linux.oracle.com/errata/ELSA-2007-0057.html",
 							},
 							Title:    "ELSA-2007-0057:  Moderate: bind security update  (MODERATE)",
 							Severity: types.SeverityMedium,
@@ -346,8 +346,8 @@ func TestVulnSrc_Commit(t *testing.T) {
 						vuln: types.VulnerabilityDetail{
 							Description: "[30:9.3.3-8]\n - added fix for #224445 - CVE-2007-0493 BIND might crash after\n   attempting to read free()-ed memory\n - added fix for #225229 - CVE-2007-0494 BIND dnssec denial of service\n - Resolves: rhbz#224445\n - Resolves: rhbz#225229",
 							References: []string{
-								"http://linux.oracle.com/errata/ELSA-2007-0057.html",
 								"http://linux.oracle.com/cve/CVE-2007-0494.html",
+								"http://linux.oracle.com/errata/ELSA-2007-0057.html",
 							},
 							Title:    "ELSA-2007-0057:  Moderate: bind security update  (MODERATE)",
 							Severity: types.SeverityMedium,
@@ -568,8 +568,8 @@ func TestVulnSrc_Commit(t *testing.T) {
 						vuln: types.VulnerabilityDetail{
 							Description: "[4.1.12-124.24.3]\n- ext4: update i_disksize when new eof exceeds it (Shan Hai)  [Orabug: 28940828] \n- ext4: update i_disksize if direct write past ondisk size (Eryu Guan)  [Orabug: 28940828] \n- ext4: protect i_disksize update by i_data_sem in direct write path (Eryu Guan)  [Orabug: 28940828] \n- ALSA: usb-audio: Fix UAF decrement if card has no live interfaces in card.c (Hui Peng)  [Orabug: 29042981]  {CVE-2018-19824}\n- ALSA: usb-audio: Replace probing flag with active refcount (Takashi Iwai)  [Orabug: 29042981]  {CVE-2018-19824}\n- ALSA: usb-audio: Avoid nested autoresume calls (Takashi Iwai)  [Orabug: 29042981]  {CVE-2018-19824}\n- ext4: validate that metadata blocks do not overlap superblock (Theodore Ts'o)  [Orabug: 29114440]  {CVE-2018-1094}\n- ext4: update inline int ext4_has_metadata_csum(struct super_block *sb) (John Donnelly)  [Orabug: 29114440]  {CVE-2018-1094}\n- ext4: always initialize the crc32c checksum driver (Theodore Ts'o)  [Orabug: 29114440]  {CVE-2018-1094} {CVE-2018-1094}\n- Revert 'bnxt_en: Reduce default rings on multi-port cards.' (Brian Maly)  [Orabug: 28687746] \n- mlx4_core: Disable P_Key Violation Traps (Hakon Bugge)  [Orabug: 27693633] \n- rds: RDS connection does not reconnect after CQ access violation error (Venkat Venkatsubra)  [Orabug: 28733324]\n\n[4.1.12-124.24.2]\n- KVM/SVM: Allow direct access to MSR_IA32_SPEC_CTRL (KarimAllah Ahmed)  [Orabug: 28069548] \n- KVM/VMX: Allow direct access to MSR_IA32_SPEC_CTRL - reloaded (Mihai Carabas)  [Orabug: 28069548] \n- KVM/x86: Add IBPB support (Ashok Raj)  [Orabug: 28069548] \n- KVM: x86: pass host_initiated to functions that read MSRs (Paolo Bonzini)  [Orabug: 28069548] \n- KVM: VMX: make MSR bitmaps per-VCPU (Paolo Bonzini)  [Orabug: 28069548] \n- KVM: VMX: introduce alloc_loaded_vmcs (Paolo Bonzini)  [Orabug: 28069548] \n- KVM: nVMX: Eliminate vmcs02 pool (Jim Mattson)  [Orabug: 28069548] \n- KVM: nVMX: fix msr bitmaps to prevent L2 from accessing L0 x2APIC (Radim Krcmar)  [Orabug: 28069548] \n- ocfs2: dont clear bh uptodate for block read (Junxiao Bi)  [Orabug: 28762940] \n- ocfs2: clear journal dirty flag after shutdown journal (Junxiao Bi)  [Orabug: 28924775] \n- ocfs2: fix panic due to unrecovered local alloc (Junxiao Bi)  [Orabug: 28924775] \n- net: rds: fix rds_ib_sysctl_max_recv_allocation error (Zhu Yanjun)  [Orabug: 28947481] \n- x86/speculation: Always disable IBRS in disable_ibrs_and_friends() (Alejandro Jimenez)  [Orabug: 29139710]",
 							References: []string{
-								"http://linux.oracle.com/errata/ELSA-2019-4510.html",
 								"http://linux.oracle.com/cve/CVE-2018-1094.html",
+								"http://linux.oracle.com/errata/ELSA-2019-4510.html",
 							},
 							Title:    "ELSA-2019-4510: Unbreakable Enterprise kernel security update (IMPORTANT)",
 							Severity: types.SeverityHigh,
@@ -583,8 +583,8 @@ func TestVulnSrc_Commit(t *testing.T) {
 						vuln: types.VulnerabilityDetail{
 							Description: "[4.1.12-124.24.3]\n- ext4: update i_disksize when new eof exceeds it (Shan Hai)  [Orabug: 28940828] \n- ext4: update i_disksize if direct write past ondisk size (Eryu Guan)  [Orabug: 28940828] \n- ext4: protect i_disksize update by i_data_sem in direct write path (Eryu Guan)  [Orabug: 28940828] \n- ALSA: usb-audio: Fix UAF decrement if card has no live interfaces in card.c (Hui Peng)  [Orabug: 29042981]  {CVE-2018-19824}\n- ALSA: usb-audio: Replace probing flag with active refcount (Takashi Iwai)  [Orabug: 29042981]  {CVE-2018-19824}\n- ALSA: usb-audio: Avoid nested autoresume calls (Takashi Iwai)  [Orabug: 29042981]  {CVE-2018-19824}\n- ext4: validate that metadata blocks do not overlap superblock (Theodore Ts'o)  [Orabug: 29114440]  {CVE-2018-1094}\n- ext4: update inline int ext4_has_metadata_csum(struct super_block *sb) (John Donnelly)  [Orabug: 29114440]  {CVE-2018-1094}\n- ext4: always initialize the crc32c checksum driver (Theodore Ts'o)  [Orabug: 29114440]  {CVE-2018-1094} {CVE-2018-1094}\n- Revert 'bnxt_en: Reduce default rings on multi-port cards.' (Brian Maly)  [Orabug: 28687746] \n- mlx4_core: Disable P_Key Violation Traps (Hakon Bugge)  [Orabug: 27693633] \n- rds: RDS connection does not reconnect after CQ access violation error (Venkat Venkatsubra)  [Orabug: 28733324]\n\n[4.1.12-124.24.2]\n- KVM/SVM: Allow direct access to MSR_IA32_SPEC_CTRL (KarimAllah Ahmed)  [Orabug: 28069548] \n- KVM/VMX: Allow direct access to MSR_IA32_SPEC_CTRL - reloaded (Mihai Carabas)  [Orabug: 28069548] \n- KVM/x86: Add IBPB support (Ashok Raj)  [Orabug: 28069548] \n- KVM: x86: pass host_initiated to functions that read MSRs (Paolo Bonzini)  [Orabug: 28069548] \n- KVM: VMX: make MSR bitmaps per-VCPU (Paolo Bonzini)  [Orabug: 28069548] \n- KVM: VMX: introduce alloc_loaded_vmcs (Paolo Bonzini)  [Orabug: 28069548] \n- KVM: nVMX: Eliminate vmcs02 pool (Jim Mattson)  [Orabug: 28069548] \n- KVM: nVMX: fix msr bitmaps to prevent L2 from accessing L0 x2APIC (Radim Krcmar)  [Orabug: 28069548] \n- ocfs2: dont clear bh uptodate for block read (Junxiao Bi)  [Orabug: 28762940] \n- ocfs2: clear journal dirty flag after shutdown journal (Junxiao Bi)  [Orabug: 28924775] \n- ocfs2: fix panic due to unrecovered local alloc (Junxiao Bi)  [Orabug: 28924775] \n- net: rds: fix rds_ib_sysctl_max_recv_allocation error (Zhu Yanjun)  [Orabug: 28947481] \n- x86/speculation: Always disable IBRS in disable_ibrs_and_friends() (Alejandro Jimenez)  [Orabug: 29139710]",
 							References: []string{
-								"http://linux.oracle.com/errata/ELSA-2019-4510.html",
 								"http://linux.oracle.com/cve/CVE-2018-19824.html",
+								"http://linux.oracle.com/errata/ELSA-2019-4510.html",
 							},
 							Title:    "ELSA-2019-4510: Unbreakable Enterprise kernel security update (IMPORTANT)",
 							Severity: types.SeverityHigh,
@@ -728,8 +728,8 @@ func TestVulnSrc_Commit(t *testing.T) {
 						vuln: types.VulnerabilityDetail{
 							Description: "[30:9.3.3-8]\n - added fix for #224445 - CVE-2007-0493 BIND might crash after\n   attempting to read free()-ed memory\n - added fix for #225229 - CVE-2007-0494 BIND dnssec denial of service\n - Resolves: rhbz#224445\n - Resolves: rhbz#225229",
 							References: []string{
-								"http://linux.oracle.com/errata/ELSA-2007-0057.html",
 								"http://linux.oracle.com/cve/CVE-2007-0493.html",
+								"http://linux.oracle.com/errata/ELSA-2007-0057.html",
 							},
 							Title:    "ELSA-2007-0057:  Moderate: bind security update  (MODERATE)",
 							Severity: types.SeverityMedium,
@@ -743,8 +743,8 @@ func TestVulnSrc_Commit(t *testing.T) {
 						vuln: types.VulnerabilityDetail{
 							Description: "[30:9.3.3-8]\n - added fix for #224445 - CVE-2007-0493 BIND might crash after\n   attempting to read free()-ed memory\n - added fix for #225229 - CVE-2007-0494 BIND dnssec denial of service\n - Resolves: rhbz#224445\n - Resolves: rhbz#225229",
 							References: []string{
-								"http://linux.oracle.com/errata/ELSA-2007-0057.html",
 								"http://linux.oracle.com/cve/CVE-2007-0494.html",
+								"http://linux.oracle.com/errata/ELSA-2007-0057.html",
 							},
 							Title:    "ELSA-2007-0057:  Moderate: bind security update  (MODERATE)",
 							Severity: types.SeverityMedium,
@@ -860,8 +860,8 @@ func TestVulnSrc_Commit(t *testing.T) {
 						vuln: types.VulnerabilityDetail{
 							Description: "[0:9.3.3-8]\n - added fix for #224445 - CVE-2007-0493 BIND might crash after\n   attempting to read free()-ed memory\n - added fix for #225229 - CVE-2007-0494 BIND dnssec denial of service\n - Resolves: rhbz#224445\n - Resolves: rhbz#225229",
 							References: []string{
-								"http://linux.oracle.com/errata/ELSA-2007-0057.html",
 								"http://linux.oracle.com/cve/CVE-2007-0493.html",
+								"http://linux.oracle.com/errata/ELSA-2007-0057.html",
 							},
 							Title:    "ELSA-2007-0057:  Moderate: bind security update  (MODERATE)",
 							Severity: types.SeverityMedium,
@@ -875,8 +875,8 @@ func TestVulnSrc_Commit(t *testing.T) {
 						vuln: types.VulnerabilityDetail{
 							Description: "[0:9.3.3-8]\n - added fix for #224445 - CVE-2007-0493 BIND might crash after\n   attempting to read free()-ed memory\n - added fix for #225229 - CVE-2007-0494 BIND dnssec denial of service\n - Resolves: rhbz#224445\n - Resolves: rhbz#225229",
 							References: []string{
-								"http://linux.oracle.com/errata/ELSA-2007-0057.html",
 								"http://linux.oracle.com/cve/CVE-2007-0494.html",
+								"http://linux.oracle.com/errata/ELSA-2007-0057.html",
 							},
 							Title:    "ELSA-2007-0057:  Moderate: bind security update  (MODERATE)",
 							Severity: types.SeverityMedium,
@@ -1049,8 +1049,8 @@ func TestVulnSrc_Commit(t *testing.T) {
 						vuln: types.VulnerabilityDetail{
 							Description: "empty description",
 							References: []string{
-								"http://linux.oracle.com/errata/ELSA-0001-0001.html",
 								"http://linux.oracle.com/cve/CVE-0001-0001.html",
+								"http://linux.oracle.com/errata/ELSA-0001-0001.html",
 							},
 							Title:    "ELSA-0001-0001:  Moderate: empty security update  (N/A)",
 							Severity: types.SeverityUnknown,
@@ -1132,8 +1132,8 @@ func TestVulnSrc_Commit(t *testing.T) {
 						vuln: types.VulnerabilityDetail{
 							Description: "unknown description",
 							References: []string{
-								"http://linux.oracle.com/errata/ELSA-0001-0001.html",
 								"http://linux.oracle.com/cve/CVE-0001-0001.html",
+								"http://linux.oracle.com/errata/ELSA-0001-0001.html",
 							},
 							Title:    "ELSA-0001-0001:  Moderate: unknown security update  (N/A)",
 							Severity: types.SeverityUnknown,

--- a/pkg/vulnsrc/oracle-oval/oracle-oval_test.go
+++ b/pkg/vulnsrc/oracle-oval/oracle-oval_test.go
@@ -234,6 +234,403 @@ func TestVulnSrc_Commit(t *testing.T) {
 			},
 		},
 		{
+			name: "happy path multi platform",
+			cves: []OracleOVAL{
+				{
+					Title:       "ELSA-2019-4510: Unbreakable Enterprise kernel security update (IMPORTANT)",
+					Description: "[4.1.12-124.24.3]\n- ext4: update i_disksize when new eof exceeds it (Shan Hai)  [Orabug: 28940828] \n- ext4: update i_disksize if direct write past ondisk size (Eryu Guan)  [Orabug: 28940828] \n- ext4: protect i_disksize update by i_data_sem in direct write path (Eryu Guan)  [Orabug: 28940828] \n- ALSA: usb-audio: Fix UAF decrement if card has no live interfaces in card.c (Hui Peng)  [Orabug: 29042981]  {CVE-2018-19824}\n- ALSA: usb-audio: Replace probing flag with active refcount (Takashi Iwai)  [Orabug: 29042981]  {CVE-2018-19824}\n- ALSA: usb-audio: Avoid nested autoresume calls (Takashi Iwai)  [Orabug: 29042981]  {CVE-2018-19824}\n- ext4: validate that metadata blocks do not overlap superblock (Theodore Ts'o)  [Orabug: 29114440]  {CVE-2018-1094}\n- ext4: update inline int ext4_has_metadata_csum(struct super_block *sb) (John Donnelly)  [Orabug: 29114440]  {CVE-2018-1094}\n- ext4: always initialize the crc32c checksum driver (Theodore Ts'o)  [Orabug: 29114440]  {CVE-2018-1094} {CVE-2018-1094}\n- Revert 'bnxt_en: Reduce default rings on multi-port cards.' (Brian Maly)  [Orabug: 28687746] \n- mlx4_core: Disable P_Key Violation Traps (Hakon Bugge)  [Orabug: 27693633] \n- rds: RDS connection does not reconnect after CQ access violation error (Venkat Venkatsubra)  [Orabug: 28733324]\n\n[4.1.12-124.24.2]\n- KVM/SVM: Allow direct access to MSR_IA32_SPEC_CTRL (KarimAllah Ahmed)  [Orabug: 28069548] \n- KVM/VMX: Allow direct access to MSR_IA32_SPEC_CTRL - reloaded (Mihai Carabas)  [Orabug: 28069548] \n- KVM/x86: Add IBPB support (Ashok Raj)  [Orabug: 28069548] \n- KVM: x86: pass host_initiated to functions that read MSRs (Paolo Bonzini)  [Orabug: 28069548] \n- KVM: VMX: make MSR bitmaps per-VCPU (Paolo Bonzini)  [Orabug: 28069548] \n- KVM: VMX: introduce alloc_loaded_vmcs (Paolo Bonzini)  [Orabug: 28069548] \n- KVM: nVMX: Eliminate vmcs02 pool (Jim Mattson)  [Orabug: 28069548] \n- KVM: nVMX: fix msr bitmaps to prevent L2 from accessing L0 x2APIC (Radim Krcmar)  [Orabug: 28069548] \n- ocfs2: dont clear bh uptodate for block read (Junxiao Bi)  [Orabug: 28762940] \n- ocfs2: clear journal dirty flag after shutdown journal (Junxiao Bi)  [Orabug: 28924775] \n- ocfs2: fix panic due to unrecovered local alloc (Junxiao Bi)  [Orabug: 28924775] \n- net: rds: fix rds_ib_sysctl_max_recv_allocation error (Zhu Yanjun)  [Orabug: 28947481] \n- x86/speculation: Always disable IBRS in disable_ibrs_and_friends() (Alejandro Jimenez)  [Orabug: 29139710]",
+					Platform:    []string{"Oracle Linux 6", "Oracle Linux 7"},
+					References: []Reference{
+						{
+							Source: "elsa",
+							URI:    "http://linux.oracle.com/errata/ELSA-2019-4510.html",
+							ID:     "ELSA-2019-4510",
+						},
+						{
+							Source: "CVE",
+							URI:    "http://linux.oracle.com/cve/CVE-2018-1094.html",
+							ID:     "CVE-2018-1094",
+						},
+						{
+							Source: "CVE",
+							URI:    "http://linux.oracle.com/cve/CVE-2018-19824.html",
+							ID:     "CVE-2018-19824",
+						},
+					},
+					Criteria: Criteria{
+						Operator: "OR",
+						Criterias: []Criteria{
+							{
+								Operator: "AND",
+								Criterias: []Criteria{
+									{
+										Operator: "OR",
+										Criterias: []Criteria{
+											{
+												Operator:  "AND",
+												Criterias: nil,
+												Criterions: []Criterion{
+													{
+														Comment: "kernel-uek-doc is earlier than 0:4.1.12-124.24.3.el6uek",
+													},
+													{
+														Comment: "kernel-uek-doc is signed with the Oracle Linux 6 key",
+													},
+												},
+											},
+											{
+												Operator:  "AND",
+												Criterias: nil,
+												Criterions: []Criterion{
+													{
+														Comment: "kernel-uek-firmware is earlier than 0:4.1.12-124.24.3.el6uek",
+													},
+													{
+														Comment: "kernel-uek-firmware is signed with the Oracle Linux 6 key",
+													},
+												},
+											},
+										},
+										Criterions: nil,
+									},
+								},
+								Criterions: []Criterion{
+									{
+										Comment: "Oracle Linux 6 is installed",
+									},
+								},
+							},
+							{
+								Operator: "AND",
+								Criterias: []Criteria{
+									{
+										Operator: "OR",
+										Criterias: []Criteria{
+											{
+												Operator:  "AND",
+												Criterias: nil,
+												Criterions: []Criterion{
+													{
+														Comment: "kernel-uek-doc is earlier than 0:4.1.12-124.24.3.el7uek",
+													},
+													{
+														Comment: "kernel-uek-doc is signed with the Oracle Linux 7 key",
+													},
+												},
+											},
+											{
+												Operator:  "AND",
+												Criterias: nil,
+												Criterions: []Criterion{
+													{
+														Comment: "kernel-uek-firmware is earlier than 0:4.1.12-124.24.3.el7uek",
+													},
+													{
+														Comment: "kernel-uek-firmware is signed with the Oracle Linux 7 key",
+													},
+												},
+											},
+										},
+										Criterions: nil,
+									},
+								},
+								Criterions: []Criterion{
+									{
+										Comment: "Oracle Linux 7 is installed",
+									},
+								},
+							},
+						},
+					},
+					Severity: "IMPORTANT",
+					Cves: []Cve{
+						{
+							Impact: "CVE",
+							Href:   "http://linux.oracle.com/cve/CVE-2018-1094.html",
+							ID:     "CVE-2018-1094",
+						},
+						{
+							Impact: "CVE",
+							Href:   "http://linux.oracle.com/cve/CVE-2018-19824.html",
+							ID:     "CVE-2018-19824",
+						},
+					},
+				},
+			},
+			putAdvisoryList: []putAdvisory{
+				{
+					input: putAdvisoryInput{
+						source:   "Oracle Linux 6",
+						pkgName:  "kernel-uek-doc",
+						cveID:    "CVE-2018-1094",
+						advisory: types.Advisory{VulnerabilityID: "", FixedVersion: "4.1.12-124.24.3.el6uek"},
+					},
+				},
+				{
+					input: putAdvisoryInput{
+						source:   "Oracle Linux 6",
+						pkgName:  "kernel-uek-doc",
+						cveID:    "CVE-2018-19824",
+						advisory: types.Advisory{VulnerabilityID: "", FixedVersion: "4.1.12-124.24.3.el6uek"},
+					},
+				},
+				{
+					input: putAdvisoryInput{
+						source:   "Oracle Linux 6",
+						pkgName:  "kernel-uek-firmware",
+						cveID:    "CVE-2018-1094",
+						advisory: types.Advisory{VulnerabilityID: "", FixedVersion: "4.1.12-124.24.3.el6uek"},
+					},
+				},
+				{
+					input: putAdvisoryInput{
+						source:   "Oracle Linux 6",
+						pkgName:  "kernel-uek-firmware",
+						cveID:    "CVE-2018-19824",
+						advisory: types.Advisory{VulnerabilityID: "", FixedVersion: "4.1.12-124.24.3.el6uek"},
+					},
+				},
+				{
+					input: putAdvisoryInput{
+						source:   "Oracle Linux 7",
+						pkgName:  "kernel-uek-doc",
+						cveID:    "CVE-2018-1094",
+						advisory: types.Advisory{VulnerabilityID: "", FixedVersion: "4.1.12-124.24.3.el7uek"},
+					},
+				},
+				{
+					input: putAdvisoryInput{
+						source:   "Oracle Linux 7",
+						pkgName:  "kernel-uek-doc",
+						cveID:    "CVE-2018-19824",
+						advisory: types.Advisory{VulnerabilityID: "", FixedVersion: "4.1.12-124.24.3.el7uek"},
+					},
+				},
+				{
+					input: putAdvisoryInput{
+						source:   "Oracle Linux 7",
+						pkgName:  "kernel-uek-firmware",
+						cveID:    "CVE-2018-1094",
+						advisory: types.Advisory{VulnerabilityID: "", FixedVersion: "4.1.12-124.24.3.el7uek"},
+					},
+				},
+				{
+					input: putAdvisoryInput{
+						source:   "Oracle Linux 7",
+						pkgName:  "kernel-uek-firmware",
+						cveID:    "CVE-2018-19824",
+						advisory: types.Advisory{VulnerabilityID: "", FixedVersion: "4.1.12-124.24.3.el7uek"},
+					},
+				},
+			},
+			putVulnerabilityDetailList: []putVulnerabilityDetail{
+				{
+					input: putVulnerabilityDetailInput{
+						cveID:  "CVE-2018-1094",
+						source: vulnerability.OracleOVAL,
+						vuln: types.VulnerabilityDetail{
+							Description: "[4.1.12-124.24.3]\n- ext4: update i_disksize when new eof exceeds it (Shan Hai)  [Orabug: 28940828] \n- ext4: update i_disksize if direct write past ondisk size (Eryu Guan)  [Orabug: 28940828] \n- ext4: protect i_disksize update by i_data_sem in direct write path (Eryu Guan)  [Orabug: 28940828] \n- ALSA: usb-audio: Fix UAF decrement if card has no live interfaces in card.c (Hui Peng)  [Orabug: 29042981]  {CVE-2018-19824}\n- ALSA: usb-audio: Replace probing flag with active refcount (Takashi Iwai)  [Orabug: 29042981]  {CVE-2018-19824}\n- ALSA: usb-audio: Avoid nested autoresume calls (Takashi Iwai)  [Orabug: 29042981]  {CVE-2018-19824}\n- ext4: validate that metadata blocks do not overlap superblock (Theodore Ts'o)  [Orabug: 29114440]  {CVE-2018-1094}\n- ext4: update inline int ext4_has_metadata_csum(struct super_block *sb) (John Donnelly)  [Orabug: 29114440]  {CVE-2018-1094}\n- ext4: always initialize the crc32c checksum driver (Theodore Ts'o)  [Orabug: 29114440]  {CVE-2018-1094} {CVE-2018-1094}\n- Revert 'bnxt_en: Reduce default rings on multi-port cards.' (Brian Maly)  [Orabug: 28687746] \n- mlx4_core: Disable P_Key Violation Traps (Hakon Bugge)  [Orabug: 27693633] \n- rds: RDS connection does not reconnect after CQ access violation error (Venkat Venkatsubra)  [Orabug: 28733324]\n\n[4.1.12-124.24.2]\n- KVM/SVM: Allow direct access to MSR_IA32_SPEC_CTRL (KarimAllah Ahmed)  [Orabug: 28069548] \n- KVM/VMX: Allow direct access to MSR_IA32_SPEC_CTRL - reloaded (Mihai Carabas)  [Orabug: 28069548] \n- KVM/x86: Add IBPB support (Ashok Raj)  [Orabug: 28069548] \n- KVM: x86: pass host_initiated to functions that read MSRs (Paolo Bonzini)  [Orabug: 28069548] \n- KVM: VMX: make MSR bitmaps per-VCPU (Paolo Bonzini)  [Orabug: 28069548] \n- KVM: VMX: introduce alloc_loaded_vmcs (Paolo Bonzini)  [Orabug: 28069548] \n- KVM: nVMX: Eliminate vmcs02 pool (Jim Mattson)  [Orabug: 28069548] \n- KVM: nVMX: fix msr bitmaps to prevent L2 from accessing L0 x2APIC (Radim Krcmar)  [Orabug: 28069548] \n- ocfs2: dont clear bh uptodate for block read (Junxiao Bi)  [Orabug: 28762940] \n- ocfs2: clear journal dirty flag after shutdown journal (Junxiao Bi)  [Orabug: 28924775] \n- ocfs2: fix panic due to unrecovered local alloc (Junxiao Bi)  [Orabug: 28924775] \n- net: rds: fix rds_ib_sysctl_max_recv_allocation error (Zhu Yanjun)  [Orabug: 28947481] \n- x86/speculation: Always disable IBRS in disable_ibrs_and_friends() (Alejandro Jimenez)  [Orabug: 29139710]",
+							References: []string{
+								"http://linux.oracle.com/errata/ELSA-2019-4510.html",
+								"http://linux.oracle.com/cve/CVE-2018-1094.html",
+							},
+							Title:    "ELSA-2019-4510: Unbreakable Enterprise kernel security update (IMPORTANT)",
+							Severity: types.SeverityHigh,
+						},
+					},
+				},
+				{
+					input: putVulnerabilityDetailInput{
+						cveID:  "CVE-2018-19824",
+						source: vulnerability.OracleOVAL,
+						vuln: types.VulnerabilityDetail{
+							Description: "[4.1.12-124.24.3]\n- ext4: update i_disksize when new eof exceeds it (Shan Hai)  [Orabug: 28940828] \n- ext4: update i_disksize if direct write past ondisk size (Eryu Guan)  [Orabug: 28940828] \n- ext4: protect i_disksize update by i_data_sem in direct write path (Eryu Guan)  [Orabug: 28940828] \n- ALSA: usb-audio: Fix UAF decrement if card has no live interfaces in card.c (Hui Peng)  [Orabug: 29042981]  {CVE-2018-19824}\n- ALSA: usb-audio: Replace probing flag with active refcount (Takashi Iwai)  [Orabug: 29042981]  {CVE-2018-19824}\n- ALSA: usb-audio: Avoid nested autoresume calls (Takashi Iwai)  [Orabug: 29042981]  {CVE-2018-19824}\n- ext4: validate that metadata blocks do not overlap superblock (Theodore Ts'o)  [Orabug: 29114440]  {CVE-2018-1094}\n- ext4: update inline int ext4_has_metadata_csum(struct super_block *sb) (John Donnelly)  [Orabug: 29114440]  {CVE-2018-1094}\n- ext4: always initialize the crc32c checksum driver (Theodore Ts'o)  [Orabug: 29114440]  {CVE-2018-1094} {CVE-2018-1094}\n- Revert 'bnxt_en: Reduce default rings on multi-port cards.' (Brian Maly)  [Orabug: 28687746] \n- mlx4_core: Disable P_Key Violation Traps (Hakon Bugge)  [Orabug: 27693633] \n- rds: RDS connection does not reconnect after CQ access violation error (Venkat Venkatsubra)  [Orabug: 28733324]\n\n[4.1.12-124.24.2]\n- KVM/SVM: Allow direct access to MSR_IA32_SPEC_CTRL (KarimAllah Ahmed)  [Orabug: 28069548] \n- KVM/VMX: Allow direct access to MSR_IA32_SPEC_CTRL - reloaded (Mihai Carabas)  [Orabug: 28069548] \n- KVM/x86: Add IBPB support (Ashok Raj)  [Orabug: 28069548] \n- KVM: x86: pass host_initiated to functions that read MSRs (Paolo Bonzini)  [Orabug: 28069548] \n- KVM: VMX: make MSR bitmaps per-VCPU (Paolo Bonzini)  [Orabug: 28069548] \n- KVM: VMX: introduce alloc_loaded_vmcs (Paolo Bonzini)  [Orabug: 28069548] \n- KVM: nVMX: Eliminate vmcs02 pool (Jim Mattson)  [Orabug: 28069548] \n- KVM: nVMX: fix msr bitmaps to prevent L2 from accessing L0 x2APIC (Radim Krcmar)  [Orabug: 28069548] \n- ocfs2: dont clear bh uptodate for block read (Junxiao Bi)  [Orabug: 28762940] \n- ocfs2: clear journal dirty flag after shutdown journal (Junxiao Bi)  [Orabug: 28924775] \n- ocfs2: fix panic due to unrecovered local alloc (Junxiao Bi)  [Orabug: 28924775] \n- net: rds: fix rds_ib_sysctl_max_recv_allocation error (Zhu Yanjun)  [Orabug: 28947481] \n- x86/speculation: Always disable IBRS in disable_ibrs_and_friends() (Alejandro Jimenez)  [Orabug: 29139710]",
+							References: []string{
+								"http://linux.oracle.com/errata/ELSA-2019-4510.html",
+								"http://linux.oracle.com/cve/CVE-2018-19824.html",
+							},
+							Title:    "ELSA-2019-4510: Unbreakable Enterprise kernel security update (IMPORTANT)",
+							Severity: types.SeverityHigh,
+						},
+					},
+				},
+			},
+			putSeverityList: []putSeverity{
+				{
+					input: putSeverityInput{
+						cveID:    "CVE-2018-1094",
+						severity: types.SeverityUnknown,
+					},
+				},
+				{
+					input: putSeverityInput{
+						cveID:    "CVE-2018-19824",
+						severity: types.SeverityUnknown,
+					},
+				},
+			},
+		},
+		{
+			name: "happy path multi package",
+			cves: []OracleOVAL{
+				{
+					Title:       "ELSA-2007-0057:  Moderate: bind security update  (MODERATE)",
+					Description: "[30:9.3.3-8]\n - added fix for #224445 - CVE-2007-0493 BIND might crash after\n   attempting to read free()-ed memory\n - added fix for #225229 - CVE-2007-0494 BIND dnssec denial of service\n - Resolves: rhbz#224445\n - Resolves: rhbz#225229",
+					Platform:    []string{"Oracle Linux 5"},
+					References: []Reference{
+						{
+							Source: "elsa",
+							URI:    "http://linux.oracle.com/errata/ELSA-2007-0057.html",
+							ID:     "ELSA-2007-0057",
+						},
+						{
+							Source: "CVE",
+							URI:    "http://linux.oracle.com/cve/CVE-2007-0493.html",
+							ID:     "CVE-2007-0493",
+						},
+						{
+							Source: "CVE",
+							URI:    "http://linux.oracle.com/cve/CVE-2007-0494.html",
+							ID:     "CVE-2007-0494",
+						},
+					},
+					Criteria: Criteria{
+						Operator: "AND",
+						Criterias: []Criteria{
+							{
+								Operator: "OR",
+								Criterias: []Criteria{
+									{
+										Operator:  "AND",
+										Criterias: nil,
+										Criterions: []Criterion{
+											{
+												Comment: "bind-devel is earlier than 30:9.3.3-8.el5",
+											},
+											{
+												Comment: "bind-devel is signed with the Oracle Linux 5 key",
+											},
+										},
+									},
+									{
+										Operator:  "AND",
+										Criterias: nil,
+										Criterions: []Criterion{
+											{
+												Comment: "bind-sdb is earlier than 30:9.3.3-8.el5",
+											},
+											{
+												Comment: "bind-sdb is signed with the Oracle Linux 5 key",
+											},
+										},
+									},
+								},
+								Criterions: nil,
+							},
+						},
+						Criterions: []Criterion{
+							{
+								Comment: "Oracle Linux 5 is installed",
+							},
+						},
+					},
+					Severity: "MODERATE",
+					Cves: []Cve{
+						{
+							Impact: "",
+							Href:   "http://linux.oracle.com/cve/CVE-2007-0493.html",
+							ID:     "CVE-2007-0493",
+						},
+						{
+							Impact: "",
+							Href:   "http://linux.oracle.com/cve/CVE-2007-0494.html",
+							ID:     "CVE-2007-0494",
+						},
+					},
+				},
+			},
+			putAdvisoryList: []putAdvisory{
+				{
+					input: putAdvisoryInput{
+						source:   "Oracle Linux 5",
+						pkgName:  "bind-devel",
+						cveID:    "CVE-2007-0493",
+						advisory: types.Advisory{VulnerabilityID: "", FixedVersion: "30:9.3.3-8.el5"},
+					},
+				},
+				{
+					input: putAdvisoryInput{
+						source:   "Oracle Linux 5",
+						pkgName:  "bind-devel",
+						cveID:    "CVE-2007-0494",
+						advisory: types.Advisory{VulnerabilityID: "", FixedVersion: "30:9.3.3-8.el5"},
+					},
+				},
+				{
+					input: putAdvisoryInput{
+						source:   "Oracle Linux 5",
+						pkgName:  "bind-sdb",
+						cveID:    "CVE-2007-0493",
+						advisory: types.Advisory{VulnerabilityID: "", FixedVersion: "30:9.3.3-8.el5"},
+					},
+				},
+				{
+					input: putAdvisoryInput{
+						source:   "Oracle Linux 5",
+						pkgName:  "bind-sdb",
+						cveID:    "CVE-2007-0494",
+						advisory: types.Advisory{VulnerabilityID: "", FixedVersion: "30:9.3.3-8.el5"},
+					},
+				},
+			},
+			putVulnerabilityDetailList: []putVulnerabilityDetail{
+				{
+					input: putVulnerabilityDetailInput{
+						cveID:  "CVE-2007-0493",
+						source: vulnerability.OracleOVAL,
+						vuln: types.VulnerabilityDetail{
+							Description: "[30:9.3.3-8]\n - added fix for #224445 - CVE-2007-0493 BIND might crash after\n   attempting to read free()-ed memory\n - added fix for #225229 - CVE-2007-0494 BIND dnssec denial of service\n - Resolves: rhbz#224445\n - Resolves: rhbz#225229",
+							References: []string{
+								"http://linux.oracle.com/errata/ELSA-2007-0057.html",
+								"http://linux.oracle.com/cve/CVE-2007-0493.html",
+							},
+							Title:    "ELSA-2007-0057:  Moderate: bind security update  (MODERATE)",
+							Severity: types.SeverityMedium,
+						},
+					},
+				},
+				{
+					input: putVulnerabilityDetailInput{
+						cveID:  "CVE-2007-0494",
+						source: vulnerability.OracleOVAL,
+						vuln: types.VulnerabilityDetail{
+							Description: "[30:9.3.3-8]\n - added fix for #224445 - CVE-2007-0493 BIND might crash after\n   attempting to read free()-ed memory\n - added fix for #225229 - CVE-2007-0494 BIND dnssec denial of service\n - Resolves: rhbz#224445\n - Resolves: rhbz#225229",
+							References: []string{
+								"http://linux.oracle.com/errata/ELSA-2007-0057.html",
+								"http://linux.oracle.com/cve/CVE-2007-0494.html",
+							},
+							Title:    "ELSA-2007-0057:  Moderate: bind security update  (MODERATE)",
+							Severity: types.SeverityMedium,
+						},
+					},
+				},
+			},
+			putSeverityList: []putSeverity{
+				{
+					input: putSeverityInput{
+						cveID:    "CVE-2007-0493",
+						severity: types.SeverityUnknown,
+					},
+				},
+				{
+					input: putSeverityInput{
+						cveID:    "CVE-2007-0494",
+						severity: types.SeverityUnknown,
+					},
+				},
+			},
+		},
+		{
 			name: "happy path epoch 0",
 			cves: []OracleOVAL{
 				{
@@ -434,7 +831,6 @@ func TestVulnSrc_Commit(t *testing.T) {
 							Description: "[0:9.3.3-8]\n - added fix for #224445 - CVE-2007-0493 BIND might crash after\n   attempting to read free()-ed memory\n - added fix for #225229 - CVE-2007-0494 BIND dnssec denial of service\n - Resolves: rhbz#224445\n - Resolves: rhbz#225229",
 							References: []string{
 								"http://linux.oracle.com/errata/ELSA-2007-0057.html",
-								"http://linux.oracle.com/cve/CVE-2007-0493.html",
 							},
 							Title:    "ELSA-2007-0057:  Moderate: bind security update  (MODERATE)",
 							Severity: types.SeverityMedium,
@@ -446,120 +842,6 @@ func TestVulnSrc_Commit(t *testing.T) {
 				{
 					input: putSeverityInput{
 						cveID:    "ELSA-2007-0057",
-						severity: types.SeverityUnknown,
-					},
-				},
-			},
-		},
-		{
-			name: "invalid fix version",
-			cves: []OracleOVAL{
-				{
-					Title:       "ELSA-2007-0057:  Moderate: bind security update  (MODERATE)",
-					Description: "[0:9.3.3-8]\n - added fix for #224445 - CVE-2007-0493 BIND might crash after\n   attempting to read free()-ed memory\n - added fix for #225229 - CVE-2007-0494 BIND dnssec denial of service\n - Resolves: rhbz#224445\n - Resolves: rhbz#225229",
-					Platform:    []string{"Oracle Linux 5"},
-					References: []Reference{
-						{
-							Source: "elsa",
-							URI:    "http://linux.oracle.com/errata/ELSA-2007-0057.html",
-							ID:     "ELSA-2007-0057",
-						},
-						{
-							Source: "CVE",
-							URI:    "http://linux.oracle.com/cve/CVE-2007-0493.html",
-							ID:     "CVE-2007-0493",
-						},
-						{
-							Source: "CVE",
-							URI:    "http://linux.oracle.com/cve/CVE-2007-0494.html",
-							ID:     "CVE-2007-0494",
-						},
-					},
-					Criteria: Criteria{
-						Operator: "AND",
-						Criterias: []Criteria{
-							{
-								Operator: "OR",
-								Criterias: []Criteria{
-									{
-										Operator:  "AND",
-										Criterias: nil,
-										Criterions: []Criterion{
-											{
-												Comment: "bind-devel is earlier than 0",
-											},
-											{
-												Comment: "bind-devel is signed with the Oracle Linux 5 key",
-											},
-										},
-									},
-								},
-								Criterions: nil,
-							},
-						},
-						Criterions: []Criterion{
-							{
-								Comment: "Oracle Linux 5 is installed",
-							},
-						},
-					},
-					Severity: "MODERATE",
-					Cves: []Cve{
-						{
-							Impact: "",
-							Href:   "http://linux.oracle.com/cve/CVE-2007-0493.html",
-							ID:     "CVE-2007-0493",
-						},
-						{
-							Impact: "",
-							Href:   "http://linux.oracle.com/cve/CVE-2007-0494.html",
-							ID:     "CVE-2007-0494",
-						},
-					},
-				},
-			},
-			putVulnerabilityDetailList: []putVulnerabilityDetail{
-				{
-					input: putVulnerabilityDetailInput{
-						cveID:  "CVE-2007-0493",
-						source: vulnerability.OracleOVAL,
-						vuln: types.VulnerabilityDetail{
-							Description: "[0:9.3.3-8]\n - added fix for #224445 - CVE-2007-0493 BIND might crash after\n   attempting to read free()-ed memory\n - added fix for #225229 - CVE-2007-0494 BIND dnssec denial of service\n - Resolves: rhbz#224445\n - Resolves: rhbz#225229",
-							References: []string{
-								"http://linux.oracle.com/errata/ELSA-2007-0057.html",
-								"http://linux.oracle.com/cve/CVE-2007-0493.html",
-							},
-							Title:    "ELSA-2007-0057:  Moderate: bind security update  (MODERATE)",
-							Severity: types.SeverityMedium,
-						},
-					},
-				},
-				{
-					input: putVulnerabilityDetailInput{
-						cveID:  "CVE-2007-0494",
-						source: vulnerability.OracleOVAL,
-						vuln: types.VulnerabilityDetail{
-							Description: "[0:9.3.3-8]\n - added fix for #224445 - CVE-2007-0493 BIND might crash after\n   attempting to read free()-ed memory\n - added fix for #225229 - CVE-2007-0494 BIND dnssec denial of service\n - Resolves: rhbz#224445\n - Resolves: rhbz#225229",
-							References: []string{
-								"http://linux.oracle.com/errata/ELSA-2007-0057.html",
-								"http://linux.oracle.com/cve/CVE-2007-0494.html",
-							},
-							Title:    "ELSA-2007-0057:  Moderate: bind security update  (MODERATE)",
-							Severity: types.SeverityMedium,
-						},
-					},
-				},
-			},
-			putSeverityList: []putSeverity{
-				{
-					input: putSeverityInput{
-						cveID:    "CVE-2007-0493",
-						severity: types.SeverityUnknown,
-					},
-				},
-				{
-					input: putSeverityInput{
-						cveID:    "CVE-2007-0494",
 						severity: types.SeverityUnknown,
 					},
 				},

--- a/pkg/vulnsrc/oracle-oval/oracle-oval_test.go
+++ b/pkg/vulnsrc/oracle-oval/oracle-oval_test.go
@@ -105,21 +105,21 @@ func TestVulnSrc_Commit(t *testing.T) {
 			name: "happy path",
 			cves: []OracleOVAL{
 				{
-					Title:       "\nELSA-2007-0057:  Moderate: bind security update  (MODERATE)\n",
-					Description: "\n [30:9.3.3-8]\n - added fix for #224445 - CVE-2007-0493 BIND might crash after\n   attempting to read free()-ed memory\n - added fix for #225229 - CVE-2007-0494 BIND dnssec denial of service\n - Resolves: rhbz#224445\n - Resolves: rhbz#225229 \n",
+					Title:       "ELSA-2007-0057:  Moderate: bind security update  (MODERATE)",
+					Description: "[30:9.3.3-8]\n - added fix for #224445 - CVE-2007-0493 BIND might crash after\n   attempting to read free()-ed memory\n - added fix for #225229 - CVE-2007-0494 BIND dnssec denial of service\n - Resolves: rhbz#224445\n - Resolves: rhbz#225229",
 					Platform:    []string{"Oracle Linux 5"},
 					References: []Reference{
-						Reference{
+						{
 							Source: "elsa",
 							URI:    "http://linux.oracle.com/errata/ELSA-2007-0057.html",
 							ID:     "ELSA-2007-0057",
 						},
-						Reference{
+						{
 							Source: "CVE",
 							URI:    "http://linux.oracle.com/cve/CVE-2007-0493.html",
 							ID:     "CVE-2007-0493",
 						},
-						Reference{
+						{
 							Source: "CVE",
 							URI:    "http://linux.oracle.com/cve/CVE-2007-0494.html",
 							ID:     "CVE-2007-0494",
@@ -128,17 +128,17 @@ func TestVulnSrc_Commit(t *testing.T) {
 					Criteria: Criteria{
 						Operator: "AND",
 						Criterias: []Criteria{
-							Criteria{
+							{
 								Operator: "OR",
 								Criterias: []Criteria{
-									Criteria{
+									{
 										Operator:  "AND",
 										Criterias: nil,
 										Criterions: []Criterion{
-											Criterion{
+											{
 												Comment: "bind-devel is earlier than 30:9.3.3-8.el5",
 											},
-											Criterion{
+											{
 												Comment: "bind-devel is signed with the Oracle Linux 5 key",
 											},
 										},
@@ -148,19 +148,19 @@ func TestVulnSrc_Commit(t *testing.T) {
 							},
 						},
 						Criterions: []Criterion{
-							Criterion{
+							{
 								Comment: "Oracle Linux 5 is installed",
 							},
 						},
 					},
 					Severity: "MODERATE",
 					Cves: []Cve{
-						Cve{
+						{
 							Impact: "",
 							Href:   "http://linux.oracle.com/cve/CVE-2007-0493.html",
 							ID:     "CVE-2007-0493",
 						},
-						Cve{
+						{
 							Impact: "",
 							Href:   "http://linux.oracle.com/cve/CVE-2007-0494.html",
 							ID:     "CVE-2007-0494",
@@ -192,12 +192,12 @@ func TestVulnSrc_Commit(t *testing.T) {
 						cveID:  "CVE-2007-0493",
 						source: vulnerability.OracleOVAL,
 						vuln: types.VulnerabilityDetail{
-							Description: "\n [30:9.3.3-8]\n - added fix for #224445 - CVE-2007-0493 BIND might crash after\n   attempting to read free()-ed memory\n - added fix for #225229 - CVE-2007-0494 BIND dnssec denial of service\n - Resolves: rhbz#224445\n - Resolves: rhbz#225229 \n",
+							Description: "[30:9.3.3-8]\n - added fix for #224445 - CVE-2007-0493 BIND might crash after\n   attempting to read free()-ed memory\n - added fix for #225229 - CVE-2007-0494 BIND dnssec denial of service\n - Resolves: rhbz#224445\n - Resolves: rhbz#225229",
 							References: []string{
 								"http://linux.oracle.com/errata/ELSA-2007-0057.html",
 								"http://linux.oracle.com/cve/CVE-2007-0493.html",
 							},
-							Title:    "ELSA-2007-0057:  Moderate: bind security update  (MODERATE)\n",
+							Title:    "ELSA-2007-0057:  Moderate: bind security update  (MODERATE)",
 							Severity: types.SeverityMedium,
 						},
 					},
@@ -207,12 +207,12 @@ func TestVulnSrc_Commit(t *testing.T) {
 						cveID:  "CVE-2007-0494",
 						source: vulnerability.OracleOVAL,
 						vuln: types.VulnerabilityDetail{
-							Description: "\n [30:9.3.3-8]\n - added fix for #224445 - CVE-2007-0493 BIND might crash after\n   attempting to read free()-ed memory\n - added fix for #225229 - CVE-2007-0494 BIND dnssec denial of service\n - Resolves: rhbz#224445\n - Resolves: rhbz#225229 \n",
+							Description: "[30:9.3.3-8]\n - added fix for #224445 - CVE-2007-0493 BIND might crash after\n   attempting to read free()-ed memory\n - added fix for #225229 - CVE-2007-0494 BIND dnssec denial of service\n - Resolves: rhbz#224445\n - Resolves: rhbz#225229",
 							References: []string{
 								"http://linux.oracle.com/errata/ELSA-2007-0057.html",
 								"http://linux.oracle.com/cve/CVE-2007-0494.html",
 							},
-							Title:    "ELSA-2007-0057:  Moderate: bind security update  (MODERATE)\n",
+							Title:    "ELSA-2007-0057:  Moderate: bind security update  (MODERATE)",
 							Severity: types.SeverityMedium,
 						},
 					},
@@ -237,21 +237,21 @@ func TestVulnSrc_Commit(t *testing.T) {
 			name: "happy path epoch 0",
 			cves: []OracleOVAL{
 				{
-					Title:       "\nELSA-2007-0057:  Moderate: bind security update  (MODERATE)\n",
-					Description: "\n [0:9.3.3-8]\n - added fix for #224445 - CVE-2007-0493 BIND might crash after\n   attempting to read free()-ed memory\n - added fix for #225229 - CVE-2007-0494 BIND dnssec denial of service\n - Resolves: rhbz#224445\n - Resolves: rhbz#225229 \n",
+					Title:       "ELSA-2007-0057:  Moderate: bind security update  (MODERATE)",
+					Description: "[0:9.3.3-8]\n - added fix for #224445 - CVE-2007-0493 BIND might crash after\n   attempting to read free()-ed memory\n - added fix for #225229 - CVE-2007-0494 BIND dnssec denial of service\n - Resolves: rhbz#224445\n - Resolves: rhbz#225229",
 					Platform:    []string{"Oracle Linux 5"},
 					References: []Reference{
-						Reference{
+						{
 							Source: "elsa",
 							URI:    "http://linux.oracle.com/errata/ELSA-2007-0057.html",
 							ID:     "ELSA-2007-0057",
 						},
-						Reference{
+						{
 							Source: "CVE",
 							URI:    "http://linux.oracle.com/cve/CVE-2007-0493.html",
 							ID:     "CVE-2007-0493",
 						},
-						Reference{
+						{
 							Source: "CVE",
 							URI:    "http://linux.oracle.com/cve/CVE-2007-0494.html",
 							ID:     "CVE-2007-0494",
@@ -260,17 +260,17 @@ func TestVulnSrc_Commit(t *testing.T) {
 					Criteria: Criteria{
 						Operator: "AND",
 						Criterias: []Criteria{
-							Criteria{
+							{
 								Operator: "OR",
 								Criterias: []Criteria{
-									Criteria{
+									{
 										Operator:  "AND",
 										Criterias: nil,
 										Criterions: []Criterion{
-											Criterion{
+											{
 												Comment: "bind-devel is earlier than 0:9.3.3-8.el5",
 											},
-											Criterion{
+											{
 												Comment: "bind-devel is signed with the Oracle Linux 5 key",
 											},
 										},
@@ -280,19 +280,19 @@ func TestVulnSrc_Commit(t *testing.T) {
 							},
 						},
 						Criterions: []Criterion{
-							Criterion{
+							{
 								Comment: "Oracle Linux 5 is installed",
 							},
 						},
 					},
 					Severity: "MODERATE",
 					Cves: []Cve{
-						Cve{
+						{
 							Impact: "",
 							Href:   "http://linux.oracle.com/cve/CVE-2007-0493.html",
 							ID:     "CVE-2007-0493",
 						},
-						Cve{
+						{
 							Impact: "",
 							Href:   "http://linux.oracle.com/cve/CVE-2007-0494.html",
 							ID:     "CVE-2007-0494",
@@ -324,12 +324,12 @@ func TestVulnSrc_Commit(t *testing.T) {
 						cveID:  "CVE-2007-0493",
 						source: vulnerability.OracleOVAL,
 						vuln: types.VulnerabilityDetail{
-							Description: "\n [0:9.3.3-8]\n - added fix for #224445 - CVE-2007-0493 BIND might crash after\n   attempting to read free()-ed memory\n - added fix for #225229 - CVE-2007-0494 BIND dnssec denial of service\n - Resolves: rhbz#224445\n - Resolves: rhbz#225229 \n",
+							Description: "[0:9.3.3-8]\n - added fix for #224445 - CVE-2007-0493 BIND might crash after\n   attempting to read free()-ed memory\n - added fix for #225229 - CVE-2007-0494 BIND dnssec denial of service\n - Resolves: rhbz#224445\n - Resolves: rhbz#225229",
 							References: []string{
 								"http://linux.oracle.com/errata/ELSA-2007-0057.html",
 								"http://linux.oracle.com/cve/CVE-2007-0493.html",
 							},
-							Title:    "ELSA-2007-0057:  Moderate: bind security update  (MODERATE)\n",
+							Title:    "ELSA-2007-0057:  Moderate: bind security update  (MODERATE)",
 							Severity: types.SeverityMedium,
 						},
 					},
@@ -339,12 +339,12 @@ func TestVulnSrc_Commit(t *testing.T) {
 						cveID:  "CVE-2007-0494",
 						source: vulnerability.OracleOVAL,
 						vuln: types.VulnerabilityDetail{
-							Description: "\n [0:9.3.3-8]\n - added fix for #224445 - CVE-2007-0493 BIND might crash after\n   attempting to read free()-ed memory\n - added fix for #225229 - CVE-2007-0494 BIND dnssec denial of service\n - Resolves: rhbz#224445\n - Resolves: rhbz#225229 \n",
+							Description: "[0:9.3.3-8]\n - added fix for #224445 - CVE-2007-0493 BIND might crash after\n   attempting to read free()-ed memory\n - added fix for #225229 - CVE-2007-0494 BIND dnssec denial of service\n - Resolves: rhbz#224445\n - Resolves: rhbz#225229",
 							References: []string{
 								"http://linux.oracle.com/errata/ELSA-2007-0057.html",
 								"http://linux.oracle.com/cve/CVE-2007-0494.html",
 							},
-							Title:    "ELSA-2007-0057:  Moderate: bind security update  (MODERATE)\n",
+							Title:    "ELSA-2007-0057:  Moderate: bind security update  (MODERATE)",
 							Severity: types.SeverityMedium,
 						},
 					},
@@ -366,41 +366,36 @@ func TestVulnSrc_Commit(t *testing.T) {
 			},
 		},
 		{
-			name: "invalid fix version",
+			name: "happy path nonCves",
 			cves: []OracleOVAL{
 				{
-					Title:       "\nELSA-2007-0057:  Moderate: bind security update  (MODERATE)\n",
-					Description: "\n [0:9.3.3-8]\n - added fix for #224445 - CVE-2007-0493 BIND might crash after\n   attempting to read free()-ed memory\n - added fix for #225229 - CVE-2007-0494 BIND dnssec denial of service\n - Resolves: rhbz#224445\n - Resolves: rhbz#225229 \n",
+					Title:       "ELSA-2007-0057:  Moderate: bind security update  (MODERATE)",
+					Description: "[0:9.3.3-8]\n - added fix for #224445 - CVE-2007-0493 BIND might crash after\n   attempting to read free()-ed memory\n - added fix for #225229 - CVE-2007-0494 BIND dnssec denial of service\n - Resolves: rhbz#224445\n - Resolves: rhbz#225229",
 					Platform:    []string{"Oracle Linux 5"},
 					References: []Reference{
-						Reference{
+						{
 							Source: "elsa",
 							URI:    "http://linux.oracle.com/errata/ELSA-2007-0057.html",
 							ID:     "ELSA-2007-0057",
 						},
-						Reference{
+						{
 							Source: "CVE",
 							URI:    "http://linux.oracle.com/cve/CVE-2007-0493.html",
 							ID:     "CVE-2007-0493",
-						},
-						Reference{
-							Source: "CVE",
-							URI:    "http://linux.oracle.com/cve/CVE-2007-0494.html",
-							ID:     "CVE-2007-0494",
 						},
 					},
 					Criteria: Criteria{
 						Operator: "AND",
 						Criterias: []Criteria{
-							Criteria{
+							{
 								Operator: "OR",
 								Criterias: []Criteria{
-									Criteria{
+									{
 										Operator:  "AND",
 										Criterias: nil,
 										Criterions: []Criterion{
-											Criterion{
-												Comment: "bind-devel is earlier than 0",
+											{
+												Comment: "bind-devel is earlier than 0:9.3.3-8.el5",
 											},
 											Criterion{
 												Comment: "bind-devel is signed with the Oracle Linux 5 key",
@@ -412,19 +407,110 @@ func TestVulnSrc_Commit(t *testing.T) {
 							},
 						},
 						Criterions: []Criterion{
-							Criterion{
+							{
+								Comment: "Oracle Linux 5 is installed",
+							},
+						},
+					},
+					Severity: "MODERATE",
+				},
+			},
+			putAdvisoryList: []putAdvisory{
+				{
+					input: putAdvisoryInput{
+						source:   "Oracle Linux 5",
+						pkgName:  "bind-devel",
+						cveID:    "ELSA-2007-0057",
+						advisory: types.Advisory{VulnerabilityID: "", FixedVersion: "9.3.3-8.el5"},
+					},
+				},
+			},
+			putVulnerabilityDetailList: []putVulnerabilityDetail{
+				{
+					input: putVulnerabilityDetailInput{
+						cveID:  "ELSA-2007-0057",
+						source: vulnerability.OracleOVAL,
+						vuln: types.VulnerabilityDetail{
+							Description: "[0:9.3.3-8]\n - added fix for #224445 - CVE-2007-0493 BIND might crash after\n   attempting to read free()-ed memory\n - added fix for #225229 - CVE-2007-0494 BIND dnssec denial of service\n - Resolves: rhbz#224445\n - Resolves: rhbz#225229",
+							References: []string{
+								"http://linux.oracle.com/errata/ELSA-2007-0057.html",
+								"http://linux.oracle.com/cve/CVE-2007-0493.html",
+							},
+							Title:    "ELSA-2007-0057:  Moderate: bind security update  (MODERATE)",
+							Severity: types.SeverityMedium,
+						},
+					},
+				},
+			},
+			putSeverityList: []putSeverity{
+				{
+					input: putSeverityInput{
+						cveID:    "ELSA-2007-0057",
+						severity: types.SeverityUnknown,
+					},
+				},
+			},
+		},
+		{
+			name: "invalid fix version",
+			cves: []OracleOVAL{
+				{
+					Title:       "ELSA-2007-0057:  Moderate: bind security update  (MODERATE)",
+					Description: "[0:9.3.3-8]\n - added fix for #224445 - CVE-2007-0493 BIND might crash after\n   attempting to read free()-ed memory\n - added fix for #225229 - CVE-2007-0494 BIND dnssec denial of service\n - Resolves: rhbz#224445\n - Resolves: rhbz#225229",
+					Platform:    []string{"Oracle Linux 5"},
+					References: []Reference{
+						{
+							Source: "elsa",
+							URI:    "http://linux.oracle.com/errata/ELSA-2007-0057.html",
+							ID:     "ELSA-2007-0057",
+						},
+						{
+							Source: "CVE",
+							URI:    "http://linux.oracle.com/cve/CVE-2007-0493.html",
+							ID:     "CVE-2007-0493",
+						},
+						{
+							Source: "CVE",
+							URI:    "http://linux.oracle.com/cve/CVE-2007-0494.html",
+							ID:     "CVE-2007-0494",
+						},
+					},
+					Criteria: Criteria{
+						Operator: "AND",
+						Criterias: []Criteria{
+							{
+								Operator: "OR",
+								Criterias: []Criteria{
+									{
+										Operator:  "AND",
+										Criterias: nil,
+										Criterions: []Criterion{
+											{
+												Comment: "bind-devel is earlier than 0",
+											},
+											{
+												Comment: "bind-devel is signed with the Oracle Linux 5 key",
+											},
+										},
+									},
+								},
+								Criterions: nil,
+							},
+						},
+						Criterions: []Criterion{
+							{
 								Comment: "Oracle Linux 5 is installed",
 							},
 						},
 					},
 					Severity: "MODERATE",
 					Cves: []Cve{
-						Cve{
+						{
 							Impact: "",
 							Href:   "http://linux.oracle.com/cve/CVE-2007-0493.html",
 							ID:     "CVE-2007-0493",
 						},
-						Cve{
+						{
 							Impact: "",
 							Href:   "http://linux.oracle.com/cve/CVE-2007-0494.html",
 							ID:     "CVE-2007-0494",
@@ -438,12 +524,12 @@ func TestVulnSrc_Commit(t *testing.T) {
 						cveID:  "CVE-2007-0493",
 						source: vulnerability.OracleOVAL,
 						vuln: types.VulnerabilityDetail{
-							Description: "\n [0:9.3.3-8]\n - added fix for #224445 - CVE-2007-0493 BIND might crash after\n   attempting to read free()-ed memory\n - added fix for #225229 - CVE-2007-0494 BIND dnssec denial of service\n - Resolves: rhbz#224445\n - Resolves: rhbz#225229 \n",
+							Description: "[0:9.3.3-8]\n - added fix for #224445 - CVE-2007-0493 BIND might crash after\n   attempting to read free()-ed memory\n - added fix for #225229 - CVE-2007-0494 BIND dnssec denial of service\n - Resolves: rhbz#224445\n - Resolves: rhbz#225229",
 							References: []string{
 								"http://linux.oracle.com/errata/ELSA-2007-0057.html",
 								"http://linux.oracle.com/cve/CVE-2007-0493.html",
 							},
-							Title:    "ELSA-2007-0057:  Moderate: bind security update  (MODERATE)\n",
+							Title:    "ELSA-2007-0057:  Moderate: bind security update  (MODERATE)",
 							Severity: types.SeverityMedium,
 						},
 					},
@@ -453,12 +539,12 @@ func TestVulnSrc_Commit(t *testing.T) {
 						cveID:  "CVE-2007-0494",
 						source: vulnerability.OracleOVAL,
 						vuln: types.VulnerabilityDetail{
-							Description: "\n [0:9.3.3-8]\n - added fix for #224445 - CVE-2007-0493 BIND might crash after\n   attempting to read free()-ed memory\n - added fix for #225229 - CVE-2007-0494 BIND dnssec denial of service\n - Resolves: rhbz#224445\n - Resolves: rhbz#225229 \n",
+							Description: "[0:9.3.3-8]\n - added fix for #224445 - CVE-2007-0493 BIND might crash after\n   attempting to read free()-ed memory\n - added fix for #225229 - CVE-2007-0494 BIND dnssec denial of service\n - Resolves: rhbz#224445\n - Resolves: rhbz#225229",
 							References: []string{
 								"http://linux.oracle.com/errata/ELSA-2007-0057.html",
 								"http://linux.oracle.com/cve/CVE-2007-0494.html",
 							},
-							Title:    "ELSA-2007-0057:  Moderate: bind security update  (MODERATE)\n",
+							Title:    "ELSA-2007-0057:  Moderate: bind security update  (MODERATE)",
 							Severity: types.SeverityMedium,
 						},
 					},
@@ -483,16 +569,16 @@ func TestVulnSrc_Commit(t *testing.T) {
 			name: "empty package name",
 			cves: []OracleOVAL{
 				{
-					Title:       "\nELSA-0001-0001:  Moderate: empty security update  (N/A)\n",
-					Description: "\n empty description \n",
+					Title:       "ELSA-0001-0001:  Moderate: empty security update  (N/A)",
+					Description: "empty description",
 					Platform:    []string{"Oracle Linux 5"},
 					References: []Reference{
-						Reference{
+						{
 							Source: "elsa",
 							URI:    "http://linux.oracle.com/errata/ELSA-0001-0001.html",
 							ID:     "ELSA-0001-0001",
 						},
-						Reference{
+						{
 							Source: "CVE",
 							URI:    "http://linux.oracle.com/cve/CVE-0001-0001.html",
 							ID:     "CVE-0001-0001",
@@ -501,17 +587,17 @@ func TestVulnSrc_Commit(t *testing.T) {
 					Criteria: Criteria{
 						Operator: "AND",
 						Criterias: []Criteria{
-							Criteria{
+							{
 								Operator: "OR",
 								Criterias: []Criteria{
-									Criteria{
+									{
 										Operator:  "AND",
 										Criterias: nil,
 										Criterions: []Criterion{
-											Criterion{
+											{
 												Comment: " is earlier than 30:9.3.3-8.el5",
 											},
-											Criterion{
+											{
 												Comment: " is signed with the Oracle Linux 5 key",
 											},
 										},
@@ -521,14 +607,14 @@ func TestVulnSrc_Commit(t *testing.T) {
 							},
 						},
 						Criterions: []Criterion{
-							Criterion{
+							{
 								Comment: "Oracle Linux 5 is installed",
 							},
 						},
 					},
 					Severity: "N/A",
 					Cves: []Cve{
-						Cve{
+						{
 							Impact: "",
 							Href:   "http://linux.oracle.com/cve/CVE-0001-0001.html",
 							ID:     "CVE-0001-0001",
@@ -542,12 +628,12 @@ func TestVulnSrc_Commit(t *testing.T) {
 						cveID:  "CVE-0001-0001",
 						source: vulnerability.OracleOVAL,
 						vuln: types.VulnerabilityDetail{
-							Description: "\n empty description \n",
+							Description: "empty description",
 							References: []string{
 								"http://linux.oracle.com/errata/ELSA-0001-0001.html",
 								"http://linux.oracle.com/cve/CVE-0001-0001.html",
 							},
-							Title:    "ELSA-0001-0001:  Moderate: empty security update  (N/A)\n",
+							Title:    "ELSA-0001-0001:  Moderate: empty security update  (N/A)",
 							Severity: types.SeverityUnknown,
 						},
 					},
@@ -566,16 +652,16 @@ func TestVulnSrc_Commit(t *testing.T) {
 			name: "unknown platform",
 			cves: []OracleOVAL{
 				{
-					Title:       "\nELSA-0001-0001:  Moderate: unknown security update  (N/A)\n",
-					Description: "\n unknown description \n",
+					Title:       "ELSA-0001-0001:  Moderate: unknown security update  (N/A)",
+					Description: "unknown description",
 					Platform:    []string{"Oracle Linux 1"},
 					References: []Reference{
-						Reference{
+						{
 							Source: "elsa",
 							URI:    "http://linux.oracle.com/errata/ELSA-0001-0001.html",
 							ID:     "ELSA-0001-0001",
 						},
-						Reference{
+						{
 							Source: "CVE",
 							URI:    "http://linux.oracle.com/cve/CVE-0001-0001.html",
 							ID:     "CVE-0001-0001",
@@ -584,17 +670,17 @@ func TestVulnSrc_Commit(t *testing.T) {
 					Criteria: Criteria{
 						Operator: "AND",
 						Criterias: []Criteria{
-							Criteria{
+							{
 								Operator: "OR",
 								Criterias: []Criteria{
-									Criteria{
+									{
 										Operator:  "AND",
 										Criterias: nil,
 										Criterions: []Criterion{
-											Criterion{
+											{
 												Comment: "test is earlier than 30:9.3.3-8.el5",
 											},
-											Criterion{
+											{
 												Comment: "test is signed with the Oracle Linux 5 key",
 											},
 										},
@@ -604,14 +690,14 @@ func TestVulnSrc_Commit(t *testing.T) {
 							},
 						},
 						Criterions: []Criterion{
-							Criterion{
+							{
 								Comment: "Oracle Linux 1 is installed",
 							},
 						},
 					},
 					Severity: "N/A",
 					Cves: []Cve{
-						Cve{
+						{
 							Impact: "",
 							Href:   "http://linux.oracle.com/cve/CVE-0001-0001.html",
 							ID:     "CVE-0001-0001",
@@ -625,12 +711,12 @@ func TestVulnSrc_Commit(t *testing.T) {
 						cveID:  "CVE-0001-0001",
 						source: vulnerability.OracleOVAL,
 						vuln: types.VulnerabilityDetail{
-							Description: "\n unknown description \n",
+							Description: "unknown description",
 							References: []string{
 								"http://linux.oracle.com/errata/ELSA-0001-0001.html",
 								"http://linux.oracle.com/cve/CVE-0001-0001.html",
 							},
-							Title:    "ELSA-0001-0001:  Moderate: unknown security update  (N/A)\n",
+							Title:    "ELSA-0001-0001:  Moderate: unknown security update  (N/A)",
 							Severity: types.SeverityUnknown,
 						},
 					},

--- a/pkg/vulnsrc/oracle-oval/oracle-oval_test.go
+++ b/pkg/vulnsrc/oracle-oval/oracle-oval_test.go
@@ -154,7 +154,7 @@ func TestVulnSrc_Commit(t *testing.T) {
 						},
 					},
 					Severity: "MODERATE",
-					CVEs: []Cve{
+					Cves: []Cve{
 						Cve{
 							Impact: "",
 							Href:   "http://linux.oracle.com/cve/CVE-2007-0493.html",
@@ -258,7 +258,7 @@ func TestVulnSrc_Commit(t *testing.T) {
 						},
 					},
 					Severity: "MODERATE",
-					CVEs: []Cve{
+					Cves: []Cve{
 						Cve{
 							Impact: "",
 							Href:   "http://linux.oracle.com/cve/CVE-2007-0493.html",
@@ -362,7 +362,7 @@ func TestVulnSrc_Commit(t *testing.T) {
 						},
 					},
 					Severity: "MODERATE",
-					CVEs: []Cve{
+					Cves: []Cve{
 						Cve{
 							Impact: "",
 							Href:   "http://linux.oracle.com/cve/CVE-2007-0493.html",
@@ -451,7 +451,7 @@ func TestVulnSrc_Commit(t *testing.T) {
 						},
 					},
 					Severity: "N/A",
-					CVEs: []Cve{
+					Cves: []Cve{
 						Cve{
 							Impact: "",
 							Href:   "http://linux.oracle.com/cve/CVE-0001-0001.html",
@@ -534,7 +534,7 @@ func TestVulnSrc_Commit(t *testing.T) {
 						},
 					},
 					Severity: "N/A",
-					CVEs: []Cve{
+					Cves: []Cve{
 						Cve{
 							Impact: "",
 							Href:   "http://linux.oracle.com/cve/CVE-0001-0001.html",

--- a/pkg/vulnsrc/oracle-oval/oracle-oval_test.go
+++ b/pkg/vulnsrc/oracle-oval/oracle-oval_test.go
@@ -173,7 +173,15 @@ func TestVulnSrc_Commit(t *testing.T) {
 					input: putAdvisoryInput{
 						source:   "Oracle Linux 5",
 						pkgName:  "bind-devel",
-						cveID:    "ELSA-2007-0057",
+						cveID:    "CVE-2007-0493",
+						advisory: types.Advisory{VulnerabilityID: "", FixedVersion: "30:9.3.3-8.el5"},
+					},
+				},
+				{
+					input: putAdvisoryInput{
+						source:   "Oracle Linux 5",
+						pkgName:  "bind-devel",
+						cveID:    "CVE-2007-0494",
 						advisory: types.Advisory{VulnerabilityID: "", FixedVersion: "30:9.3.3-8.el5"},
 					},
 				},
@@ -181,13 +189,27 @@ func TestVulnSrc_Commit(t *testing.T) {
 			putVulnerabilityDetailList: []putVulnerabilityDetail{
 				{
 					input: putVulnerabilityDetailInput{
-						cveID:  "ELSA-2007-0057",
+						cveID:  "CVE-2007-0493",
 						source: vulnerability.OracleOVAL,
 						vuln: types.VulnerabilityDetail{
 							Description: "\n [30:9.3.3-8]\n - added fix for #224445 - CVE-2007-0493 BIND might crash after\n   attempting to read free()-ed memory\n - added fix for #225229 - CVE-2007-0494 BIND dnssec denial of service\n - Resolves: rhbz#224445\n - Resolves: rhbz#225229 \n",
 							References: []string{
 								"http://linux.oracle.com/errata/ELSA-2007-0057.html",
 								"http://linux.oracle.com/cve/CVE-2007-0493.html",
+							},
+							Title:    "ELSA-2007-0057:  Moderate: bind security update  (MODERATE)\n",
+							Severity: types.SeverityMedium,
+						},
+					},
+				},
+				{
+					input: putVulnerabilityDetailInput{
+						cveID:  "CVE-2007-0494",
+						source: vulnerability.OracleOVAL,
+						vuln: types.VulnerabilityDetail{
+							Description: "\n [30:9.3.3-8]\n - added fix for #224445 - CVE-2007-0493 BIND might crash after\n   attempting to read free()-ed memory\n - added fix for #225229 - CVE-2007-0494 BIND dnssec denial of service\n - Resolves: rhbz#224445\n - Resolves: rhbz#225229 \n",
+							References: []string{
+								"http://linux.oracle.com/errata/ELSA-2007-0057.html",
 								"http://linux.oracle.com/cve/CVE-2007-0494.html",
 							},
 							Title:    "ELSA-2007-0057:  Moderate: bind security update  (MODERATE)\n",
@@ -199,7 +221,13 @@ func TestVulnSrc_Commit(t *testing.T) {
 			putSeverityList: []putSeverity{
 				{
 					input: putSeverityInput{
-						cveID:    "ELSA-2007-0057",
+						cveID:    "CVE-2007-0493",
+						severity: types.SeverityUnknown,
+					},
+				},
+				{
+					input: putSeverityInput{
+						cveID:    "CVE-2007-0494",
 						severity: types.SeverityUnknown,
 					},
 				},
@@ -277,7 +305,15 @@ func TestVulnSrc_Commit(t *testing.T) {
 					input: putAdvisoryInput{
 						source:   "Oracle Linux 5",
 						pkgName:  "bind-devel",
-						cveID:    "ELSA-2007-0057",
+						cveID:    "CVE-2007-0493",
+						advisory: types.Advisory{VulnerabilityID: "", FixedVersion: "9.3.3-8.el5"},
+					},
+				},
+				{
+					input: putAdvisoryInput{
+						source:   "Oracle Linux 5",
+						pkgName:  "bind-devel",
+						cveID:    "CVE-2007-0494",
 						advisory: types.Advisory{VulnerabilityID: "", FixedVersion: "9.3.3-8.el5"},
 					},
 				},
@@ -285,13 +321,27 @@ func TestVulnSrc_Commit(t *testing.T) {
 			putVulnerabilityDetailList: []putVulnerabilityDetail{
 				{
 					input: putVulnerabilityDetailInput{
-						cveID:  "ELSA-2007-0057",
+						cveID:  "CVE-2007-0493",
 						source: vulnerability.OracleOVAL,
 						vuln: types.VulnerabilityDetail{
 							Description: "\n [0:9.3.3-8]\n - added fix for #224445 - CVE-2007-0493 BIND might crash after\n   attempting to read free()-ed memory\n - added fix for #225229 - CVE-2007-0494 BIND dnssec denial of service\n - Resolves: rhbz#224445\n - Resolves: rhbz#225229 \n",
 							References: []string{
 								"http://linux.oracle.com/errata/ELSA-2007-0057.html",
 								"http://linux.oracle.com/cve/CVE-2007-0493.html",
+							},
+							Title:    "ELSA-2007-0057:  Moderate: bind security update  (MODERATE)\n",
+							Severity: types.SeverityMedium,
+						},
+					},
+				},
+				{
+					input: putVulnerabilityDetailInput{
+						cveID:  "CVE-2007-0494",
+						source: vulnerability.OracleOVAL,
+						vuln: types.VulnerabilityDetail{
+							Description: "\n [0:9.3.3-8]\n - added fix for #224445 - CVE-2007-0493 BIND might crash after\n   attempting to read free()-ed memory\n - added fix for #225229 - CVE-2007-0494 BIND dnssec denial of service\n - Resolves: rhbz#224445\n - Resolves: rhbz#225229 \n",
+							References: []string{
+								"http://linux.oracle.com/errata/ELSA-2007-0057.html",
 								"http://linux.oracle.com/cve/CVE-2007-0494.html",
 							},
 							Title:    "ELSA-2007-0057:  Moderate: bind security update  (MODERATE)\n",
@@ -303,7 +353,13 @@ func TestVulnSrc_Commit(t *testing.T) {
 			putSeverityList: []putSeverity{
 				{
 					input: putSeverityInput{
-						cveID:    "ELSA-2007-0057",
+						cveID:    "CVE-2007-0493",
+						severity: types.SeverityUnknown,
+					},
+				},
+				{
+					input: putSeverityInput{
+						cveID:    "CVE-2007-0494",
 						severity: types.SeverityUnknown,
 					},
 				},
@@ -379,13 +435,27 @@ func TestVulnSrc_Commit(t *testing.T) {
 			putVulnerabilityDetailList: []putVulnerabilityDetail{
 				{
 					input: putVulnerabilityDetailInput{
-						cveID:  "ELSA-2007-0057",
+						cveID:  "CVE-2007-0493",
 						source: vulnerability.OracleOVAL,
 						vuln: types.VulnerabilityDetail{
 							Description: "\n [0:9.3.3-8]\n - added fix for #224445 - CVE-2007-0493 BIND might crash after\n   attempting to read free()-ed memory\n - added fix for #225229 - CVE-2007-0494 BIND dnssec denial of service\n - Resolves: rhbz#224445\n - Resolves: rhbz#225229 \n",
 							References: []string{
 								"http://linux.oracle.com/errata/ELSA-2007-0057.html",
 								"http://linux.oracle.com/cve/CVE-2007-0493.html",
+							},
+							Title:    "ELSA-2007-0057:  Moderate: bind security update  (MODERATE)\n",
+							Severity: types.SeverityMedium,
+						},
+					},
+				},
+				{
+					input: putVulnerabilityDetailInput{
+						cveID:  "CVE-2007-0494",
+						source: vulnerability.OracleOVAL,
+						vuln: types.VulnerabilityDetail{
+							Description: "\n [0:9.3.3-8]\n - added fix for #224445 - CVE-2007-0493 BIND might crash after\n   attempting to read free()-ed memory\n - added fix for #225229 - CVE-2007-0494 BIND dnssec denial of service\n - Resolves: rhbz#224445\n - Resolves: rhbz#225229 \n",
+							References: []string{
+								"http://linux.oracle.com/errata/ELSA-2007-0057.html",
 								"http://linux.oracle.com/cve/CVE-2007-0494.html",
 							},
 							Title:    "ELSA-2007-0057:  Moderate: bind security update  (MODERATE)\n",
@@ -397,7 +467,13 @@ func TestVulnSrc_Commit(t *testing.T) {
 			putSeverityList: []putSeverity{
 				{
 					input: putSeverityInput{
-						cveID:    "ELSA-2007-0057",
+						cveID:    "CVE-2007-0493",
+						severity: types.SeverityUnknown,
+					},
+				},
+				{
+					input: putSeverityInput{
+						cveID:    "CVE-2007-0494",
 						severity: types.SeverityUnknown,
 					},
 				},
@@ -463,7 +539,7 @@ func TestVulnSrc_Commit(t *testing.T) {
 			putVulnerabilityDetailList: []putVulnerabilityDetail{
 				{
 					input: putVulnerabilityDetailInput{
-						cveID:  "ELSA-0001-0001",
+						cveID:  "CVE-0001-0001",
 						source: vulnerability.OracleOVAL,
 						vuln: types.VulnerabilityDetail{
 							Description: "\n empty description \n",
@@ -480,7 +556,7 @@ func TestVulnSrc_Commit(t *testing.T) {
 			putSeverityList: []putSeverity{
 				{
 					input: putSeverityInput{
-						cveID:    "ELSA-0001-0001",
+						cveID:    "CVE-0001-0001",
 						severity: types.SeverityUnknown,
 					},
 				},
@@ -546,7 +622,7 @@ func TestVulnSrc_Commit(t *testing.T) {
 			putVulnerabilityDetailList: []putVulnerabilityDetail{
 				{
 					input: putVulnerabilityDetailInput{
-						cveID:  "ELSA-0001-0001",
+						cveID:  "CVE-0001-0001",
 						source: vulnerability.OracleOVAL,
 						vuln: types.VulnerabilityDetail{
 							Description: "\n unknown description \n",
@@ -563,7 +639,7 @@ func TestVulnSrc_Commit(t *testing.T) {
 			putSeverityList: []putSeverity{
 				{
 					input: putSeverityInput{
-						cveID:    "ELSA-0001-0001",
+						cveID:    "CVE-0001-0001",
 						severity: types.SeverityUnknown,
 					},
 				},

--- a/pkg/vulnsrc/oracle-oval/oracle-oval_test.go
+++ b/pkg/vulnsrc/oracle-oval/oracle-oval_test.go
@@ -234,6 +234,143 @@ func TestVulnSrc_Commit(t *testing.T) {
 			},
 		},
 		{
+			name: "happy path duplicate reference",
+			cves: []OracleOVAL{
+				{
+					Title:       "ELSA-2007-0057:  Moderate: bind security update  (MODERATE)",
+					Description: "[30:9.3.3-8]\n - added fix for #224445 - CVE-2007-0493 BIND might crash after\n   attempting to read free()-ed memory\n - added fix for #225229 - CVE-2007-0494 BIND dnssec denial of service\n - Resolves: rhbz#224445\n - Resolves: rhbz#225229",
+					Platform:    []string{"Oracle Linux 5"},
+					References: []Reference{
+						{
+							Source: "elsa",
+							URI:    "http://linux.oracle.com/errata/ELSA-2007-0057.html",
+							ID:     "ELSA-2007-0057",
+						},
+						{
+							Source: "elsa",
+							URI:    "http://linux.oracle.com/errata/ELSA-2007-0057.html",
+							ID:     "ELSA-2007-0057",
+						},
+						{
+							Source: "CVE",
+							URI:    "http://linux.oracle.com/cve/CVE-2007-0493.html",
+							ID:     "CVE-2007-0493",
+						},
+						{
+							Source: "CVE",
+							URI:    "http://linux.oracle.com/cve/CVE-2007-0494.html",
+							ID:     "CVE-2007-0494",
+						},
+					},
+					Criteria: Criteria{
+						Operator: "AND",
+						Criterias: []Criteria{
+							{
+								Operator: "OR",
+								Criterias: []Criteria{
+									{
+										Operator:  "AND",
+										Criterias: nil,
+										Criterions: []Criterion{
+											{
+												Comment: "bind-devel is earlier than 30:9.3.3-8.el5",
+											},
+											{
+												Comment: "bind-devel is signed with the Oracle Linux 5 key",
+											},
+										},
+									},
+								},
+								Criterions: nil,
+							},
+						},
+						Criterions: []Criterion{
+							{
+								Comment: "Oracle Linux 5 is installed",
+							},
+						},
+					},
+					Severity: "MODERATE",
+					Cves: []Cve{
+						{
+							Impact: "",
+							Href:   "http://linux.oracle.com/cve/CVE-2007-0493.html",
+							ID:     "CVE-2007-0493",
+						},
+						{
+							Impact: "",
+							Href:   "http://linux.oracle.com/cve/CVE-2007-0494.html",
+							ID:     "CVE-2007-0494",
+						},
+					},
+				},
+			},
+			putAdvisoryList: []putAdvisory{
+				{
+					input: putAdvisoryInput{
+						source:   "Oracle Linux 5",
+						pkgName:  "bind-devel",
+						cveID:    "CVE-2007-0493",
+						advisory: types.Advisory{VulnerabilityID: "", FixedVersion: "30:9.3.3-8.el5"},
+					},
+				},
+				{
+					input: putAdvisoryInput{
+						source:   "Oracle Linux 5",
+						pkgName:  "bind-devel",
+						cveID:    "CVE-2007-0494",
+						advisory: types.Advisory{VulnerabilityID: "", FixedVersion: "30:9.3.3-8.el5"},
+					},
+				},
+			},
+			putVulnerabilityDetailList: []putVulnerabilityDetail{
+				{
+					input: putVulnerabilityDetailInput{
+						cveID:  "CVE-2007-0493",
+						source: vulnerability.OracleOVAL,
+						vuln: types.VulnerabilityDetail{
+							Description: "[30:9.3.3-8]\n - added fix for #224445 - CVE-2007-0493 BIND might crash after\n   attempting to read free()-ed memory\n - added fix for #225229 - CVE-2007-0494 BIND dnssec denial of service\n - Resolves: rhbz#224445\n - Resolves: rhbz#225229",
+							References: []string{
+								"http://linux.oracle.com/errata/ELSA-2007-0057.html",
+								"http://linux.oracle.com/cve/CVE-2007-0493.html",
+							},
+							Title:    "ELSA-2007-0057:  Moderate: bind security update  (MODERATE)",
+							Severity: types.SeverityMedium,
+						},
+					},
+				},
+				{
+					input: putVulnerabilityDetailInput{
+						cveID:  "CVE-2007-0494",
+						source: vulnerability.OracleOVAL,
+						vuln: types.VulnerabilityDetail{
+							Description: "[30:9.3.3-8]\n - added fix for #224445 - CVE-2007-0493 BIND might crash after\n   attempting to read free()-ed memory\n - added fix for #225229 - CVE-2007-0494 BIND dnssec denial of service\n - Resolves: rhbz#224445\n - Resolves: rhbz#225229",
+							References: []string{
+								"http://linux.oracle.com/errata/ELSA-2007-0057.html",
+								"http://linux.oracle.com/cve/CVE-2007-0494.html",
+							},
+							Title:    "ELSA-2007-0057:  Moderate: bind security update  (MODERATE)",
+							Severity: types.SeverityMedium,
+						},
+					},
+				},
+			},
+			putSeverityList: []putSeverity{
+				{
+					input: putSeverityInput{
+						cveID:    "CVE-2007-0493",
+						severity: types.SeverityUnknown,
+					},
+				},
+				{
+					input: putSeverityInput{
+						cveID:    "CVE-2007-0494",
+						severity: types.SeverityUnknown,
+					},
+				},
+			},
+		},
+		{
 			name: "happy path multi platform",
 			cves: []OracleOVAL{
 				{

--- a/pkg/vulnsrc/oracle-oval/oracle-oval_test.go
+++ b/pkg/vulnsrc/oracle-oval/oracle-oval_test.go
@@ -1287,6 +1287,8 @@ func TestVulnSrc_Get(t *testing.T) {
 				assert.NoError(t, err, tc.name)
 			}
 			assert.Equal(t, tc.expectedVulns, vuls, tc.name)
+
+			mockDBConfig.AssertExpectations(t)
 		})
 	}
 }

--- a/pkg/vulnsrc/oracle-oval/testdata/vuln-list/oval/oracle/2007/ELSA-2007-0057.json
+++ b/pkg/vulnsrc/oracle-oval/testdata/vuln-list/oval/oracle/2007/ELSA-2007-0057.json
@@ -1,0 +1,65 @@
+{
+  "Title": "\nELSA-2007-0057:  Moderate: bind security update  (MODERATE)\n",
+  "Description": "\n [30:9.3.3-8]\n - added fix for #224445 - CVE-2007-0493 BIND might crash after\n   attempting to read free()-ed memory\n - added fix for #225229 - CVE-2007-0494 BIND dnssec denial of service\n - Resolves: rhbz#224445\n - Resolves: rhbz#225229 \n",
+  "Platform": [
+    "Oracle Linux 5"
+  ],
+  "References": [
+    {
+      "Source": "elsa",
+      "URI": "http://linux.oracle.com/errata/ELSA-2007-0057.html",
+      "ID": "ELSA-2007-0057"
+    },
+    {
+      "Source": "CVE",
+      "URI": "http://linux.oracle.com/cve/CVE-2007-0493.html",
+      "ID": "CVE-2007-0493"
+    },
+    {
+      "Source": "CVE",
+      "URI": "http://linux.oracle.com/cve/CVE-2007-0494.html",
+      "ID": "CVE-2007-0494"
+    }
+  ],
+  "Criteria": {
+    "Operator": "AND",
+    "Criterias": [
+      {
+        "Operator": "OR",
+        "Criterias": [
+          {
+            "Operator": "AND",
+            "Criterias": null,
+            "Criterions": [
+              {
+                "Comment": "bind-devel is earlier than 30:9.3.3-8.el5"
+              },
+              {
+                "Comment": "bind-devel is signed with the Oracle Linux 5 key"
+              }
+            ]
+          }
+        ],
+        "Criterions": null
+      }
+    ],
+    "Criterions": [
+      {
+        "Comment": "Oracle Linux 5 is installed"
+      }
+    ]
+  },
+  "Severity": "MODERATE",
+  "CVEs": [
+    {
+      "Impact": "",
+      "Href": "http://linux.oracle.com/cve/CVE-2007-0493.html",
+      "ID": "CVE-2007-0493"
+    },
+    {
+      "Impact": "",
+      "Href": "http://linux.oracle.com/cve/CVE-2007-0494.html",
+      "ID": "CVE-2007-0494"
+    }
+  ]
+}

--- a/pkg/vulnsrc/oracle-oval/testdata/vuln-list/oval/oracle/2007/ELSA-2007-0057.json
+++ b/pkg/vulnsrc/oracle-oval/testdata/vuln-list/oval/oracle/2007/ELSA-2007-0057.json
@@ -50,7 +50,7 @@
     ]
   },
   "Severity": "MODERATE",
-  "CVEs": [
+  "Cves": [
     {
       "Impact": "",
       "Href": "http://linux.oracle.com/cve/CVE-2007-0493.html",

--- a/pkg/vulnsrc/oracle-oval/testdata/vuln-list/oval/oracle/2007/ELSA-2007-0057.json
+++ b/pkg/vulnsrc/oracle-oval/testdata/vuln-list/oval/oracle/2007/ELSA-2007-0057.json
@@ -1,6 +1,6 @@
 {
-  "Title": "\nELSA-2007-0057:  Moderate: bind security update  (MODERATE)\n",
-  "Description": "\n [30:9.3.3-8]\n - added fix for #224445 - CVE-2007-0493 BIND might crash after\n   attempting to read free()-ed memory\n - added fix for #225229 - CVE-2007-0494 BIND dnssec denial of service\n - Resolves: rhbz#224445\n - Resolves: rhbz#225229 \n",
+  "Title": "ELSA-2007-0057:  Moderate: bind security update  (MODERATE)",
+  "Description": "[30:9.3.3-8]\n - added fix for #224445 - CVE-2007-0493 BIND might crash after\n   attempting to read free()-ed memory\n - added fix for #225229 - CVE-2007-0494 BIND dnssec denial of service\n - Resolves: rhbz#224445\n - Resolves: rhbz#225229",
   "Platform": [
     "Oracle Linux 5"
   ],

--- a/pkg/vulnsrc/oracle-oval/types.go
+++ b/pkg/vulnsrc/oracle-oval/types.go
@@ -7,7 +7,7 @@ type OracleOVAL struct {
 	References  []Reference
 	Criteria    Criteria
 	Severity    string
-	CVEs        []Cve
+	Cves        []Cve
 }
 
 type Reference struct {

--- a/pkg/vulnsrc/oracle-oval/types.go
+++ b/pkg/vulnsrc/oracle-oval/types.go
@@ -1,0 +1,43 @@
+package oracleoval
+
+type OracleOVAL struct {
+	Title       string
+	Description string
+	Platform    []string
+	References  []Reference
+	Criteria    Criteria
+	Severity    string
+	CVEs        []Cve
+}
+
+type Reference struct {
+	Source string
+	URI    string
+	ID     string
+}
+
+type Cve struct {
+	Impact string
+	Href   string
+	ID     string
+}
+
+type Criteria struct {
+	Operator   string
+	Criterias  []Criteria
+	Criterions []Criterion
+}
+
+type Criterion struct {
+	Comment string
+}
+
+type Package struct {
+	Name         string
+	FixedVersion string
+}
+
+type AffectedPackage struct {
+	Package Package
+	OSVer   string
+}

--- a/pkg/vulnsrc/vulnerability/const.go
+++ b/pkg/vulnsrc/vulnerability/const.go
@@ -11,11 +11,11 @@ const (
 	CentOS                = "centos"
 	Fedora                = "fedora"
 	Amazon                = "amazon"
+	OracleOVAL            = "oracle-oval"
 	Alpine                = "alpine"
 	RubySec               = "ruby-advisory-db"
 	RustSec               = "rust-advisory-db"
 	PhpSecurityAdvisories = "php-security-advisories"
 	NodejsSecurityWg      = "nodejs-security-wg"
 	PythonSafetyDB        = "python-safety-db"
-	OracleOVAL            = "oracle-oval"
 )

--- a/pkg/vulnsrc/vulnerability/const.go
+++ b/pkg/vulnsrc/vulnerability/const.go
@@ -17,4 +17,5 @@ const (
 	PhpSecurityAdvisories = "php-security-advisories"
 	NodejsSecurityWg      = "nodejs-security-wg"
 	PythonSafetyDB        = "python-safety-db"
+	OracleOVAL            = "oracle-oval"
 )

--- a/pkg/vulnsrc/vulnerability/vulnerability.go
+++ b/pkg/vulnsrc/vulnerability/vulnerability.go
@@ -12,7 +12,7 @@ import (
 
 var (
 	sources = []string{Nvd, RedHat, Debian, DebianOVAL, Alpine, Amazon,
-		RubySec, RustSec, PhpSecurityAdvisories, NodejsSecurityWg, PythonSafetyDB}
+		RubySec, RustSec, PhpSecurityAdvisories, NodejsSecurityWg, PythonSafetyDB, OracleOVAL}
 )
 
 func GetDetail(vulnID string) (types.Severity, string, string, []string) {

--- a/pkg/vulnsrc/vulnerability/vulnerability.go
+++ b/pkg/vulnsrc/vulnerability/vulnerability.go
@@ -11,8 +11,8 @@ import (
 )
 
 var (
-	sources = []string{Nvd, RedHat, Debian, DebianOVAL, Alpine, Amazon,
-		RubySec, RustSec, PhpSecurityAdvisories, NodejsSecurityWg, PythonSafetyDB, OracleOVAL}
+	sources = []string{Nvd, RedHat, Debian, DebianOVAL, Alpine, Amazon, OracleOVAL,
+		RubySec, RustSec, PhpSecurityAdvisories, NodejsSecurityWg, PythonSafetyDB}
 )
 
 func GetDetail(vulnID string) (types.Severity, string, string, []string) {

--- a/pkg/vulnsrc/vulnsrc.go
+++ b/pkg/vulnsrc/vulnsrc.go
@@ -4,27 +4,28 @@ import (
 	"log"
 	"time"
 
-	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/cargo"
-	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/python"
-	redhatoval "github.com/aquasecurity/trivy-db/pkg/vulnsrc/redhat-oval"
-
-	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/node"
-
-	"github.com/aquasecurity/trivy-db/pkg/db"
-	bolt "github.com/etcd-io/bbolt"
-
-	"github.com/aquasecurity/trivy-db/pkg/types"
-
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/alpine"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/amazon"
-	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/bundler"
-	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/composer"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/debian"
 	debianoval "github.com/aquasecurity/trivy-db/pkg/vulnsrc/debian-oval"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/nvd"
-	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/redhat"
+	oracleoval "github.com/aquasecurity/trivy-db/pkg/vulnsrc/oracle-oval"
+	redhatoval "github.com/aquasecurity/trivy-db/pkg/vulnsrc/redhat-oval"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/ubuntu"
+
+	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/bundler"
+	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/cargo"
+	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/composer"
+	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/node"
+	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/python"
+	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/redhat"
+
+	"github.com/aquasecurity/trivy-db/pkg/db"
+	"github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/vulnerability"
+
+	bolt "github.com/etcd-io/bbolt"
+
 	"golang.org/x/xerrors"
 )
 
@@ -49,6 +50,7 @@ var (
 		vulnerability.NodejsSecurityWg:      node.NewVulnSrc(),
 		vulnerability.PythonSafetyDB:        python.NewVulnSrc(),
 		vulnerability.RustSec:               cargo.NewVulnSrc(),
+		vulnerability.OracleOVAL:            oracleoval.NewVulnSrc(),
 	}
 )
 

--- a/pkg/vulnsrc/vulnsrc.go
+++ b/pkg/vulnsrc/vulnsrc.go
@@ -45,12 +45,12 @@ var (
 		vulnerability.DebianOVAL:            debianoval.NewVulnSrc(),
 		vulnerability.Ubuntu:                ubuntu.NewVulnSrc(),
 		vulnerability.Amazon:                amazon.NewVulnSrc(),
+		vulnerability.OracleOVAL:            oracleoval.NewVulnSrc(),
 		vulnerability.RubySec:               bundler.NewVulnSrc(),
 		vulnerability.PhpSecurityAdvisories: composer.NewVulnSrc(),
 		vulnerability.NodejsSecurityWg:      node.NewVulnSrc(),
 		vulnerability.PythonSafetyDB:        python.NewVulnSrc(),
 		vulnerability.RustSec:               cargo.NewVulnSrc(),
-		vulnerability.OracleOVAL:            oracleoval.NewVulnSrc(),
 	}
 )
 


### PR DESCRIPTION
Support Oracle Linux Security Advisory.
related: https://github.com/aquasecurity/vuln-list-update/pull/18

# Note
## Source Data
```
{
  "Title": "\nELSA-2007-0123:  Moderate: cups security update  (MODERATE)\n",
  "Description": "\n [1.1.22-0.rc1.9.18]\n - REVERTED these changes:\n   - Applied patch from STR #1301 (bug #195354).\n   - Patch pdftops to understand 'includeifexists', and use that in the\n     pdftops.conf file (bug #188583).\n   - Clear the printer's state_message and state_reasons after successful\n     job completion (bug #187457).\n   - Include dest-cache-v2 patch (bug #175847).\n   - Back-ported CUPS 1.2.x change to fix out of order IPP jobs (bug #171142).\n   - Back-ported large file support (bug #211915).\n   - Back-ported HTTP timing fix for STR #1020 (bug #194025).\n \n [1.1.22-0.rc1.9.16]\n - Restored use_dbus setting.\n \n [1.1.22-0.rc1.9.15]\n - Added timeouts to SSL negotiation (bug #232241).\n \n [1.1.22-0.rc1.9.14]\n - Back-ported HTTP timing fix for STR #1020 (bug #194025).\n \n [1.1.22-0.rc1.9.13]\n - Back-ported large file support (bug #211915).\n \n [1.1.22-0.rc1.9.12]\n - Back-ported CUPS 1.2.x change to fix out of order IPP jobs (bug #171142).\n - Include dest-cache-v2 patch (bug #175847).\n - Resolves: rhbz #171142 \n",
  "Platform": [
    "Oracle Linux 5"
  ],
  "References": [
    {
      "Source": "elsa",
      "URI": "http://linux.oracle.com/errata/ELSA-2007-0123.html",
      "ID": "ELSA-2007-0123"
    },
    {
      "Source": "CVE",
      "URI": "http://linux.oracle.com/cve/CVE-2007-0720.html",
      "ID": "CVE-2007-0720"
    }
  ],
・・・ // Cut Criteria info
  "Severity": "MODERATE",
  "CVEs": [
    {
      "Impact": "",
      "Href": "http://linux.oracle.com/cve/CVE-2007-0720.html",
      "ID": "CVE-2007-0720"
    }
  ]
}
```

## FullDB  (boltbrower view)
```
Path: vulnerability → ELSA-2007-0123
Key: ELSA-2007-0123
Value:
{
  "Description": "\n [1.1.22-0.rc1.9.18]\n - REVERTED these changes:\n   - Applied patch from STR #1301 (bug #195354).\n 
  "References": [
    "http://linux.oracle.com/cve/CVE-2007-0720.html",
    "http://linux.oracle.com/errata/ELSA-2007-0123.html"
  ],
  "Severity": "MEDIUM",
  "Title": "ELSA-2007-0123:  Moderate: cups security update  (MODERATE)\n"
}
```

## LightDB  (boltbrower view)
```
Path: severity → ELSA-2007-0123
Key: ELSA-2007-0123
Value: MEDIUM
```