### PR TITLE
fix(severity): insert severities of library vulnerabilities

### DIFF
--- a/pkg/vulnsrc/bundler/bundler.go
+++ b/pkg/vulnsrc/bundler/bundler.go
@@ -133,6 +133,10 @@ func (vs VulnSrc) walk(tx *bolt.Tx, root string) error {
 		if err = vs.dbc.PutVulnerabilityDetail(tx, vulnerabilityID, vulnerability.RubySec, vuln); err != nil {
 			return xerrors.Errorf("failed to save ruby vulnerability detail: %w", err)
 		}
+
+		if err := vs.dbc.PutSeverity(tx, vulnerabilityID, types.SeverityUnknown); err != nil {
+			return xerrors.Errorf("failed to save ruby vulnerability severity: %w", err)
+		}
 		return nil
 	})
 }

--- a/pkg/vulnsrc/cargo/cargo.go
+++ b/pkg/vulnsrc/cargo/cargo.go
@@ -114,6 +114,10 @@ func (vs VulnSrc) walk(tx *bolt.Tx, root string) error {
 			return xerrors.Errorf("failed to save rust vulnerability detail: %w", err)
 		}
 
+		if err := vs.dbc.PutSeverity(tx, advisory.Id, types.SeverityUnknown); err != nil {
+			return xerrors.Errorf("failed to save rust vulnerability severity: %w", err)
+		}
+
 		return nil
 	})
 }

--- a/pkg/vulnsrc/composer/composer.go
+++ b/pkg/vulnsrc/composer/composer.go
@@ -111,6 +111,9 @@ func (vs VulnSrc) walk(tx *bolt.Tx, root string) error {
 			return xerrors.Errorf("failed to save php vulnerability detail: %w", err)
 		}
 
+		if err := vs.dbc.PutSeverity(tx, vulnerabilityID, types.SeverityUnknown); err != nil {
+			return xerrors.Errorf("failed to save php vulnerability severity: %w", err)
+		}
 		return nil
 	})
 }

--- a/pkg/vulnsrc/node/node.go
+++ b/pkg/vulnsrc/node/node.go
@@ -137,6 +137,10 @@ func (vs VulnSrc) walk(tx *bolt.Tx, root string) error {
 			if err = vs.dbc.PutVulnerabilityDetail(tx, vulnID, vulnerability.NodejsSecurityWg, vuln); err != nil {
 				return xerrors.Errorf("failed to save node vulnerability detail: %w", err)
 			}
+
+			if err := vs.dbc.PutSeverity(tx, vulnID, types.SeverityUnknown); err != nil {
+				return xerrors.Errorf("failed to save node vulnerability severity: %w", err)
+			}
 		}
 
 		return nil

--- a/pkg/vulnsrc/python/python.go
+++ b/pkg/vulnsrc/python/python.go
@@ -107,6 +107,9 @@ func (vs VulnSrc) commit(tx *bolt.Tx, advisoryDB AdvisoryDB) error {
 			if err = vs.dbc.PutVulnerabilityDetail(tx, vulnerabilityID, vulnerability.PythonSafetyDB, vuln); err != nil {
 				return xerrors.Errorf("failed to save python vulnerability detail: %w", err)
 			}
+			if err := vs.dbc.PutSeverity(tx, vulnerabilityID, types.SeverityUnknown); err != nil {
+				return xerrors.Errorf("failed to save python vulnerability severity: %w", err)
+			}
 		}
 	}
 	return nil

--- a/pkg/vulnsrc/vulnsrc.go
+++ b/pkg/vulnsrc/vulnsrc.go
@@ -94,7 +94,6 @@ func Update(targets []string, cacheDir string, light bool, updateInterval time.D
 		return optimizeLightDB(dbc)
 	}
 	return optimizeFullDB(dbc)
-
 }
 
 func optimizeFullDB(dbc db.Config) error {


### PR DESCRIPTION
The severities of os packages from each vendor are already inserted into DB, but I forgot to insert the severities of library vulnerabilities to DB.