### PR TITLE
Add Dockerfile to build trivy-db locally

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -28,54 +28,38 @@ jobs:
             dep ensure
         fi
 
-    - name: Prepare dirs
-      run: mkdir cache assets
-
-    - name: Download vuln-list
-      run: |
-        wget --quiet https://github.com/aquasecurity/vuln-list/archive/master.zip
-        unzip -q master.zip
-        mv vuln-list-master cache/vuln-list
-
-    - name: Clone advisories
-      run: |
-        git clone --depth 1 https://github.com/rubysec/ruby-advisory-db.git cache/ruby-advisory-db
-        git clone --depth 1 https://github.com/RustSec/advisory-db.git cache/rust-advisory-db
-        git clone --depth 1 https://github.com/FriendsOfPHP/security-advisories cache/php-security-advisories
-        git clone --depth 1 https://github.com/nodejs/security-wg.git cache/nodejs-security-wg
-        git clone --depth 1 https://github.com/pyupio/safety-db.git cache/python-safety-db
+    - name: Download vuln-list and advisories
+      run: make db-fetch
 
     - name: Build the binary
-      run: go build -o trivy-db cmd/trivy-db/main.go
+      run: make build
 
     #
     # Full DB
     #
     - name: Build full database
-      run: ./trivy-db build --cache-dir ./cache --update-interval 12h
+      run: make db-build
 
     - name: Compact DB
-      run: |
-        export PATH=$PATH:$(go env GOPATH)/bin
-        bbolt compact -o assets/trivy.db cache/db/trivy.db
-        rm cache/db/trivy.db
+      run: make db-compact
 
     #
     # Light DB
     #
     - name: Build light database
-      run: ./trivy-db build --light --cache-dir ./cache --update-interval 12h
+      run: make db-build
+      env:
+        DB_TYPE: trivy-light
 
     - name: Compact DB
-      run: |
-        export PATH=$PATH:$(go env GOPATH)/bin
-        bbolt compact -o assets/trivy-light.db cache/db/trivy.db
-
+      run: make db-compact
+      env:
+        DB_TYPE: trivy-light
     #
     # Upload
     #
     - name: Compress assets
-      run: gzip assets/*
+      run: make db-compress
 
     - name: Upload assets
       run: ./trivy-db upload --dir assets

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang:1.13-alpine as builder
+
+ARG DB_TYPE=trivy
+
+WORKDIR /build
+COPY . /build
+SHELL ["/bin/ash", "-o", "pipefail", "-c"]
+
+RUN apk --no-cache add make
+
+RUN DB_TYPE=${DB_TYPE} make db-all
+
+FROM scratch
+COPY --from=builder /build/assets/trivy*.db.gz .

--- a/README.md
+++ b/README.md
@@ -28,3 +28,9 @@ GLOBAL OPTIONS:
    --help, -h     show help
    --version, -v  print the version
 ```
+
+### Building the DB
+You can utilize `make db-all` to build the database, the DB artifact is outputted to the assets folder.
+If you want to build the light DB, please set your environment to contain `DB_TYPE=trivy-light`.
+Alternatively Docker is supported, you can run `docker build . -t trivy-db`.
+If you want to build the light DB, please run `docker build --build-arg DB_TYPE=trivy-light . -t trivy-db-light`


### PR DESCRIPTION
This adds a Dockerfile so the trivy-db.gzip can be built locally.

I've made some changes to the github workflow
* use tar.gz instead of the .zip archive for vuln-list (zip is 350MB vs. 121MB as .tar.gz)
* use wget instead of git to get the master tarballs

That should make it faster and I can send a PR for the gh workflow if desired.

Eventually the next step would be to provide a solution to https://github.com/aquasecurity/trivy/issues/294 so trivy can use the container including the trivy.db.gz 