### PR TITLE
db: Add JSON tags and tests for it

### DIFF
--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -49,10 +49,10 @@ type Operation interface {
 }
 
 type Metadata struct {
-	Version    int
-	Type       Type
-	NextUpdate time.Time
-	UpdatedAt  time.Time
+	Version    int        `json:",omitempty"`
+	Type       Type       `json:",omitempty"`
+	NextUpdate *time.Time `json:",omitempty"`
+	UpdatedAt  *time.Time `json:",omitempty"`
 }
 
 type Config struct {
@@ -95,7 +95,7 @@ func (dbc Config) GetVersion() int {
 func (dbc Config) GetMetadata() (Metadata, error) {
 	var metadata Metadata
 	value, err := Config{}.get("trivy", "metadata", "data")
-	if err != nil {
+	if err != nil { // FIXME: get only returns nil, will this ever be true?
 		return Metadata{}, err
 	}
 	if err = json.Unmarshal(value, &metadata); err != nil {

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -49,10 +49,10 @@ type Operation interface {
 }
 
 type Metadata struct {
-	Version    int        `json:",omitempty"`
-	Type       Type       `json:",omitempty"`
-	NextUpdate *time.Time `json:",omitempty"`
-	UpdatedAt  *time.Time `json:",omitempty"`
+	Version    int  `json:",omitempty"`
+	Type       Type `json:",omitempty"`
+	NextUpdate time.Time
+	UpdatedAt  time.Time
 }
 
 type Config struct {
@@ -95,7 +95,7 @@ func (dbc Config) GetVersion() int {
 func (dbc Config) GetMetadata() (Metadata, error) {
 	var metadata Metadata
 	value, err := Config{}.get("trivy", "metadata", "data")
-	if err != nil { // FIXME: get only returns nil, will this ever be true?
+	if err != nil {
 		return Metadata{}, err
 	}
 	if err = json.Unmarshal(value, &metadata); err != nil {

--- a/pkg/db/db_test.go
+++ b/pkg/db/db_test.go
@@ -1,0 +1,56 @@
+package db_test
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/aquasecurity/trivy-db/pkg/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfig_GetMetadata(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		d, _ := ioutil.TempDir("", "TestConfig_GetMetadata_*")
+		defer func() {
+			os.RemoveAll(d)
+		}()
+
+		_ = db.Init(d)
+		dbc := db.Config{}
+
+		fixedTime := time.Unix(1584149443, 0)
+		_ = dbc.SetMetadata(db.Metadata{
+			Version:    42,
+			Type:       db.TypeFull,
+			NextUpdate: &fixedTime,
+			UpdatedAt:  &fixedTime,
+		})
+
+		md, err := dbc.GetMetadata()
+		require.NoError(t, err)
+		assert.Equal(t, 42, md.Version)
+		assert.Equal(t, db.TypeFull, md.Type)
+		assert.Equal(t, time.Unix(1584149443, 0).Unix(), md.NextUpdate.Unix())
+		assert.Equal(t, time.Unix(1584149443, 0).Unix(), md.UpdatedAt.Unix())
+	})
+
+	t.Run("sad path, no bucket exists", func(t *testing.T) {
+		d, _ := ioutil.TempDir("", "TestConfig_GetMetadata_*")
+		defer func() {
+			os.RemoveAll(d)
+		}()
+
+		_ = db.Init(d)
+		dbc := db.Config{}
+
+		md, err := dbc.GetMetadata()
+		assert.EqualError(t, err, "unexpected end of JSON input")
+		b, _ := json.Marshal(md) // verify output with omitempty
+		assert.Equal(t, `{}`, string(b))
+		assert.Empty(t, md)
+	})
+}

--- a/pkg/db/db_test.go
+++ b/pkg/db/db_test.go
@@ -26,8 +26,8 @@ func TestConfig_GetMetadata(t *testing.T) {
 		_ = dbc.SetMetadata(db.Metadata{
 			Version:    42,
 			Type:       db.TypeFull,
-			NextUpdate: &fixedTime,
-			UpdatedAt:  &fixedTime,
+			NextUpdate: fixedTime,
+			UpdatedAt:  fixedTime,
 		})
 
 		md, err := dbc.GetMetadata()
@@ -49,8 +49,8 @@ func TestConfig_GetMetadata(t *testing.T) {
 
 		md, err := dbc.GetMetadata()
 		assert.EqualError(t, err, "unexpected end of JSON input")
-		b, _ := json.Marshal(md) // verify output with omitempty
-		assert.Equal(t, `{}`, string(b))
+		b, _ := json.Marshal(md)
+		assert.Equal(t, `{"NextUpdate":"0001-01-01T00:00:00Z","UpdatedAt":"0001-01-01T00:00:00Z"}`, string(b))
 		assert.Empty(t, md)
 	})
 }

--- a/pkg/vulnsrc/vulnsrc.go
+++ b/pkg/vulnsrc/vulnsrc.go
@@ -119,14 +119,11 @@ func (u Updater) Update(targets []string) error {
 		}
 	}
 
-	timeUpdatedAt := u.clock.Now().UTC()
-	timeNextUpdate := timeUpdatedAt.Add(u.updateInterval)
-
 	err := u.dbc.SetMetadata(db.Metadata{
 		Version:    db.SchemaVersion,
 		Type:       u.dbType,
-		NextUpdate: timeNextUpdate,
-		UpdatedAt:  timeUpdatedAt,
+		NextUpdate: u.clock.Now().UTC().Add(u.updateInterval),
+		UpdatedAt:  u.clock.Now().UTC(),
 	})
 	if err != nil {
 		return xerrors.Errorf("failed to save metadata: %w", err)

--- a/pkg/vulnsrc/vulnsrc.go
+++ b/pkg/vulnsrc/vulnsrc.go
@@ -125,8 +125,8 @@ func (u Updater) Update(targets []string) error {
 	err := u.dbc.SetMetadata(db.Metadata{
 		Version:    db.SchemaVersion,
 		Type:       u.dbType,
-		NextUpdate: &timeNextUpdate,
-		UpdatedAt:  &timeUpdatedAt,
+		NextUpdate: timeNextUpdate,
+		UpdatedAt:  timeUpdatedAt,
 	})
 	if err != nil {
 		return xerrors.Errorf("failed to save metadata: %w", err)

--- a/pkg/vulnsrc/vulnsrc.go
+++ b/pkg/vulnsrc/vulnsrc.go
@@ -119,11 +119,14 @@ func (u Updater) Update(targets []string) error {
 		}
 	}
 
+	timeUpdatedAt := u.clock.Now().UTC()
+	timeNextUpdate := timeUpdatedAt.Add(u.updateInterval)
+
 	err := u.dbc.SetMetadata(db.Metadata{
 		Version:    db.SchemaVersion,
 		Type:       u.dbType,
-		NextUpdate: u.clock.Now().UTC().Add(u.updateInterval),
-		UpdatedAt:  u.clock.Now().UTC(),
+		NextUpdate: &timeNextUpdate,
+		UpdatedAt:  &timeUpdatedAt,
 	})
 	if err != nil {
 		return xerrors.Errorf("failed to save metadata: %w", err)

--- a/pkg/vulnsrc/vulnsrc_test.go
+++ b/pkg/vulnsrc/vulnsrc_test.go
@@ -78,6 +78,9 @@ func TestNewUpdater(t *testing.T) {
 }
 
 func TestUpdater_Update(t *testing.T) {
+	fixedNextUpdateTime := time.Date(2019, 1, 1, 12, 0, 0, 0, time.UTC)
+	fixedUpdatedAtTime := time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC)
+
 	type fields struct {
 		UpdateMap      map[string]VulnSrc
 		CacheDir       string
@@ -122,8 +125,8 @@ func TestUpdater_Update(t *testing.T) {
 						Metadata: db.Metadata{
 							Version:    1,
 							Type:       db.TypeFull,
-							NextUpdate: time.Date(2019, 1, 1, 12, 0, 0, 0, time.UTC),
-							UpdatedAt:  time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC),
+							NextUpdate: &fixedNextUpdateTime,
+							UpdatedAt:  &fixedUpdatedAtTime,
 						},
 					},
 					Returns: SetMetadataReturns{},
@@ -194,8 +197,8 @@ func TestUpdater_Update(t *testing.T) {
 						Metadata: db.Metadata{
 							Version:    1,
 							Type:       db.TypeFull,
-							NextUpdate: time.Date(2019, 1, 1, 12, 0, 0, 0, time.UTC),
-							UpdatedAt:  time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC),
+							NextUpdate: &fixedNextUpdateTime,
+							UpdatedAt:  &fixedUpdatedAtTime,
 						},
 					},
 					Returns: SetMetadataReturns{

--- a/pkg/vulnsrc/vulnsrc_test.go
+++ b/pkg/vulnsrc/vulnsrc_test.go
@@ -125,8 +125,8 @@ func TestUpdater_Update(t *testing.T) {
 						Metadata: db.Metadata{
 							Version:    1,
 							Type:       db.TypeFull,
-							NextUpdate: &fixedNextUpdateTime,
-							UpdatedAt:  &fixedUpdatedAtTime,
+							NextUpdate: fixedNextUpdateTime,
+							UpdatedAt:  fixedUpdatedAtTime,
 						},
 					},
 					Returns: SetMetadataReturns{},
@@ -197,8 +197,8 @@ func TestUpdater_Update(t *testing.T) {
 						Metadata: db.Metadata{
 							Version:    1,
 							Type:       db.TypeFull,
-							NextUpdate: &fixedNextUpdateTime,
-							UpdatedAt:  &fixedUpdatedAtTime,
+							NextUpdate: fixedNextUpdateTime,
+							UpdatedAt:  fixedUpdatedAtTime,
 						},
 					},
 					Returns: SetMetadataReturns{


### PR DESCRIPTION
### Motivation
Currently if the fields are not set, we will return empty JSON, which isn't so appealing to look at through something like `trivy -version` output.

This PR also  adds tests as there  were none.

Part of: https://github.com/aquasecurity/harbor-scanner-trivy/issues/48

Signed-off-by: Simarpreet Singh <simar@linux.com>