### PR TITLE
mod: Fix bbolt import name issue

### DIFF
--- a/pkg/vulnsrc/nvd/nvd_test.go
+++ b/pkg/vulnsrc/nvd/nvd_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/vulnerability"
 
 	"github.com/aquasecurity/trivy-db/pkg/db"
-	bolt "github.com/etcd-io/bbolt"
 	"github.com/stretchr/testify/assert"
+	bolt "go.etcd.io/bbolt"
 )
 
 func TestVulnSrc_Commit(t *testing.T) {


### PR DESCRIPTION
Currently golangci-lint fails https://github.com/aquasecurity/trivy-db/runs/672505572

This is a misleading error as it can be seen here: https://github.com/golangci/golangci-lint/issues/825

Signed-off-by: Simarpreet Singh <simar@linux.com>