### PR TITLE
vulnsrc: Add CVSS scores to output in addition to vectors

### DIFF
--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -12,11 +12,16 @@ type Severity int
 type VendorSeverity map[string]Severity
 
 type CVSSVector struct {
-	V2      string  `json:"v2,omitempty"`
-	V2Score float64 `json:"v2_score,omitempty"`
-	V3      string  `json:"v3,omitempty"`
-	V3Score float64 `json:"v3_score,omitempty"`
+	V2     string `json:"v2,omitempty"`
+	V3     string `json:"v3,omitempty"`
+	Scores CVSSScore
 }
+
+type CVSSScore struct {
+	V2 float64 `json:"v2,omitempty"`
+	V3 float64 `json:"v3,omitempty"`
+}
+
 type VendorVectors map[string]CVSSVector
 
 const (

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -12,8 +12,10 @@ type Severity int
 type VendorSeverity map[string]Severity
 
 type CVSSVector struct {
-	V2 string `json:"v2,omitempty"`
-	V3 string `json:"v3,omitempty"`
+	V2      string  `json:"v2,omitempty"`
+	V2Score float64 `json:"v2_score,omitempty"`
+	V3      string  `json:"v3,omitempty"`
+	V3Score float64 `json:"v3_score,omitempty"`
 }
 type VendorVectors map[string]CVSSVector
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -11,13 +11,13 @@ type Severity int
 
 type VendorSeverity map[string]Severity
 
-type CVSS struct {
-	V2Vector string  `json:"v2_vector,omitempty"`
-	V2Score  float64 `json:"v2_score,omitempty"`
-	V3Vector string  `json:"v3_vector,omitempty"`
-	V3Score  float64 `json:"v3_score,omitempty"`
+type CVSSVector struct {
+	V2      string  `json:"v2,omitempty"`
+	V2Score float64 `json:"v2_score,omitempty"`
+	V3      string  `json:"v3,omitempty"`
+	V3Score float64 `json:"v3_score,omitempty"`
 }
-type VendorVectors map[string]CVSS
+type VendorVectors map[string]CVSSVector
 
 const (
 	SeverityUnknown Severity = iota

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -18,7 +18,13 @@ type CVSS struct {
 	V3Score float64 `json:"v3_score,omitempty"`
 }
 
+type CVSSVector struct {
+	V2 string `json:"v2,omitempty"`
+	V3 string `json:"v3,omitempty"`
+}
+
 type VendorCVSS map[string]CVSS
+type VendorVectors map[string]CVSSVector
 
 const (
 	SeverityUnknown Severity = iota
@@ -99,7 +105,8 @@ type Vulnerability struct {
 	Description    string         `json:",omitempty"`
 	Severity       string         `json:",omitempty"`
 	VendorSeverity VendorSeverity `json:",omitempty"`
-	VendorVectors  VendorCVSS     `json:",omitempty"`
+	VendorVectors  VendorVectors  `json:",omitempty"` // Deprecated: VendorVectors is only for backwards compatibility. Use CVSS instead.
+	CVSS           VendorCVSS     `json:",omitempty"`
 	References     []string       `json:",omitempty"`
 }
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -11,18 +11,14 @@ type Severity int
 
 type VendorSeverity map[string]Severity
 
-type CVSSVector struct {
-	V2     string `json:"v2,omitempty"`
-	V3     string `json:"v3,omitempty"`
-	Scores CVSSScore
+type CVSS struct {
+	V2      string  `json:"v2,omitempty"`
+	V3      string  `json:"v3,omitempty"`
+	V2Score float64 `json:"v2_score,omitempty"`
+	V3Score float64 `json:"v3_score,omitempty"`
 }
 
-type CVSSScore struct {
-	V2 float64 `json:"v2,omitempty"`
-	V3 float64 `json:"v3,omitempty"`
-}
-
-type VendorVectors map[string]CVSSVector
+type VendorCVSS map[string]CVSS
 
 const (
 	SeverityUnknown Severity = iota
@@ -103,7 +99,7 @@ type Vulnerability struct {
 	Description    string         `json:",omitempty"`
 	Severity       string         `json:",omitempty"`
 	VendorSeverity VendorSeverity `json:",omitempty"`
-	VendorVectors  VendorVectors  `json:",omitempty"`
+	VendorVectors  VendorCVSS     `json:",omitempty"`
 	References     []string       `json:",omitempty"`
 }
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -12,10 +12,10 @@ type Severity int
 type VendorSeverity map[string]Severity
 
 type CVSS struct {
-	V2      string  `json:"v2,omitempty"`
-	V3      string  `json:"v3,omitempty"`
-	V2Score float64 `json:"v2_score,omitempty"`
-	V3Score float64 `json:"v3_score,omitempty"`
+	V2Vector string  `json:"v2_vector,omitempty"`
+	V3Vector string  `json:"v3_vector,omitempty"`
+	V2Score  float64 `json:"v2_score,omitempty"`
+	V3Score  float64 `json:"v3_score,omitempty"`
 }
 
 type CVSSVector struct {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -11,13 +11,13 @@ type Severity int
 
 type VendorSeverity map[string]Severity
 
-type CVSSVector struct {
-	V2      string  `json:"v2,omitempty"`
-	V2Score float64 `json:"v2_score,omitempty"`
-	V3      string  `json:"v3,omitempty"`
-	V3Score float64 `json:"v3_score,omitempty"`
+type CVSS struct {
+	V2Vector string  `json:"v2_vector,omitempty"`
+	V2Score  float64 `json:"v2_score,omitempty"`
+	V3Vector string  `json:"v3_vector,omitempty"`
+	V3Score  float64 `json:"v3_score,omitempty"`
 }
-type VendorVectors map[string]CVSSVector
+type VendorVectors map[string]CVSS
 
 const (
 	SeverityUnknown Severity = iota

--- a/pkg/vulnsrc/nvd/types.go
+++ b/pkg/vulnsrc/nvd/types.go
@@ -30,8 +30,8 @@ type BaseMetricV2 struct {
 }
 
 type CvssV2 struct {
-	BaseScore    float64
-	VectorString string `json:"vectorString"`
+	BaseScore    float64 `json:"baseScore"`
+	VectorString string  `json:"vectorString"`
 }
 
 type BaseMetricV3 struct {
@@ -39,7 +39,7 @@ type BaseMetricV3 struct {
 }
 
 type CvssV3 struct {
-	BaseScore    float64
+	BaseScore    float64 `json:"baseScore"`
 	BaseSeverity string
 	VectorString string `json:"vectorString"`
 }

--- a/pkg/vulnsrc/vulnerability/vulnerability.go
+++ b/pkg/vulnsrc/vulnerability/vulnerability.go
@@ -39,11 +39,11 @@ func getVendorVectors(details map[string]types.VulnerabilityDetail) types.Vendor
 		if (detail.CvssVector == "" || detail.CvssScore == 0) && (detail.CvssVectorV3 == "" || detail.CvssScoreV3 == 0) {
 			continue
 		}
-		vv[vendor] = types.CVSSVector{
-			V2:      detail.CvssVector,
-			V2Score: detail.CvssScore,
-			V3:      detail.CvssVectorV3,
-			V3Score: detail.CvssScoreV3,
+		vv[vendor] = types.CVSS{
+			V2Vector: detail.CvssVector,
+			V2Score:  detail.CvssScore,
+			V3Vector: detail.CvssVectorV3,
+			V3Score:  detail.CvssScoreV3,
 		}
 	}
 	return vv

--- a/pkg/vulnsrc/vulnerability/vulnerability.go
+++ b/pkg/vulnsrc/vulnerability/vulnerability.go
@@ -30,23 +30,23 @@ func GetDetail(vulnID string) (types.Severity, types.VendorSeverity, types.Vendo
 		return types.SeverityUnknown, nil, nil, "", "", nil
 	}
 
-	return getSeverity(details), getVendorSeverity(details), getVendorVectors(details), getTitle(details), getDescription(details), getReferences(details)
+	return getSeverity(details), getVendorSeverity(details), getCVSS(details), getTitle(details), getDescription(details), getReferences(details)
 }
 
-func getVendorVectors(details map[string]types.VulnerabilityDetail) types.VendorCVSS {
-	vv := make(types.VendorCVSS)
+func getCVSS(details map[string]types.VulnerabilityDetail) types.VendorCVSS {
+	vc := make(types.VendorCVSS)
 	for vendor, detail := range details {
 		if (detail.CvssVector == "" || detail.CvssScore == 0) && (detail.CvssVectorV3 == "" || detail.CvssScoreV3 == 0) {
 			continue
 		}
-		vv[vendor] = types.CVSS{
+		vc[vendor] = types.CVSS{
 			V2:      detail.CvssVector,
 			V3:      detail.CvssVectorV3,
 			V2Score: detail.CvssScore,
 			V3Score: detail.CvssScoreV3,
 		}
 	}
-	return vv
+	return vc
 }
 
 func getVendorSeverity(details map[string]types.VulnerabilityDetail) types.VendorSeverity {

--- a/pkg/vulnsrc/vulnerability/vulnerability.go
+++ b/pkg/vulnsrc/vulnerability/vulnerability.go
@@ -40,10 +40,12 @@ func getVendorVectors(details map[string]types.VulnerabilityDetail) types.Vendor
 			continue
 		}
 		vv[vendor] = types.CVSSVector{
-			V2:      detail.CvssVector,
-			V2Score: detail.CvssScore,
-			V3:      detail.CvssVectorV3,
-			V3Score: detail.CvssScoreV3,
+			V2: detail.CvssVector,
+			V3: detail.CvssVectorV3,
+			Scores: types.CVSSScore{
+				V2: detail.CvssScore,
+				V3: detail.CvssScoreV3,
+			},
 		}
 	}
 	return vv

--- a/pkg/vulnsrc/vulnerability/vulnerability.go
+++ b/pkg/vulnsrc/vulnerability/vulnerability.go
@@ -21,7 +21,7 @@ var (
 	getVulnerabilityDetailFunc = db.Config{}.GetVulnerabilityDetail
 )
 
-func GetDetail(vulnID string) (types.Severity, types.VendorSeverity, types.VendorVectors, string, string, []string) {
+func GetDetail(vulnID string) (types.Severity, types.VendorSeverity, types.VendorCVSS, string, string, []string) {
 	details, err := getVulnerabilityDetailFunc(vulnID)
 	if err != nil {
 		log.Println(err)
@@ -33,19 +33,17 @@ func GetDetail(vulnID string) (types.Severity, types.VendorSeverity, types.Vendo
 	return getSeverity(details), getVendorSeverity(details), getVendorVectors(details), getTitle(details), getDescription(details), getReferences(details)
 }
 
-func getVendorVectors(details map[string]types.VulnerabilityDetail) types.VendorVectors {
-	vv := make(types.VendorVectors)
+func getVendorVectors(details map[string]types.VulnerabilityDetail) types.VendorCVSS {
+	vv := make(types.VendorCVSS)
 	for vendor, detail := range details {
 		if (detail.CvssVector == "" || detail.CvssScore == 0) && (detail.CvssVectorV3 == "" || detail.CvssScoreV3 == 0) {
 			continue
 		}
-		vv[vendor] = types.CVSSVector{
-			V2: detail.CvssVector,
-			V3: detail.CvssVectorV3,
-			Scores: types.CVSSScore{
-				V2: detail.CvssScore,
-				V3: detail.CvssScoreV3,
-			},
+		vv[vendor] = types.CVSS{
+			V2:      detail.CvssVector,
+			V3:      detail.CvssVectorV3,
+			V2Score: detail.CvssScore,
+			V3Score: detail.CvssScoreV3,
 		}
 	}
 	return vv

--- a/pkg/vulnsrc/vulnerability/vulnerability.go
+++ b/pkg/vulnsrc/vulnerability/vulnerability.go
@@ -21,16 +21,16 @@ var (
 	getVulnerabilityDetailFunc = db.Config{}.GetVulnerabilityDetail
 )
 
-func GetDetail(vulnID string) (types.Severity, types.VendorSeverity, types.VendorCVSS, string, string, []string) {
+func GetDetail(vulnID string) (types.Severity, types.VendorSeverity, types.VendorCVSS, types.VendorVectors, string, string, []string) {
 	details, err := getVulnerabilityDetailFunc(vulnID)
 	if err != nil {
 		log.Println(err)
-		return types.SeverityUnknown, nil, nil, "", "", nil
+		return types.SeverityUnknown, nil, nil, nil, "", "", nil
 	} else if len(details) == 0 {
-		return types.SeverityUnknown, nil, nil, "", "", nil
+		return types.SeverityUnknown, nil, nil, nil, "", "", nil
 	}
 
-	return getSeverity(details), getVendorSeverity(details), getCVSS(details), getTitle(details), getDescription(details), getReferences(details)
+	return getSeverity(details), getVendorSeverity(details), getCVSS(details), getVendorVectors(details), getTitle(details), getDescription(details), getReferences(details)
 }
 
 func getCVSS(details map[string]types.VulnerabilityDetail) types.VendorCVSS {
@@ -47,6 +47,21 @@ func getCVSS(details map[string]types.VulnerabilityDetail) types.VendorCVSS {
 		}
 	}
 	return vc
+}
+
+// Deprecated: Use getCVSS instead.
+func getVendorVectors(details map[string]types.VulnerabilityDetail) types.VendorVectors {
+	vv := make(types.VendorVectors)
+	for vendor, detail := range details {
+		if detail.CvssVector == "" && detail.CvssVectorV3 == "" {
+			continue
+		}
+		vv[vendor] = types.CVSSVector{
+			V2: detail.CvssVector,
+			V3: detail.CvssVectorV3,
+		}
+	}
+	return vv
 }
 
 func getVendorSeverity(details map[string]types.VulnerabilityDetail) types.VendorSeverity {

--- a/pkg/vulnsrc/vulnerability/vulnerability.go
+++ b/pkg/vulnsrc/vulnerability/vulnerability.go
@@ -12,6 +12,7 @@ import (
 
 var (
 	sources = []string{Nvd, RedHat, Debian, DebianOVAL, Alpine, Amazon, OracleOVAL, SuseCVRF, Photon,
+		//sources = []string{Nvd, RedHat, Debian, DebianOVAL, Ubuntu, Alpine, Amazon, OracleOVAL, SuseCVRF, Photon,
 		RubySec, RustSec, PhpSecurityAdvisories, NodejsSecurityWg, PythonSafetyDB,
 		GHSAComposer, GHSAMaven, GHSANpm, GHSANuget, GHSAPip, GHSARubygems}
 )
@@ -36,12 +37,14 @@ func GetDetail(vulnID string) (types.Severity, types.VendorSeverity, types.Vendo
 func getVendorVectors(details map[string]types.VulnerabilityDetail) types.VendorVectors {
 	vv := make(types.VendorVectors)
 	for vendor, detail := range details {
-		if detail.CvssVector == "" && detail.CvssVectorV3 == "" {
+		if (detail.CvssVector == "" || detail.CvssScore == 0) && (detail.CvssVectorV3 == "" || detail.CvssScoreV3 == 0) {
 			continue
 		}
 		vv[vendor] = types.CVSSVector{
-			V2: detail.CvssVector,
-			V3: detail.CvssVectorV3,
+			V2:      detail.CvssVector,
+			V2Score: detail.CvssScore,
+			V3:      detail.CvssVectorV3,
+			V3Score: detail.CvssScoreV3,
 		}
 	}
 	return vv

--- a/pkg/vulnsrc/vulnerability/vulnerability.go
+++ b/pkg/vulnsrc/vulnerability/vulnerability.go
@@ -40,10 +40,10 @@ func getCVSS(details map[string]types.VulnerabilityDetail) types.VendorCVSS {
 			continue
 		}
 		vc[vendor] = types.CVSS{
-			V2:      detail.CvssVector,
-			V3:      detail.CvssVectorV3,
-			V2Score: detail.CvssScore,
-			V3Score: detail.CvssScoreV3,
+			V2Vector: detail.CvssVector,
+			V3Vector: detail.CvssVectorV3,
+			V2Score:  detail.CvssScore,
+			V3Score:  detail.CvssScoreV3,
 		}
 	}
 	return vc

--- a/pkg/vulnsrc/vulnerability/vulnerability.go
+++ b/pkg/vulnsrc/vulnerability/vulnerability.go
@@ -11,8 +11,7 @@ import (
 )
 
 var (
-	sources = []string{Nvd, RedHat, Debian, DebianOVAL, Alpine, Amazon, OracleOVAL, SuseCVRF, Photon,
-		//sources = []string{Nvd, RedHat, Debian, DebianOVAL, Ubuntu, Alpine, Amazon, OracleOVAL, SuseCVRF, Photon,
+	sources = []string{Nvd, RedHat, Debian, DebianOVAL, Ubuntu, Alpine, Amazon, OracleOVAL, SuseCVRF, Photon,
 		RubySec, RustSec, PhpSecurityAdvisories, NodejsSecurityWg, PythonSafetyDB,
 		GHSAComposer, GHSAMaven, GHSANpm, GHSANuget, GHSAPip, GHSARubygems}
 )

--- a/pkg/vulnsrc/vulnerability/vulnerability.go
+++ b/pkg/vulnsrc/vulnerability/vulnerability.go
@@ -39,11 +39,11 @@ func getVendorVectors(details map[string]types.VulnerabilityDetail) types.Vendor
 		if (detail.CvssVector == "" || detail.CvssScore == 0) && (detail.CvssVectorV3 == "" || detail.CvssScoreV3 == 0) {
 			continue
 		}
-		vv[vendor] = types.CVSS{
-			V2Vector: detail.CvssVector,
-			V2Score:  detail.CvssScore,
-			V3Vector: detail.CvssVectorV3,
-			V3Score:  detail.CvssScoreV3,
+		vv[vendor] = types.CVSSVector{
+			V2:      detail.CvssVector,
+			V2Score: detail.CvssScore,
+			V3:      detail.CvssVectorV3,
+			V3Score: detail.CvssScoreV3,
 		}
 	}
 	return vv

--- a/pkg/vulnsrc/vulnerability/vulnerability_test.go
+++ b/pkg/vulnsrc/vulnerability/vulnerability_test.go
@@ -72,14 +72,14 @@ func TestGetDetail(t *testing.T) {
 			},
 			expectedVendorCVSS: types.VendorCVSS{
 				RedHat: types.CVSS{
-					V2:      "AV:N/AC:M/Au:N/C:N/I:P/A:N",
-					V3:      "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
-					V2Score: 4.2,
-					V3Score: 5.6,
+					V2Vector: "AV:N/AC:M/Au:N/C:N/I:P/A:N",
+					V3Vector: "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+					V2Score:  4.2,
+					V3Score:  5.6,
 				},
 				Ubuntu: types.CVSS{
-					V3:      "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
-					V3Score: 3.4,
+					V3Vector: "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+					V3Score:  3.4,
 				},
 			},
 			expectedTitle:       "test vulnerability",

--- a/pkg/vulnsrc/vulnerability/vulnerability_test.go
+++ b/pkg/vulnsrc/vulnerability/vulnerability_test.go
@@ -61,15 +61,15 @@ func TestGetDetail(t *testing.T) {
 			expectedSeverity:       types.SeverityMedium,
 			expectedVendorSeverity: types.VendorSeverity{"redhat": 4, "ubuntu": 1, "rust-advisory-db": 4},
 			expectedVendorVectors: types.VendorVectors{
-				RedHat: types.CVSS{
-					V2Vector: "AV:N/AC:M/Au:N/C:N/I:P/A:N",
-					V2Score:  4.2,
-					V3Vector: "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
-					V3Score:  5.6,
+				RedHat: types.CVSSVector{
+					V2:      "AV:N/AC:M/Au:N/C:N/I:P/A:N",
+					V2Score: 4.2,
+					V3:      "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+					V3Score: 5.6,
 				},
-				Ubuntu: types.CVSS{
-					V3Vector: "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
-					V3Score:  3.4,
+				Ubuntu: types.CVSSVector{
+					V3:      "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+					V3Score: 3.4,
 				},
 			},
 			expectedTitle:       "test vulnerability",

--- a/pkg/vulnsrc/vulnerability/vulnerability_test.go
+++ b/pkg/vulnsrc/vulnerability/vulnerability_test.go
@@ -62,14 +62,18 @@ func TestGetDetail(t *testing.T) {
 			expectedVendorSeverity: types.VendorSeverity{"redhat": 4, "ubuntu": 1, "rust-advisory-db": 4},
 			expectedVendorVectors: types.VendorVectors{
 				RedHat: types.CVSSVector{
-					V2:      "AV:N/AC:M/Au:N/C:N/I:P/A:N",
-					V2Score: 4.2,
-					V3:      "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
-					V3Score: 5.6,
+					V2: "AV:N/AC:M/Au:N/C:N/I:P/A:N",
+					V3: "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+					Scores: types.CVSSScore{
+						V2: 4.2,
+						V3: 5.6,
+					},
 				},
 				Ubuntu: types.CVSSVector{
-					V3:      "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
-					V3Score: 3.4,
+					V3: "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+					Scores: types.CVSSScore{
+						V3: 3.4,
+					},
 				},
 			},
 			expectedTitle:       "test vulnerability",

--- a/pkg/vulnsrc/vulnerability/vulnerability_test.go
+++ b/pkg/vulnsrc/vulnerability/vulnerability_test.go
@@ -37,7 +37,6 @@ func TestGetDetail(t *testing.T) {
 					},
 					Ubuntu: {
 						ID:           "CVE-2020-1234",
-						CvssScore:    1.2,
 						CvssScoreV3:  3.4,
 						CvssVectorV3: "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
 						Severity:     types.SeverityLow,
@@ -63,11 +62,14 @@ func TestGetDetail(t *testing.T) {
 			expectedVendorSeverity: types.VendorSeverity{"redhat": 4, "ubuntu": 1, "rust-advisory-db": 4},
 			expectedVendorVectors: types.VendorVectors{
 				RedHat: types.CVSSVector{
-					V2: "AV:N/AC:M/Au:N/C:N/I:P/A:N",
-					V3: "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+					V2:      "AV:N/AC:M/Au:N/C:N/I:P/A:N",
+					V2Score: 4.2,
+					V3:      "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+					V3Score: 5.6,
 				},
 				Ubuntu: types.CVSSVector{
-					V3: "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+					V3:      "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+					V3Score: 3.4,
 				},
 			},
 			expectedTitle:       "test vulnerability",
@@ -107,6 +109,38 @@ func TestGetDetail(t *testing.T) {
 			expectedTitle:          "test vulnerability",
 			expectedDescription:    "a test vulnerability where vendor rates it lower than NVD",
 		},
+		// TODO: Bring this back
+		//{
+		//	name: "happy path, classifications for redhat (only CVSSv3), ubuntu and nodejs with variety vectors but no scores",
+		//	getVulnerabilityDetailFunc: func(cveID string) (m map[string]types.VulnerabilityDetail, err error) {
+		//		return map[string]types.VulnerabilityDetail{
+		//			RedHat: {
+		//				ID:           "CVE-2020-1234",
+		//				CvssVector:   "AV:N/AC:M/Au:N/C:N/I:P/A:N",
+		//				CvssVectorV3: "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+		//				Title:        "test vulnerability",
+		//				Description:  "a test vulnerability where vendor rates it lower than NVD",
+		//			},
+		//			Ubuntu: {
+		//				ID:          "CVE-2020-1234",
+		//				Severity:    types.SeverityLow,
+		//				SeverityV3:  types.SeverityMedium,
+		//				Title:       "test vulnerability",
+		//				Description: "a test vulnerability where vendor rates it lower than NVD",
+		//			},
+		//			NodejsSecurityWg: {
+		//				ID:          "CVE-2020-1234",
+		//				Title:       "test vulnerability",
+		//				Description: "a test vulnerability where vendor rates it lower than NVD",
+		//			},
+		//		}, nil
+		//	},
+		//	expectedSeverity:       types.SeverityMedium,
+		//	expectedVendorSeverity: types.VendorSeverity{"ubuntu": 1},
+		//	expectedVendorVectors:  types.VendorVectors{},
+		//	expectedTitle:          "test vulnerability",
+		//	expectedDescription:    "a test vulnerability where vendor rates it lower than NVD",
+		//},
 		{
 			name: "sad path, getVulnerabilityDetailFunc returns an error",
 			getVulnerabilityDetailFunc: func(cveID string) (m map[string]types.VulnerabilityDetail, err error) {

--- a/pkg/vulnsrc/vulnerability/vulnerability_test.go
+++ b/pkg/vulnsrc/vulnerability/vulnerability_test.go
@@ -109,38 +109,37 @@ func TestGetDetail(t *testing.T) {
 			expectedTitle:          "test vulnerability",
 			expectedDescription:    "a test vulnerability where vendor rates it lower than NVD",
 		},
-		// TODO: Bring this back
-		//{
-		//	name: "happy path, classifications for redhat (only CVSSv3), ubuntu and nodejs with variety vectors but no scores",
-		//	getVulnerabilityDetailFunc: func(cveID string) (m map[string]types.VulnerabilityDetail, err error) {
-		//		return map[string]types.VulnerabilityDetail{
-		//			RedHat: {
-		//				ID:           "CVE-2020-1234",
-		//				CvssVector:   "AV:N/AC:M/Au:N/C:N/I:P/A:N",
-		//				CvssVectorV3: "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
-		//				Title:        "test vulnerability",
-		//				Description:  "a test vulnerability where vendor rates it lower than NVD",
-		//			},
-		//			Ubuntu: {
-		//				ID:          "CVE-2020-1234",
-		//				Severity:    types.SeverityLow,
-		//				SeverityV3:  types.SeverityMedium,
-		//				Title:       "test vulnerability",
-		//				Description: "a test vulnerability where vendor rates it lower than NVD",
-		//			},
-		//			NodejsSecurityWg: {
-		//				ID:          "CVE-2020-1234",
-		//				Title:       "test vulnerability",
-		//				Description: "a test vulnerability where vendor rates it lower than NVD",
-		//			},
-		//		}, nil
-		//	},
-		//	expectedSeverity:       types.SeverityMedium,
-		//	expectedVendorSeverity: types.VendorSeverity{"ubuntu": 1},
-		//	expectedVendorVectors:  types.VendorVectors{},
-		//	expectedTitle:          "test vulnerability",
-		//	expectedDescription:    "a test vulnerability where vendor rates it lower than NVD",
-		//},
+		{
+			name: "happy path, classifications for redhat (only CVSSv3), ubuntu and nodejs with variety vectors but no scores",
+			getVulnerabilityDetailFunc: func(cveID string) (m map[string]types.VulnerabilityDetail, err error) {
+				return map[string]types.VulnerabilityDetail{
+					RedHat: {
+						ID:           "CVE-2020-1234",
+						CvssVector:   "AV:N/AC:M/Au:N/C:N/I:P/A:N",
+						CvssVectorV3: "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+						Title:        "test vulnerability",
+						Description:  "a test vulnerability where vendor rates it lower than NVD",
+					},
+					Ubuntu: {
+						ID:          "CVE-2020-1234",
+						Severity:    types.SeverityLow,
+						SeverityV3:  types.SeverityMedium,
+						Title:       "test vulnerability",
+						Description: "a test vulnerability where vendor rates it lower than NVD",
+					},
+					NodejsSecurityWg: {
+						ID:          "CVE-2020-1234",
+						Title:       "test vulnerability",
+						Description: "a test vulnerability where vendor rates it lower than NVD",
+					},
+				}, nil
+			},
+			expectedSeverity:       types.SeverityLow,
+			expectedVendorSeverity: types.VendorSeverity{"ubuntu": 1},
+			expectedVendorVectors:  types.VendorVectors{},
+			expectedTitle:          "test vulnerability",
+			expectedDescription:    "a test vulnerability where vendor rates it lower than NVD",
+		},
 		{
 			name: "sad path, getVulnerabilityDetailFunc returns an error",
 			getVulnerabilityDetailFunc: func(cveID string) (m map[string]types.VulnerabilityDetail, err error) {

--- a/pkg/vulnsrc/vulnerability/vulnerability_test.go
+++ b/pkg/vulnsrc/vulnerability/vulnerability_test.go
@@ -15,7 +15,8 @@ func TestGetDetail(t *testing.T) {
 		getVulnerabilityDetailFunc func(cveID string) (m map[string]types.VulnerabilityDetail, err error)
 		expectedSeverity           types.Severity
 		expectedVendorSeverity     types.VendorSeverity
-		expectedVendorVectors      types.VendorCVSS
+		expectedVendorVectors      types.VendorVectors
+		expectedVendorCVSS         types.VendorCVSS
 		expectedTitle              string
 		expectedDescription        string
 		expectedRefs               []string
@@ -60,7 +61,16 @@ func TestGetDetail(t *testing.T) {
 			},
 			expectedSeverity:       types.SeverityMedium,
 			expectedVendorSeverity: types.VendorSeverity{"redhat": 4, "ubuntu": 1, "rust-advisory-db": 4},
-			expectedVendorVectors: types.VendorCVSS{
+			expectedVendorVectors: types.VendorVectors{
+				RedHat: types.CVSSVector{
+					V2: "AV:N/AC:M/Au:N/C:N/I:P/A:N",
+					V3: "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+				},
+				Ubuntu: types.CVSSVector{
+					V3: "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+				},
+			},
+			expectedVendorCVSS: types.VendorCVSS{
 				RedHat: types.CVSS{
 					V2:      "AV:N/AC:M/Au:N/C:N/I:P/A:N",
 					V3:      "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
@@ -105,7 +115,8 @@ func TestGetDetail(t *testing.T) {
 			},
 			expectedSeverity:       types.SeverityMedium,
 			expectedVendorSeverity: types.VendorSeverity{"redhat": 2, "ubuntu": 1, "nodejs-security-wg": 4},
-			expectedVendorVectors:  types.VendorCVSS{},
+			expectedVendorVectors:  types.VendorVectors{},
+			expectedVendorCVSS:     types.VendorCVSS{},
 			expectedTitle:          "test vulnerability",
 			expectedDescription:    "a test vulnerability where vendor rates it lower than NVD",
 		},
@@ -136,9 +147,15 @@ func TestGetDetail(t *testing.T) {
 			},
 			expectedSeverity:       types.SeverityLow,
 			expectedVendorSeverity: types.VendorSeverity{"ubuntu": 1},
-			expectedVendorVectors:  types.VendorCVSS{},
-			expectedTitle:          "test vulnerability",
-			expectedDescription:    "a test vulnerability where vendor rates it lower than NVD",
+			expectedVendorVectors: types.VendorVectors{
+				"redhat": types.CVSSVector{
+					V2: "AV:N/AC:M/Au:N/C:N/I:P/A:N",
+					V3: "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+				},
+			},
+			expectedVendorCVSS:  types.VendorCVSS{},
+			expectedTitle:       "test vulnerability",
+			expectedDescription: "a test vulnerability where vendor rates it lower than NVD",
 		},
 		{
 			name: "sad path, getVulnerabilityDetailFunc returns an error",
@@ -156,10 +173,11 @@ func TestGetDetail(t *testing.T) {
 		}()
 		getVulnerabilityDetailFunc = tc.getVulnerabilityDetailFunc
 
-		gotSeverity, gotVendorSeverity, gotVendorVectors, gotTitle, gotDescription, gotRefs := GetDetail("CVE-2020-123")
+		gotSeverity, gotVendorSeverity, gotVendorCVSS, gotVendorVectors, gotTitle, gotDescription, gotRefs := GetDetail("CVE-2020-123")
 		assert.Equal(t, tc.expectedSeverity, gotSeverity, tc.name)
 		assert.Equal(t, tc.expectedVendorSeverity, gotVendorSeverity, tc.name)
 		assert.Equal(t, tc.expectedVendorVectors, gotVendorVectors, tc.name)
+		assert.Equal(t, tc.expectedVendorCVSS, gotVendorCVSS, tc.name)
 		assert.Equal(t, tc.expectedTitle, gotTitle, tc.name)
 		assert.Equal(t, tc.expectedDescription, gotDescription, tc.name)
 		assert.Equal(t, tc.expectedRefs, gotRefs, tc.name)

--- a/pkg/vulnsrc/vulnerability/vulnerability_test.go
+++ b/pkg/vulnsrc/vulnerability/vulnerability_test.go
@@ -15,7 +15,7 @@ func TestGetDetail(t *testing.T) {
 		getVulnerabilityDetailFunc func(cveID string) (m map[string]types.VulnerabilityDetail, err error)
 		expectedSeverity           types.Severity
 		expectedVendorSeverity     types.VendorSeverity
-		expectedVendorVectors      types.VendorVectors
+		expectedVendorVectors      types.VendorCVSS
 		expectedTitle              string
 		expectedDescription        string
 		expectedRefs               []string
@@ -60,20 +60,16 @@ func TestGetDetail(t *testing.T) {
 			},
 			expectedSeverity:       types.SeverityMedium,
 			expectedVendorSeverity: types.VendorSeverity{"redhat": 4, "ubuntu": 1, "rust-advisory-db": 4},
-			expectedVendorVectors: types.VendorVectors{
-				RedHat: types.CVSSVector{
-					V2: "AV:N/AC:M/Au:N/C:N/I:P/A:N",
-					V3: "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
-					Scores: types.CVSSScore{
-						V2: 4.2,
-						V3: 5.6,
-					},
+			expectedVendorVectors: types.VendorCVSS{
+				RedHat: types.CVSS{
+					V2:      "AV:N/AC:M/Au:N/C:N/I:P/A:N",
+					V3:      "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+					V2Score: 4.2,
+					V3Score: 5.6,
 				},
-				Ubuntu: types.CVSSVector{
-					V3: "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
-					Scores: types.CVSSScore{
-						V3: 3.4,
-					},
+				Ubuntu: types.CVSS{
+					V3:      "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+					V3Score: 3.4,
 				},
 			},
 			expectedTitle:       "test vulnerability",
@@ -109,7 +105,7 @@ func TestGetDetail(t *testing.T) {
 			},
 			expectedSeverity:       types.SeverityMedium,
 			expectedVendorSeverity: types.VendorSeverity{"redhat": 2, "ubuntu": 1, "nodejs-security-wg": 4},
-			expectedVendorVectors:  types.VendorVectors{},
+			expectedVendorVectors:  types.VendorCVSS{},
 			expectedTitle:          "test vulnerability",
 			expectedDescription:    "a test vulnerability where vendor rates it lower than NVD",
 		},
@@ -140,7 +136,7 @@ func TestGetDetail(t *testing.T) {
 			},
 			expectedSeverity:       types.SeverityLow,
 			expectedVendorSeverity: types.VendorSeverity{"ubuntu": 1},
-			expectedVendorVectors:  types.VendorVectors{},
+			expectedVendorVectors:  types.VendorCVSS{},
 			expectedTitle:          "test vulnerability",
 			expectedDescription:    "a test vulnerability where vendor rates it lower than NVD",
 		},

--- a/pkg/vulnsrc/vulnerability/vulnerability_test.go
+++ b/pkg/vulnsrc/vulnerability/vulnerability_test.go
@@ -61,15 +61,15 @@ func TestGetDetail(t *testing.T) {
 			expectedSeverity:       types.SeverityMedium,
 			expectedVendorSeverity: types.VendorSeverity{"redhat": 4, "ubuntu": 1, "rust-advisory-db": 4},
 			expectedVendorVectors: types.VendorVectors{
-				RedHat: types.CVSSVector{
-					V2:      "AV:N/AC:M/Au:N/C:N/I:P/A:N",
-					V2Score: 4.2,
-					V3:      "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
-					V3Score: 5.6,
+				RedHat: types.CVSS{
+					V2Vector: "AV:N/AC:M/Au:N/C:N/I:P/A:N",
+					V2Score:  4.2,
+					V3Vector: "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+					V3Score:  5.6,
 				},
-				Ubuntu: types.CVSSVector{
-					V3:      "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
-					V3Score: 3.4,
+				Ubuntu: types.CVSS{
+					V3Vector: "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+					V3Score:  3.4,
 				},
 			},
 			expectedTitle:       "test vulnerability",

--- a/pkg/vulnsrc/vulnsrc.go
+++ b/pkg/vulnsrc/vulnsrc.go
@@ -172,13 +172,14 @@ var (
 )
 
 func (o fullOptimizer) fullOptimize(tx *bolt.Tx, cveID string) error {
-	severity, vs, vc, title, description, references := getDetailFunc(cveID)
+	severity, vs, vc, vv, title, description, references := getDetailFunc(cveID)
 	vuln := types.Vulnerability{
 		Title:          title,
 		Description:    description,
 		Severity:       severity.String(), // TODO: We have to keep this key until we deprecate
 		References:     references,
 		VendorSeverity: vs,
+		VendorVectors:  vv, // TODO: We have to keep this for backwards compatibility.
 		CVSS:           vc,
 	}
 
@@ -208,7 +209,7 @@ func (o lightOptimizer) Optimize() error {
 
 func (o lightOptimizer) lightOptimize(cveID string, tx *bolt.Tx) error {
 	// get correct severity
-	severity, vendorSeverity, _, _, _, _ := getDetailFunc(cveID)
+	severity, vendorSeverity, _, _, _, _, _ := getDetailFunc(cveID)
 	vuln := types.Vulnerability{
 		VendorSeverity: vendorSeverity,
 	}

--- a/pkg/vulnsrc/vulnsrc.go
+++ b/pkg/vulnsrc/vulnsrc.go
@@ -172,14 +172,14 @@ var (
 )
 
 func (o fullOptimizer) fullOptimize(tx *bolt.Tx, cveID string) error {
-	severity, vs, vv, title, description, references := getDetailFunc(cveID)
+	severity, vs, vc, title, description, references := getDetailFunc(cveID)
 	vuln := types.Vulnerability{
 		Title:          title,
 		Description:    description,
 		Severity:       severity.String(), // TODO: We have to keep this key until we deprecate
 		References:     references,
 		VendorSeverity: vs,
-		VendorVectors:  vv,
+		CVSS:           vc,
 	}
 
 	if err := o.dbc.PutVulnerability(tx, cveID, vuln); err != nil {

--- a/pkg/vulnsrc/vulnsrc_test.go
+++ b/pkg/vulnsrc/vulnsrc_test.go
@@ -392,12 +392,12 @@ func Test_fullOptimize(t *testing.T) {
 		getDetailFunc = oldgetDetailFunc
 	}()
 
-	getDetailFunc = func(vulnID string) (severity types.Severity, vendorSeverity types.VendorSeverity, vendorVectors types.VendorVectors, s string, s2 string, strings []string) {
+	getDetailFunc = func(vulnID string) (severity types.Severity, vendorSeverity types.VendorSeverity, vendorVectors types.VendorCVSS, s string, s2 string, strings []string) {
 		return types.SeverityCritical, types.VendorSeverity{
 				"redhat": types.SeverityHigh,
 				"ubuntu": types.SeverityLow,
-			}, types.VendorVectors{
-				"redhat": types.CVSSVector{
+			}, types.VendorCVSS{
+				"redhat": types.CVSS{
 					V2: "AV:N/AC:M/Au:N/C:N/I:P/A:N",
 					V3: "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
 				},
@@ -420,7 +420,7 @@ func Test_fullOptimize(t *testing.T) {
 					"redhat": types.SeverityHigh,
 					"ubuntu": types.SeverityLow,
 				},
-				VendorVectors: map[string]types.CVSSVector{
+				VendorVectors: map[string]types.CVSS{
 					"redhat": {
 						V2: "AV:N/AC:M/Au:N/C:N/I:P/A:N",
 						V3: "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
@@ -444,11 +444,11 @@ func Test_lightOptimize(t *testing.T) {
 		getDetailFunc = oldgetDetailFunc
 	}()
 
-	getDetailFunc = func(vulnID string) (severity types.Severity, vendorSeverity types.VendorSeverity, vendorVectors types.VendorVectors, s string, s2 string, strings []string) {
+	getDetailFunc = func(vulnID string) (severity types.Severity, vendorSeverity types.VendorSeverity, vendorVectors types.VendorCVSS, s string, s2 string, strings []string) {
 		return types.SeverityCritical, types.VendorSeverity{
 			"redhat": types.SeverityHigh,
 			"ubuntu": types.SeverityLow,
-		}, types.VendorVectors{}, "test title", "test description", []string{"test reference"}
+		}, types.VendorCVSS{}, "test title", "test description", []string{"test reference"}
 	}
 
 	mockDBOperation := new(db.MockOperation)

--- a/pkg/vulnsrc/vulnsrc_test.go
+++ b/pkg/vulnsrc/vulnsrc_test.go
@@ -397,9 +397,9 @@ func Test_fullOptimize(t *testing.T) {
 				"redhat": types.SeverityHigh,
 				"ubuntu": types.SeverityLow,
 			}, types.VendorVectors{
-				"redhat": types.CVSS{
-					V2Vector: "AV:N/AC:M/Au:N/C:N/I:P/A:N",
-					V3Vector: "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+				"redhat": types.CVSSVector{
+					V2: "AV:N/AC:M/Au:N/C:N/I:P/A:N",
+					V3: "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
 				},
 			}, "test title", "test description", []string{"test reference"}
 	}
@@ -420,10 +420,10 @@ func Test_fullOptimize(t *testing.T) {
 					"redhat": types.SeverityHigh,
 					"ubuntu": types.SeverityLow,
 				},
-				VendorVectors: map[string]types.CVSS{
+				VendorVectors: map[string]types.CVSSVector{
 					"redhat": {
-						V2Vector: "AV:N/AC:M/Au:N/C:N/I:P/A:N",
-						V3Vector: "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+						V2: "AV:N/AC:M/Au:N/C:N/I:P/A:N",
+						V3: "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
 					},
 				},
 				References: []string{"test reference"},

--- a/pkg/vulnsrc/vulnsrc_test.go
+++ b/pkg/vulnsrc/vulnsrc_test.go
@@ -420,7 +420,7 @@ func Test_fullOptimize(t *testing.T) {
 					"redhat": types.SeverityHigh,
 					"ubuntu": types.SeverityLow,
 				},
-				VendorVectors: map[string]types.CVSS{
+				CVSS: map[string]types.CVSS{
 					"redhat": {
 						V2: "AV:N/AC:M/Au:N/C:N/I:P/A:N",
 						V3: "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",

--- a/pkg/vulnsrc/vulnsrc_test.go
+++ b/pkg/vulnsrc/vulnsrc_test.go
@@ -397,9 +397,9 @@ func Test_fullOptimize(t *testing.T) {
 				"redhat": types.SeverityHigh,
 				"ubuntu": types.SeverityLow,
 			}, types.VendorVectors{
-				"redhat": types.CVSSVector{
-					V2: "AV:N/AC:M/Au:N/C:N/I:P/A:N",
-					V3: "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+				"redhat": types.CVSS{
+					V2Vector: "AV:N/AC:M/Au:N/C:N/I:P/A:N",
+					V3Vector: "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
 				},
 			}, "test title", "test description", []string{"test reference"}
 	}
@@ -420,10 +420,10 @@ func Test_fullOptimize(t *testing.T) {
 					"redhat": types.SeverityHigh,
 					"ubuntu": types.SeverityLow,
 				},
-				VendorVectors: map[string]types.CVSSVector{
+				VendorVectors: map[string]types.CVSS{
 					"redhat": {
-						V2: "AV:N/AC:M/Au:N/C:N/I:P/A:N",
-						V3: "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+						V2Vector: "AV:N/AC:M/Au:N/C:N/I:P/A:N",
+						V3Vector: "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
 					},
 				},
 				References: []string{"test reference"},

--- a/pkg/vulnsrc/vulnsrc_test.go
+++ b/pkg/vulnsrc/vulnsrc_test.go
@@ -398,10 +398,10 @@ func Test_fullOptimize(t *testing.T) {
 				"ubuntu": types.SeverityLow,
 			}, types.VendorCVSS{
 				"redhat": types.CVSS{
-					V2:      "AV:N/AC:M/Au:N/C:N/I:P/A:N",
-					V2Score: 4.5,
-					V3:      "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
-					V3Score: 5.6,
+					V2Vector: "AV:N/AC:M/Au:N/C:N/I:P/A:N",
+					V2Score:  4.5,
+					V3Vector: "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+					V3Score:  5.6,
 				},
 			},
 			types.VendorVectors{
@@ -430,10 +430,10 @@ func Test_fullOptimize(t *testing.T) {
 				},
 				CVSS: map[string]types.CVSS{
 					"redhat": {
-						V2:      "AV:N/AC:M/Au:N/C:N/I:P/A:N",
-						V2Score: 4.5,
-						V3:      "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
-						V3Score: 5.6,
+						V2Vector: "AV:N/AC:M/Au:N/C:N/I:P/A:N",
+						V2Score:  4.5,
+						V3Vector: "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+						V3Score:  5.6,
 					},
 				},
 				VendorVectors: types.VendorVectors{

--- a/pkg/vulnsrc/vulnsrc_test.go
+++ b/pkg/vulnsrc/vulnsrc_test.go
@@ -392,12 +392,20 @@ func Test_fullOptimize(t *testing.T) {
 		getDetailFunc = oldgetDetailFunc
 	}()
 
-	getDetailFunc = func(vulnID string) (severity types.Severity, vendorSeverity types.VendorSeverity, vendorVectors types.VendorCVSS, s string, s2 string, strings []string) {
+	getDetailFunc = func(vulnID string) (severity types.Severity, vendorSeverity types.VendorSeverity, vendorCVSS types.VendorCVSS, vendorVectors types.VendorVectors, s string, s2 string, strings []string) {
 		return types.SeverityCritical, types.VendorSeverity{
 				"redhat": types.SeverityHigh,
 				"ubuntu": types.SeverityLow,
 			}, types.VendorCVSS{
 				"redhat": types.CVSS{
+					V2:      "AV:N/AC:M/Au:N/C:N/I:P/A:N",
+					V2Score: 4.5,
+					V3:      "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+					V3Score: 5.6,
+				},
+			},
+			types.VendorVectors{
+				"redhat": types.CVSSVector{
 					V2: "AV:N/AC:M/Au:N/C:N/I:P/A:N",
 					V3: "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
 				},
@@ -422,6 +430,14 @@ func Test_fullOptimize(t *testing.T) {
 				},
 				CVSS: map[string]types.CVSS{
 					"redhat": {
+						V2:      "AV:N/AC:M/Au:N/C:N/I:P/A:N",
+						V2Score: 4.5,
+						V3:      "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+						V3Score: 5.6,
+					},
+				},
+				VendorVectors: types.VendorVectors{
+					"redhat": types.CVSSVector{
 						V2: "AV:N/AC:M/Au:N/C:N/I:P/A:N",
 						V3: "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
 					},
@@ -444,11 +460,11 @@ func Test_lightOptimize(t *testing.T) {
 		getDetailFunc = oldgetDetailFunc
 	}()
 
-	getDetailFunc = func(vulnID string) (severity types.Severity, vendorSeverity types.VendorSeverity, vendorVectors types.VendorCVSS, s string, s2 string, strings []string) {
+	getDetailFunc = func(vulnID string) (severity types.Severity, vendorSeverity types.VendorSeverity, vendorCVSS types.VendorCVSS, vendorVectors types.VendorVectors, s string, s2 string, strings []string) {
 		return types.SeverityCritical, types.VendorSeverity{
 			"redhat": types.SeverityHigh,
 			"ubuntu": types.SeverityLow,
-		}, types.VendorCVSS{}, "test title", "test description", []string{"test reference"}
+		}, types.VendorCVSS{}, types.VendorVectors{}, "test title", "test description", []string{"test reference"}
 	}
 
 	mockDBOperation := new(db.MockOperation)


### PR DESCRIPTION
Addresses: https://github.com/aquasecurity/trivy/issues/92

<img width="975" alt="image" src="https://user-images.githubusercontent.com/1254783/83204938-00951c00-a102-11ea-9090-92cd28daea83.png">


Signed-off-by: Simarpreet Singh <simar@linux.com>