### PR TITLE
fix(vulnsrc): fix error values referencing wrong vuln src

### DIFF
--- a/pkg/vulnsrc/alpine/alpine.go
+++ b/pkg/vulnsrc/alpine/alpine.go
@@ -68,7 +68,7 @@ func (vs VulnSrc) save(cves []AlpineCVE) error {
 				FixedVersion: cve.FixedVersion,
 			}
 			if err := vs.dbc.PutAdvisory(tx, platformName, pkgName, cve.VulnerabilityID, advisory); err != nil {
-				return xerrors.Errorf("failed to save alpine advisory: %w", err)
+				return xerrors.Errorf("failed to save Alpine advisory: %w", err)
 			}
 
 			vuln := types.VulnerabilityDetail{
@@ -76,12 +76,12 @@ func (vs VulnSrc) save(cves []AlpineCVE) error {
 				Description: cve.Description,
 			}
 			if err := vs.dbc.PutVulnerabilityDetail(tx, cve.VulnerabilityID, vulnerability.Alpine, vuln); err != nil {
-				return xerrors.Errorf("failed to save alpine vulnerability: %w", err)
+				return xerrors.Errorf("failed to save Alpine vulnerability: %w", err)
 			}
 
 			// for light DB
 			if err := vs.dbc.PutSeverity(tx, cve.VulnerabilityID, types.SeverityUnknown); err != nil {
-				return xerrors.Errorf("failed to save alpine vulnerability severity: %w", err)
+				return xerrors.Errorf("failed to save Alpine vulnerability severity: %w", err)
 			}
 		}
 		return nil

--- a/pkg/vulnsrc/amazon/amazon.go
+++ b/pkg/vulnsrc/amazon/amazon.go
@@ -50,11 +50,11 @@ func (vs VulnSrc) Update(dir string) error {
 
 	err := fileWalker(rootDir, vs.walkFunc)
 	if err != nil {
-		return xerrors.Errorf("error in amazon walk: %w", err)
+		return xerrors.Errorf("error in Amazon walk: %w", err)
 	}
 
 	if err = vs.save(); err != nil {
-		return xerrors.Errorf("error in amazon save: %w", err)
+		return xerrors.Errorf("error in Amazon save: %w", err)
 	}
 
 	return nil
@@ -67,13 +67,13 @@ func (vs *VulnSrc) walkFunc(r io.Reader, path string) error {
 	}
 	version := paths[len(paths)-2]
 	if !utils.StringInSlice(version, targetVersions) {
-		log.Printf("unsupported amazon version: %s\n", version)
+		log.Printf("unsupported Amazon version: %s\n", version)
 		return nil
 	}
 
 	var vuln amazon.ALAS
 	if err := json.NewDecoder(r).Decode(&vuln); err != nil {
-		return xerrors.Errorf("failed to decode amazon JSON: %w", err)
+		return xerrors.Errorf("failed to decode Amazon JSON: %w", err)
 	}
 
 	vs.alasList = append(vs.alasList, alas{
@@ -84,7 +84,7 @@ func (vs *VulnSrc) walkFunc(r io.Reader, path string) error {
 }
 
 func (vs VulnSrc) save() error {
-	log.Println("Saving amazon DB")
+	log.Println("Saving Amazon DB")
 	err := vs.dbc.BatchUpdate(vs.commit())
 	if err != nil {
 		return xerrors.Errorf("error in batch update: %w", err)
@@ -106,7 +106,7 @@ func (vs VulnSrc) commitFunc(tx *bolt.Tx) error {
 					FixedVersion: constructVersion(pkg.Epoch, pkg.Version, pkg.Release),
 				}
 				if err := vs.dbc.PutAdvisory(tx, platformName, pkg.Name, cveID, advisory); err != nil {
-					return xerrors.Errorf("failed to save amazon advisory: %w", err)
+					return xerrors.Errorf("failed to save Amazon advisory: %w", err)
 				}
 
 				var references []string
@@ -121,12 +121,12 @@ func (vs VulnSrc) commitFunc(tx *bolt.Tx) error {
 					Title:       "",
 				}
 				if err := vs.dbc.PutVulnerabilityDetail(tx, cveID, vulnerability.Amazon, vuln); err != nil {
-					return xerrors.Errorf("failed to save amazon vulnerability detail: %w", err)
+					return xerrors.Errorf("failed to save Amazon vulnerability detail: %w", err)
 				}
 
 				// for light DB
 				if err := vs.dbc.PutSeverity(tx, cveID, types.SeverityUnknown); err != nil {
-					return xerrors.Errorf("failed to save alpine vulnerability severity: %w", err)
+					return xerrors.Errorf("failed to save Amazon vulnerability severity: %w", err)
 				}
 			}
 		}

--- a/pkg/vulnsrc/amazon/amazon_test.go
+++ b/pkg/vulnsrc/amazon/amazon_test.go
@@ -44,7 +44,7 @@ func TestVulnSrc_Update(t *testing.T) {
 			batchUpdate: db.BatchUpdateExpectation{
 				Args: db.BatchUpdateArgs{FnAnything: true},
 			},
-			expectedError: errors.New("error in amazon walk: error in file walk: lstat badpathdoesnotexist/vuln-list/amazon: no such file or directory"),
+			expectedError: errors.New("error in Amazon walk: error in file walk: lstat badpathdoesnotexist/vuln-list/amazon: no such file or directory"),
 		},
 		{
 			name:     "unable to save amazon defintions",
@@ -55,7 +55,7 @@ func TestVulnSrc_Update(t *testing.T) {
 					Err: errors.New("unable to batch update"),
 				},
 			},
-			expectedError: errors.New("error in amazon save: error in batch update: unable to batch update"),
+			expectedError: errors.New("error in Amazon save: error in batch update: unable to batch update"),
 		},
 	}
 
@@ -251,7 +251,7 @@ func TestVulnSrc_WalkFunc(t *testing.T) {
 			ioReader:         strings.NewReader(`invalidjson`),
 			inputPath:        "1/2/1",
 			expectedALASList: []alas(nil),
-			expectedError:    errors.New("failed to decode amazon JSON: invalid character 'i' looking for beginning of value"),
+			expectedError:    errors.New("failed to decode Amazon JSON: invalid character 'i' looking for beginning of value"),
 		},
 		{
 			name:          "unsupported amazon version",
@@ -396,7 +396,7 @@ func TestVulnSrc_CommitFunc(t *testing.T) {
 					},
 				},
 			},
-			expectedError: errors.New("failed to save amazon advisory: failed to put advisory"),
+			expectedError: errors.New("failed to save Amazon advisory: failed to put advisory"),
 		},
 		{
 			name: "failed to save Amazon advisory, PutVulnerabilityDetail() returns an error",
@@ -454,7 +454,7 @@ func TestVulnSrc_CommitFunc(t *testing.T) {
 					},
 				},
 			},
-			expectedError: errors.New("failed to save amazon vulnerability detail: failed to put vulnerability detail"),
+			expectedError: errors.New("failed to save Amazon vulnerability detail: failed to put vulnerability detail"),
 		},
 	}
 

--- a/pkg/vulnsrc/debian-oval/debian-oval.go
+++ b/pkg/vulnsrc/debian-oval/debian-oval.go
@@ -130,7 +130,7 @@ func (vs VulnSrc) save(cves []DebianOVAL) error {
 
 				// for light DB
 				if err := vs.dbc.PutSeverity(tx, cveID, types.SeverityUnknown); err != nil {
-					return xerrors.Errorf("failed to save alpine vulnerability severity: %w", err)
+					return xerrors.Errorf("failed to save Debian OVAL vulnerability severity: %w", err)
 				}
 			}
 		}
@@ -147,7 +147,7 @@ func (vs VulnSrc) Get(release string, pkgName string) ([]types.Advisory, error) 
 	bucket := fmt.Sprintf(platformFormat, release)
 	advisories, err := vs.dbc.GetAdvisories(bucket, pkgName)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to get Alpine advisories: %w", err)
+		return nil, xerrors.Errorf("failed to get Debian OVAL advisories: %w", err)
 	}
 	return advisories, nil
 }

--- a/pkg/vulnsrc/debian/debian.go
+++ b/pkg/vulnsrc/debian/debian.go
@@ -112,7 +112,7 @@ func (vs VulnSrc) commit(tx *bolt.Tx, cves []DebianCVE) error {
 
 				// for light DB
 				if err := vs.dbc.PutSeverity(tx, cve.VulnerabilityID, types.SeverityUnknown); err != nil {
-					return xerrors.Errorf("failed to save alpine vulnerability severity: %w", err)
+					return xerrors.Errorf("failed to save Debian vulnerability severity: %w", err)
 				}
 			}
 		}

--- a/pkg/vulnsrc/redhat-oval/redhat-oval.go
+++ b/pkg/vulnsrc/redhat-oval/redhat-oval.go
@@ -123,7 +123,7 @@ func (vs VulnSrc) Get(release string, pkgName string) ([]types.Advisory, error) 
 	bucket := fmt.Sprintf(platformFormat, release)
 	advisories, err := vs.dbc.GetAdvisories(bucket, pkgName)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to get Alpine advisories: %w", err)
+		return nil, xerrors.Errorf("failed to get Red Hat OVAL advisories: %w", err)
 	}
 	return advisories, nil
 }

--- a/pkg/vulnsrc/ubuntu/ubuntu.go
+++ b/pkg/vulnsrc/ubuntu/ubuntu.go
@@ -126,7 +126,7 @@ func (vs VulnSrc) commit(tx *bolt.Tx, cves []UbuntuCVE) error {
 
 				// for light DB
 				if err := vs.dbc.PutSeverity(tx, cve.Candidate, types.SeverityUnknown); err != nil {
-					return xerrors.Errorf("failed to save alpine vulnerability severity: %w", err)
+					return xerrors.Errorf("failed to save Ubuntu vulnerability severity: %w", err)
 				}
 			}
 		}
@@ -138,7 +138,7 @@ func (vs VulnSrc) Get(release string, pkgName string) ([]types.Advisory, error) 
 	bucket := fmt.Sprintf(platformFormat, release)
 	advisories, err := vs.dbc.GetAdvisories(bucket, pkgName)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to get Amazon advisories: %w", err)
+		return nil, xerrors.Errorf("failed to get Ubuntu advisories: %w", err)
 	}
 	return advisories, nil
 }


### PR DESCRIPTION
Noticed that some error values referenced wrong VulnSrc names 🧐 

Also tried to make some of the VulnSrc name capitalization more consistent within their files (e.g `amazon` vs `Amazon`) 