### PR TITLE
feat(nvd): add CWE-ID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 .idea
 
 assets
+cache

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -104,7 +104,7 @@ type Advisory struct {
 type Vulnerability struct {
 	Title          string         `json:",omitempty"`
 	Description    string         `json:",omitempty"`
-	Severity       string         `json:",omitempty"`
+	Severity       string         `json:",omitempty"` // Deprecated: Severity is only for backwards compatibility. Use VendorSeverity instead.
 	CweIDs         []string       `json:",omitempty"` // e.g. CWE-78, CWE-89
 	VendorSeverity VendorSeverity `json:",omitempty"`
 	VendorVectors  VendorVectors  `json:",omitempty"` // Deprecated: VendorVectors is only for backwards compatibility. Use CVSS instead.

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -81,6 +81,7 @@ type VulnerabilityDetail struct {
 	CvssVectorV3 string   `json:",omitempty"`
 	Severity     Severity `json:",omitempty"`
 	SeverityV3   Severity `json:",omitempty"`
+	CweIDs       []string `json:",omitempty"` // e.g. CWE-78, CWE-89
 	References   []string `json:",omitempty"`
 	Title        string   `json:",omitempty"`
 	Description  string   `json:",omitempty"`
@@ -95,6 +96,7 @@ type Vulnerability struct {
 	Title          string         `json:",omitempty"`
 	Description    string         `json:",omitempty"`
 	Severity       string         `json:",omitempty"`
+	CweIDs         []string       `json:",omitempty"` // e.g. CWE-78, CWE-89
 	VendorSeverity VendorSeverity `json:",omitempty"`
 	VendorVectors  VendorVectors  `json:",omitempty"`
 	References     []string       `json:",omitempty"`

--- a/pkg/vulnsrc/nvd/nvd.go
+++ b/pkg/vulnsrc/nvd/nvd.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log"
 	"path/filepath"
+	"strings"
 
 	"github.com/aquasecurity/trivy-db/pkg/types"
 	bolt "go.etcd.io/bbolt"
@@ -80,6 +81,9 @@ func (vs VulnSrc) commit(tx *bolt.Tx, items []Item) error {
 		var cweIDs []string
 		for _, data := range item.Cve.ProblemType.ProblemTypeData {
 			for _, desc := range data.Description {
+				if !strings.HasPrefix(desc.Value, "CWE") {
+					continue
+				}
 				cweIDs = append(cweIDs, desc.Value)
 			}
 		}

--- a/pkg/vulnsrc/nvd/nvd.go
+++ b/pkg/vulnsrc/nvd/nvd.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 
 	"github.com/aquasecurity/trivy-db/pkg/types"
-
 	bolt "go.etcd.io/bbolt"
 	"golang.org/x/xerrors"
 
@@ -78,6 +77,13 @@ func (vs VulnSrc) commit(tx *bolt.Tx, items []Item) error {
 			}
 		}
 
+		var cweIDs []string
+		for _, data := range item.Cve.ProblemType.ProblemTypeData {
+			for _, desc := range data.Description {
+				cweIDs = append(cweIDs, desc.Value)
+			}
+		}
+
 		vuln := types.VulnerabilityDetail{
 			CvssScore:    item.Impact.BaseMetricV2.CvssV2.BaseScore,
 			CvssVector:   item.Impact.BaseMetricV2.CvssV2.VectorString,
@@ -85,6 +91,7 @@ func (vs VulnSrc) commit(tx *bolt.Tx, items []Item) error {
 			CvssVectorV3: item.Impact.BaseMetricV3.CvssV3.VectorString,
 			Severity:     severity,
 			SeverityV3:   severityV3,
+			CweIDs:       cweIDs,
 			References:   references,
 			Title:        "",
 			Description:  description,

--- a/pkg/vulnsrc/nvd/nvd_test.go
+++ b/pkg/vulnsrc/nvd/nvd_test.go
@@ -62,15 +62,13 @@ func TestVulnSrc_Update(t *testing.T) {
 			case tc.wantErr != "":
 				require.NotNil(t, err)
 				assert.Contains(t, err.Error(), tc.wantErr, tc.name)
-				return
 			default:
 				assert.NoError(t, err, tc.name)
+				dbc := db.Config{}
+				got, err := dbc.GetVulnerabilityDetail(tc.cveID)
+				require.NoError(t, err)
+				assert.Equal(t, tc.want, got["nvd"])
 			}
-
-			dbc := db.Config{}
-			got, err := dbc.GetVulnerabilityDetail(tc.cveID)
-			require.NoError(t, err)
-			assert.Equal(t, tc.want, got["nvd"])
 		})
 	}
 }

--- a/pkg/vulnsrc/nvd/nvd_test.go
+++ b/pkg/vulnsrc/nvd/nvd_test.go
@@ -1,7 +1,11 @@
 package nvd
 
 import (
+	"io/ioutil"
+	"os"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/vulnerability"
@@ -11,6 +15,65 @@ import (
 	bolt "go.etcd.io/bbolt"
 )
 
+func TestVulnSrc_Update(t *testing.T) {
+	testCases := []struct {
+		name    string
+		dir     string
+		cveID   string
+		want    types.VulnerabilityDetail
+		wantErr string
+	}{
+		{
+			name:  "happy path",
+			dir:   "./testdata",
+			cveID: "CVE-2020-0001",
+			want: types.VulnerabilityDetail{
+				Description:  "In getProcessRecordLocked of ActivityManagerService.java isolated apps are not handled correctly. This could lead to local escalation of privilege with no additional execution privileges needed. User interaction is not needed for exploitation. Product: Android Versions: Android-8.0, Android-8.1, Android-9, and Android-10 Android ID: A-140055304",
+				CvssScore:    7.2,
+				CvssVector:   "AV:L/AC:L/Au:N/C:C/I:C/A:C",
+				CvssScoreV3:  7.8,
+				CvssVectorV3: "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+				Severity:     types.SeverityHigh,
+				SeverityV3:   types.SeverityHigh,
+				CweIDs:       []string{"CWE-269"},
+				References:   []string{"https://source.android.com/security/bulletin/2020-01-01"},
+			},
+		},
+		{
+			name:    "sad path",
+			dir:     "./sad",
+			wantErr: "no such file or directory",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cacheDir, err := ioutil.TempDir("", "nvd")
+			require.NoError(t, err)
+			err = db.Init(cacheDir)
+			require.NoError(t, err)
+			defer db.Close()
+			defer os.RemoveAll(cacheDir)
+
+			vs := NewVulnSrc()
+			err = vs.Update(tc.dir)
+
+			switch {
+			case tc.wantErr != "":
+				require.NotNil(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr, tc.name)
+				return
+			default:
+				assert.NoError(t, err, tc.name)
+			}
+
+			dbc := db.Config{}
+			got, err := dbc.GetVulnerabilityDetail(tc.cveID)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got["nvd"])
+		})
+	}
+}
 func TestVulnSrc_Commit(t *testing.T) {
 	testCases := []struct {
 		name                   string

--- a/pkg/vulnsrc/nvd/testdata/vuln-list/nvd/CVE-2020-0001.json
+++ b/pkg/vulnsrc/nvd/testdata/vuln-list/nvd/CVE-2020-0001.json
@@ -1,0 +1,112 @@
+{
+  "configurations": {
+    "CVE_data_version": "4.0",
+    "nodes": [
+      {
+        "cpe_match": [
+          {
+            "cpe23Uri": "cpe:2.3:o:google:android:8.0:*:*:*:*:*:*:*",
+            "vulnerable": true
+          },
+          {
+            "cpe23Uri": "cpe:2.3:o:google:android:8.1:*:*:*:*:*:*:*",
+            "vulnerable": true
+          },
+          {
+            "cpe23Uri": "cpe:2.3:o:google:android:9.0:*:*:*:*:*:*:*",
+            "vulnerable": true
+          },
+          {
+            "cpe23Uri": "cpe:2.3:o:google:android:10.0:*:*:*:*:*:*:*",
+            "vulnerable": true
+          }
+        ],
+        "operator": "OR"
+      }
+    ]
+  },
+  "cve": {
+    "CVE_data_meta": {
+      "ASSIGNER": "cve@mitre.org",
+      "ID": "CVE-2020-0001"
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
+    "description": {
+      "description_data": [
+        {
+          "lang": "en",
+          "value": "In getProcessRecordLocked of ActivityManagerService.java isolated apps are not handled correctly. This could lead to local escalation of privilege with no additional execution privileges needed. User interaction is not needed for exploitation. Product: Android Versions: Android-8.0, Android-8.1, Android-9, and Android-10 Android ID: A-140055304"
+        }
+      ]
+    },
+    "problemtype": {
+      "problemtype_data": [
+        {
+          "description": [
+            {
+              "lang": "en",
+              "value": "CWE-269"
+            }
+          ]
+        }
+      ]
+    },
+    "references": {
+      "reference_data": [
+        {
+          "name": "https://source.android.com/security/bulletin/2020-01-01",
+          "refsource": "CONFIRM",
+          "tags": [
+            "Vendor Advisory"
+          ],
+          "url": "https://source.android.com/security/bulletin/2020-01-01"
+        }
+      ]
+    }
+  },
+  "impact": {
+    "baseMetricV2": {
+      "acInsufInfo": false,
+      "cvssV2": {
+        "accessComplexity": "LOW",
+        "accessVector": "LOCAL",
+        "authentication": "NONE",
+        "availabilityImpact": "COMPLETE",
+        "baseScore": 7.2,
+        "confidentialityImpact": "COMPLETE",
+        "integrityImpact": "COMPLETE",
+        "vectorString": "AV:L/AC:L/Au:N/C:C/I:C/A:C",
+        "version": "2.0"
+      },
+      "exploitabilityScore": 3.9,
+      "impactScore": 10,
+      "obtainAllPrivilege": false,
+      "obtainOtherPrivilege": false,
+      "obtainUserPrivilege": false,
+      "severity": "HIGH",
+      "userInteractionRequired": false
+    },
+    "baseMetricV3": {
+      "cvssV3": {
+        "attackComplexity": "LOW",
+        "attackVector": "LOCAL",
+        "availabilityImpact": "HIGH",
+        "baseScore": 7.8,
+        "baseSeverity": "HIGH",
+        "confidentialityImpact": "HIGH",
+        "integrityImpact": "HIGH",
+        "privilegesRequired": "LOW",
+        "scope": "UNCHANGED",
+        "userInteraction": "NONE",
+        "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+        "version": "3.1"
+      },
+      "exploitabilityScore": 1.8,
+      "impactScore": 5.9
+    }
+  },
+  "lastModifiedDate": "2020-01-14T21:52Z",
+  "publishedDate": "2020-01-08T19:15Z"
+}

--- a/pkg/vulnsrc/nvd/testdata/vuln-list/nvd/CVE-2020-0001.json
+++ b/pkg/vulnsrc/nvd/testdata/vuln-list/nvd/CVE-2020-0001.json
@@ -48,6 +48,10 @@
             {
               "lang": "en",
               "value": "CWE-269"
+            },
+            {
+              "lang": "en",
+              "value": "DUMMY-100"
             }
           ]
         }

--- a/pkg/vulnsrc/nvd/types.go
+++ b/pkg/vulnsrc/nvd/types.go
@@ -13,6 +13,7 @@ type Cve struct {
 	Meta        Meta `json:"CVE_data_meta"`
 	References  References
 	Description Description
+	ProblemType ProblemType
 }
 
 type Meta struct {
@@ -58,6 +59,19 @@ type Description struct {
 }
 
 type DescriptionData struct {
+	Lang  string
+	Value string
+}
+
+type ProblemType struct {
+	ProblemTypeData []ProblemTypeData `json:"problemtype_data"`
+}
+
+type ProblemTypeData struct {
+	Description []ProblemTypeDataDescription
+}
+
+type ProblemTypeDataDescription struct {
 	Lang  string
 	Value string
 }

--- a/pkg/vulnsrc/vulnerability/vulnerability.go
+++ b/pkg/vulnsrc/vulnerability/vulnerability.go
@@ -21,16 +21,24 @@ var (
 	getVulnerabilityDetailFunc = db.Config{}.GetVulnerabilityDetail
 )
 
-func GetDetail(vulnID string) (types.Severity, types.VendorSeverity, types.VendorVectors, string, string, []string) {
+func GetDetail(vulnID string) types.Vulnerability {
 	details, err := getVulnerabilityDetailFunc(vulnID)
 	if err != nil {
 		log.Println(err)
-		return types.SeverityUnknown, nil, nil, "", "", nil
+		return types.Vulnerability{}
 	} else if len(details) == 0 {
-		return types.SeverityUnknown, nil, nil, "", "", nil
+		return types.Vulnerability{}
 	}
 
-	return getSeverity(details), getVendorSeverity(details), getVendorVectors(details), getTitle(details), getDescription(details), getReferences(details)
+	return types.Vulnerability{
+		Title:          getTitle(details),
+		Description:    getDescription(details),
+		Severity:       getSeverity(details).String(), // TODO: We have to keep this key until we deprecate
+		CweIDs:         getCweIDs(details),
+		VendorSeverity: getVendorSeverity(details),
+		VendorVectors:  getVendorVectors(details),
+		References:     getReferences(details),
+	}
 }
 
 func getVendorVectors(details map[string]types.VulnerabilityDetail) types.VendorVectors {
@@ -106,6 +114,19 @@ func getDescription(details map[string]types.VulnerabilityDetail) string {
 		}
 	}
 	return ""
+}
+
+func getCweIDs(details map[string]types.VulnerabilityDetail) []string {
+	for _, source := range sources {
+		d, ok := details[source]
+		if !ok {
+			continue
+		}
+		if len(d.CweIDs) != 0 {
+			return d.CweIDs
+		}
+	}
+	return nil
 }
 
 func getReferences(details map[string]types.VulnerabilityDetail) []string {

--- a/pkg/vulnsrc/vulnerability/vulnerability_test.go
+++ b/pkg/vulnsrc/vulnerability/vulnerability_test.go
@@ -13,13 +13,48 @@ func TestGetDetail(t *testing.T) {
 	testCases := []struct {
 		name                       string
 		getVulnerabilityDetailFunc func(cveID string) (m map[string]types.VulnerabilityDetail, err error)
-		expectedSeverity           types.Severity
-		expectedVendorSeverity     types.VendorSeverity
-		expectedVendorVectors      types.VendorVectors
-		expectedTitle              string
-		expectedDescription        string
-		expectedRefs               []string
+		want                       types.Vulnerability
 	}{
+		{
+			name: "happy path",
+			getVulnerabilityDetailFunc: func(cveID string) (m map[string]types.VulnerabilityDetail, err error) {
+				return map[string]types.VulnerabilityDetail{
+					Nvd: {
+						CvssScore:    4.2,
+						CvssVector:   "AV:N/AC:M/Au:N/C:N/I:P/A:N",
+						CvssScoreV3:  5.6,
+						CvssVectorV3: "CVSS:3.0/AV:A/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+						SeverityV3:   types.SeverityMedium,
+						CweIDs:       []string{"CWE-125", "CWE-200"},
+					},
+					RedHat: {
+						CvssScoreV3:  6.7,
+						CvssVectorV3: "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+						SeverityV3:   types.SeverityHigh,
+						Title:        "test vulnerability",
+						Description:  "a test vulnerability where vendor rates it lower than NVD",
+						References:   []string{"http://foo-bar.com/baz"},
+					},
+				}, nil
+			},
+			want: types.Vulnerability{
+				Title:          "test vulnerability",
+				Description:    "a test vulnerability where vendor rates it lower than NVD",
+				Severity:       types.SeverityMedium.String(),
+				VendorSeverity: types.VendorSeverity{"nvd": 2, "redhat": 3},
+				VendorVectors: types.VendorVectors{
+					Nvd: types.CVSSVector{
+						V2: "AV:N/AC:M/Au:N/C:N/I:P/A:N",
+						V3: "CVSS:3.0/AV:A/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+					},
+					RedHat: types.CVSSVector{
+						V3: "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+					},
+				},
+				CweIDs:     []string{"CWE-125", "CWE-200"},
+				References: []string{"http://foo-bar.com/baz"},
+			},
+		},
 		{
 			name: "happy path, classifications for redhat, ubuntu and nodejs with variety of scores and vectors",
 			getVulnerabilityDetailFunc: func(cveID string) (m map[string]types.VulnerabilityDetail, err error) {
@@ -59,20 +94,22 @@ func TestGetDetail(t *testing.T) {
 					},
 				}, nil
 			},
-			expectedSeverity:       types.SeverityMedium,
-			expectedVendorSeverity: types.VendorSeverity{"redhat": 4, "ubuntu": 1, "rust-advisory-db": 4},
-			expectedVendorVectors: types.VendorVectors{
-				RedHat: types.CVSSVector{
-					V2: "AV:N/AC:M/Au:N/C:N/I:P/A:N",
-					V3: "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+			want: types.Vulnerability{
+				Title:          "test vulnerability",
+				Description:    "a test vulnerability where vendor rates it lower than NVD",
+				Severity:       types.SeverityMedium.String(),
+				VendorSeverity: types.VendorSeverity{"redhat": 4, "ubuntu": 1, "rust-advisory-db": 4},
+				VendorVectors: types.VendorVectors{
+					RedHat: types.CVSSVector{
+						V2: "AV:N/AC:M/Au:N/C:N/I:P/A:N",
+						V3: "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+					},
+					Ubuntu: types.CVSSVector{
+						V3: "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+					},
 				},
-				Ubuntu: types.CVSSVector{
-					V3: "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
-				},
+				References: []string{"http://foo-bar.com/baz"},
 			},
-			expectedTitle:       "test vulnerability",
-			expectedDescription: "a test vulnerability where vendor rates it lower than NVD",
-			expectedRefs:        []string{"http://foo-bar.com/baz"},
 		},
 		{
 			name: "happy path, classifications for redhat (only CVSSv3), ubuntu and nodejs with variety of scores but no vectors",
@@ -101,35 +138,32 @@ func TestGetDetail(t *testing.T) {
 					},
 				}, nil
 			},
-			expectedSeverity:       types.SeverityMedium,
-			expectedVendorSeverity: types.VendorSeverity{"redhat": 2, "ubuntu": 1, "nodejs-security-wg": 4},
-			expectedVendorVectors:  types.VendorVectors{},
-			expectedTitle:          "test vulnerability",
-			expectedDescription:    "a test vulnerability where vendor rates it lower than NVD",
+			want: types.Vulnerability{
+				Severity:       types.SeverityMedium.String(),
+				VendorSeverity: types.VendorSeverity{"redhat": 2, "ubuntu": 1, "nodejs-security-wg": 4},
+				VendorVectors:  types.VendorVectors{},
+				Title:          "test vulnerability",
+				Description:    "a test vulnerability where vendor rates it lower than NVD",
+			},
 		},
 		{
 			name: "sad path, getVulnerabilityDetailFunc returns an error",
 			getVulnerabilityDetailFunc: func(cveID string) (m map[string]types.VulnerabilityDetail, err error) {
 				return map[string]types.VulnerabilityDetail{}, errors.New("unable to get vulnerability detail")
 			},
-			expectedSeverity: types.SeverityUnknown,
 		},
 	}
 
 	for _, tc := range testCases {
-		oldGetVulnerabilityDetailFunc := getVulnerabilityDetailFunc
-		defer func() {
-			getVulnerabilityDetailFunc = oldGetVulnerabilityDetailFunc
-		}()
-		getVulnerabilityDetailFunc = tc.getVulnerabilityDetailFunc
+		t.Run(tc.name, func(t *testing.T) {
+			oldGetVulnerabilityDetailFunc := getVulnerabilityDetailFunc
+			defer func() {
+				getVulnerabilityDetailFunc = oldGetVulnerabilityDetailFunc
+			}()
+			getVulnerabilityDetailFunc = tc.getVulnerabilityDetailFunc
 
-		gotSeverity, gotVendorSeverity, gotVendorVectors, gotTitle, gotDescription, gotRefs := GetDetail("CVE-2020-123")
-		assert.Equal(t, tc.expectedSeverity, gotSeverity, tc.name)
-		assert.Equal(t, tc.expectedVendorSeverity, gotVendorSeverity, tc.name)
-		assert.Equal(t, tc.expectedVendorVectors, gotVendorVectors, tc.name)
-		assert.Equal(t, tc.expectedTitle, gotTitle, tc.name)
-		assert.Equal(t, tc.expectedDescription, gotDescription, tc.name)
-		assert.Equal(t, tc.expectedRefs, gotRefs, tc.name)
+			got := GetDetail("CVE-2020-123")
+			assert.Equal(t, tc.want, got)
+		})
 	}
-
 }

--- a/pkg/vulnsrc/vulnerability/vulnerability_test.go
+++ b/pkg/vulnsrc/vulnerability/vulnerability_test.go
@@ -51,6 +51,20 @@ func TestGetDetail(t *testing.T) {
 						V3: "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
 					},
 				},
+				CVSS: types.VendorCVSS{
+					Nvd: types.CVSS{
+						V2Vector: "AV:N/AC:M/Au:N/C:N/I:P/A:N",
+						V3Vector: "CVSS:3.0/AV:A/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+						V2Score:  4.2,
+						V3Score:  5.6,
+					},
+					RedHat: types.CVSS{
+						V2Vector: "",
+						V3Vector: "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+						V2Score:  0,
+						V3Score:  6.7,
+					},
+				},
 				CweIDs:     []string{"CWE-125", "CWE-200"},
 				References: []string{"http://foo-bar.com/baz"},
 			},
@@ -153,6 +167,7 @@ func TestGetDetail(t *testing.T) {
 				Severity:       types.SeverityMedium.String(),
 				VendorSeverity: types.VendorSeverity{"redhat": 2, "ubuntu": 1, "nodejs-security-wg": 4},
 				VendorVectors:  types.VendorVectors{},
+				CVSS:           types.VendorCVSS{},
 				Title:          "test vulnerability",
 				Description:    "a test vulnerability where vendor rates it lower than NVD",
 			},
@@ -181,6 +196,19 @@ func TestGetDetail(t *testing.T) {
 						Description: "a test vulnerability where vendor rates it lower than NVD",
 					},
 				}, nil
+			},
+			want: types.Vulnerability{
+				Severity:       types.SeverityLow.String(),
+				VendorSeverity: types.VendorSeverity{"ubuntu": 1},
+				VendorVectors: types.VendorVectors{
+					RedHat: types.CVSSVector{
+						V2: "AV:N/AC:M/Au:N/C:N/I:P/A:N",
+						V3: "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+					},
+				},
+				CVSS:        types.VendorCVSS{},
+				Title:       "test vulnerability",
+				Description: "a test vulnerability where vendor rates it lower than NVD",
 			},
 		},
 		{

--- a/pkg/vulnsrc/vulnsrc.go
+++ b/pkg/vulnsrc/vulnsrc.go
@@ -213,9 +213,11 @@ func (o lightOptimizer) lightOptimize(cveID string, tx *bolt.Tx) error {
 		VendorSeverity: vuln.VendorSeverity,
 	}
 
+	// TODO: We have to keep this "severity" variable for the "severity" bucket until we deprecate
+	// GetDetail converts types.Severity to string, so this line just reconverts it.
 	severity, _ := types.NewSeverity(vuln.Severity)
 
-	// TODO: We have to keep this bucket until we deprecate
+	// TODO: We have to keep the "severity" bucket until we deprecate
 	// overwrite unknown severity with correct severity
 	if err := o.dbOp.PutSeverity(tx, cveID, severity); err != nil {
 		return xerrors.Errorf("failed to put severity: %w", err)

--- a/pkg/vulnsrc/vulnsrc_test.go
+++ b/pkg/vulnsrc/vulnsrc_test.go
@@ -457,16 +457,24 @@ func Test_fullOptimize(t *testing.T) {
 		getDetailFunc = oldgetDetailFunc
 	}()
 
-	getDetailFunc = func(vulnID string) (severity types.Severity, vendorSeverity types.VendorSeverity, vendorVectors types.VendorVectors, s string, s2 string, strings []string) {
-		return types.SeverityCritical, types.VendorSeverity{
+	getDetailFunc = func(vulnID string) types.Vulnerability {
+		return types.Vulnerability{
+			Title:       "test title",
+			Description: "test description",
+			Severity:    types.SeverityCritical.String(),
+			VendorSeverity: types.VendorSeverity{
 				"redhat": types.SeverityHigh,
 				"ubuntu": types.SeverityLow,
-			}, types.VendorVectors{
+			},
+			VendorVectors: types.VendorVectors{
 				"redhat": types.CVSSVector{
 					V2: "AV:N/AC:M/Au:N/C:N/I:P/A:N",
 					V3: "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
 				},
-			}, "test title", "test description", []string{"test reference"}
+			},
+			CweIDs:     []string{"CWE-134"},
+			References: []string{"test reference"},
+		}
 	}
 
 	mockDBOperation := new(db.MockOperation)
@@ -491,6 +499,7 @@ func Test_fullOptimize(t *testing.T) {
 						V3: "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
 					},
 				},
+				CweIDs:     []string{"CWE-134"},
 				References: []string{"test reference"},
 			},
 		},
@@ -509,11 +518,19 @@ func Test_lightOptimize(t *testing.T) {
 		getDetailFunc = oldgetDetailFunc
 	}()
 
-	getDetailFunc = func(vulnID string) (severity types.Severity, vendorSeverity types.VendorSeverity, vendorVectors types.VendorVectors, s string, s2 string, strings []string) {
-		return types.SeverityCritical, types.VendorSeverity{
-			"redhat": types.SeverityHigh,
-			"ubuntu": types.SeverityLow,
-		}, types.VendorVectors{}, "test title", "test description", []string{"test reference"}
+	getDetailFunc = func(vulnID string) types.Vulnerability {
+		return types.Vulnerability{
+			Title:       "test title",
+			Description: "test description",
+			Severity:    types.SeverityCritical.String(),
+			VendorSeverity: types.VendorSeverity{
+				"redhat": types.SeverityHigh,
+				"ubuntu": types.SeverityLow,
+			},
+			VendorVectors: types.VendorVectors{},
+			CweIDs:        []string{"CWE-134"},
+			References:    []string{"test reference"},
+		}
 	}
 
 	mockDBOperation := new(db.MockOperation)

--- a/pkg/vulnsrc/vulnsrc_test.go
+++ b/pkg/vulnsrc/vulnsrc_test.go
@@ -457,7 +457,6 @@ func Test_fullOptimize(t *testing.T) {
 		getDetailFunc = oldgetDetailFunc
 	}()
 
-<<<<<<< HEAD
 	getDetailFunc = func(vulnID string) types.Vulnerability {
 		return types.Vulnerability{
 			Title:       "test title",
@@ -467,13 +466,7 @@ func Test_fullOptimize(t *testing.T) {
 				"redhat": types.SeverityHigh,
 				"ubuntu": types.SeverityLow,
 			},
-			VendorVectors: types.VendorVectors{
-=======
-	getDetailFunc = func(vulnID string) (severity types.Severity, vendorSeverity types.VendorSeverity, vendorCVSS types.VendorCVSS, vendorVectors types.VendorVectors, s string, s2 string, strings []string) {
-		return types.SeverityCritical, types.VendorSeverity{
-				"redhat": types.SeverityHigh,
-				"ubuntu": types.SeverityLow,
-			}, types.VendorCVSS{
+			CVSS: types.VendorCVSS{
 				"redhat": types.CVSS{
 					V2Vector: "AV:N/AC:M/Au:N/C:N/I:P/A:N",
 					V2Score:  4.5,
@@ -481,8 +474,7 @@ func Test_fullOptimize(t *testing.T) {
 					V3Score:  5.6,
 				},
 			},
-			types.VendorVectors{
->>>>>>> master
+			VendorVectors: types.VendorVectors{
 				"redhat": types.CVSSVector{
 					V2: "AV:N/AC:M/Au:N/C:N/I:P/A:N",
 					V3: "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
@@ -542,7 +534,6 @@ func Test_lightOptimize(t *testing.T) {
 		getDetailFunc = oldgetDetailFunc
 	}()
 
-<<<<<<< HEAD
 	getDetailFunc = func(vulnID string) types.Vulnerability {
 		return types.Vulnerability{
 			Title:       "test title",
@@ -556,13 +547,6 @@ func Test_lightOptimize(t *testing.T) {
 			CweIDs:        []string{"CWE-134"},
 			References:    []string{"test reference"},
 		}
-=======
-	getDetailFunc = func(vulnID string) (severity types.Severity, vendorSeverity types.VendorSeverity, vendorCVSS types.VendorCVSS, vendorVectors types.VendorVectors, s string, s2 string, strings []string) {
-		return types.SeverityCritical, types.VendorSeverity{
-			"redhat": types.SeverityHigh,
-			"ubuntu": types.SeverityLow,
-		}, types.VendorCVSS{}, types.VendorVectors{}, "test title", "test description", []string{"test reference"}
->>>>>>> master
 	}
 
 	mockDBOperation := new(db.MockOperation)


### PR DESCRIPTION
NVD has information regarding CWE-ID such as CWE-89 (SQL Injection). This information is useful to filter vulnerabilities in trivy. For example, we might be able to ignore CWE-20 (Improper Input Validation) depending on the service.
https://nvd.nist.gov/vuln/detail/CVE-2020-11010