### PR TITLE
Fix: Support v2 format in cargo

### DIFF
--- a/pkg/vulnsrc/cargo/cargo.go
+++ b/pkg/vulnsrc/cargo/cargo.go
@@ -24,23 +24,28 @@ const (
 
 type Lockfile struct {
 	RawAdvisory `toml:"advisory"`
+	RawVersion  `toml:"versions"`
 }
 
 type RawAdvisory struct {
-	Id                string
-	Package           string
-	Title             string `toml:"title"`
-	Url               string
-	Date              string
-	Description       string
-	Keywords          []string
-	PatchedVersions   []string `toml:"patched_versions"`
-	AffectedFunctions []string `toml:"affected_functions"`
+	Id          string
+	Package     string
+	Title       string `toml:"title"`
+	Url         string
+	Date        string
+	Description string
+	Keywords    []string
+}
+
+type RawVersion struct {
+	PatchedVersions    []string `toml:"patched"`
+	UnaffectedVersions []string `toml:"unaffected"`
 }
 
 type Advisory struct {
-	VulnerabilityID string   `json:",omitempty"`
-	PatchedVersions []string `json:",omitempty"`
+	VulnerabilityID    string   `json:",omitempty"`
+	PatchedVersions    []string `json:",omitempty"`
+	UnaffectedVersions []string `json:",omitempty"`
 }
 
 type VulnSrc struct {
@@ -97,7 +102,8 @@ func (vs VulnSrc) walk(tx *bolt.Tx, root string) error {
 		}
 
 		// for detecting vulnerabilities
-		a := Advisory{PatchedVersions: advisory.PatchedVersions}
+		a := Advisory{PatchedVersions: advisory.PatchedVersions,
+			UnaffectedVersions: advisory.UnaffectedVersions}
 		err = vs.dbc.PutAdvisoryDetail(tx, advisory.Id, vulnerability.RustSec, advisory.Package, a)
 		if err != nil {
 			return xerrors.Errorf("failed to save rust advisory: %w", err)

--- a/pkg/vulnsrc/cargo/cargo_test.go
+++ b/pkg/vulnsrc/cargo/cargo_test.go
@@ -1,0 +1,161 @@
+package cargo
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/aquasecurity/trivy-db/pkg/db"
+	"github.com/aquasecurity/trivy-db/pkg/types"
+	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/vulnerability"
+)
+
+func TestVulnSrc_Update(t *testing.T) {
+	type args struct {
+		dir string
+	}
+	tests := []struct {
+		name        string
+		args        args
+		batchUpdate []db.OperationBatchUpdateExpectation
+		wantErr     string
+	}{
+		{
+			name: "happy path",
+			args: args{
+				dir: "testdata",
+			},
+			batchUpdate: []db.OperationBatchUpdateExpectation{
+				{
+					Args: db.OperationBatchUpdateArgs{
+						FnAnything: true,
+					},
+				},
+			},
+		},
+		{
+			name: "BatchUpdate returns an error",
+			args: args{
+				dir: "testdata",
+			},
+			batchUpdate: []db.OperationBatchUpdateExpectation{
+				{
+					Args: db.OperationBatchUpdateArgs{
+						FnAnything: true,
+					},
+					Returns: db.OperationBatchUpdateReturns{
+						Err: errors.New("error"),
+					},
+				},
+			},
+			wantErr: "batch update failed: error",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockDBConfig := new(db.MockOperation)
+			mockDBConfig.ApplyBatchUpdateExpectations(tt.batchUpdate)
+
+			vs := VulnSrc{
+				dbc: mockDBConfig,
+			}
+			err := vs.Update(tt.args.dir)
+			if tt.wantErr != "" {
+				require.NotNil(t, err, tt.name)
+				assert.Contains(t, err.Error(), tt.wantErr, tt.name)
+			} else {
+				assert.NoError(t, err, tt.name)
+			}
+			mockDBConfig.AssertExpectations(t)
+		})
+	}
+}
+
+func TestVulnSrc_update(t *testing.T) {
+	type args struct {
+		dir string
+	}
+	tests := []struct {
+		name                   string
+		args                   args
+		putAdvisoryDetail      []db.OperationPutAdvisoryDetailExpectation
+		putVulnerabilityDetail []db.OperationPutVulnerabilityDetailExpectation
+		putSeverity            []db.OperationPutSeverityExpectation
+		wantErr                string
+	}{
+		{
+			name: "happy path",
+			args: args{
+				dir: "testdata/crates",
+			},
+			putAdvisoryDetail: []db.OperationPutAdvisoryDetailExpectation{
+				{
+					Args: db.OperationPutAdvisoryDetailArgs{
+						TxAnything:      true,
+						Source:          "rust-advisory-db",
+						PkgName:         "bitvec",
+						VulnerabilityID: "RUSTSEC-2020-0007",
+						Advisory: Advisory{
+							PatchedVersions: []string{
+								">= 0.17.4",
+							},
+							UnaffectedVersions: []string{
+								"< 0.11.0",
+							},
+						},
+					},
+				},
+			},
+			putVulnerabilityDetail: []db.OperationPutVulnerabilityDetailExpectation{
+				{
+					Args: db.OperationPutVulnerabilityDetailArgs{
+						TxAnything:      true,
+						Source:          vulnerability.RustSec,
+						VulnerabilityID: "RUSTSEC-2020-0007",
+						Vulnerability: types.VulnerabilityDetail{
+							ID:       "RUSTSEC-2020-0007",
+							Severity: types.SeverityUnknown,
+							References: []string{
+								"https://github.com/myrrlyn/bitvec/issues/55",
+							},
+							Title:       "use-after or double free of allocated memory",
+							Description: "Conversion of `BitVec` to `BitBox` did not account for allocation movement.\n\nThe flaw was corrected by using the address after resizing, rather than the original base address.\n",
+						},
+					},
+				},
+			},
+			putSeverity: []db.OperationPutSeverityExpectation{
+				{
+					Args: db.OperationPutSeverityArgs{
+						TxAnything:      true,
+						VulnerabilityID: "RUSTSEC-2020-0007",
+						Severity:        types.SeverityUnknown,
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockDBConfig := new(db.MockOperation)
+			mockDBConfig.ApplyPutAdvisoryDetailExpectations(tt.putAdvisoryDetail)
+			mockDBConfig.ApplyPutVulnerabilityDetailExpectations(tt.putVulnerabilityDetail)
+			mockDBConfig.ApplyPutSeverityExpectations(tt.putSeverity)
+
+			vs := VulnSrc{
+				dbc: mockDBConfig,
+			}
+			err := vs.walk(nil, tt.args.dir)
+
+			if tt.wantErr != "" {
+				require.NotNil(t, err, tt.name)
+				assert.Contains(t, err.Error(), tt.wantErr, tt.name)
+			} else {
+				assert.NoError(t, err, tt.name)
+			}
+			mockDBConfig.AssertExpectations(t)
+		})
+	}
+}

--- a/pkg/vulnsrc/cargo/testdata/crates/bitvec/RUSTSEC-2020-0007.toml
+++ b/pkg/vulnsrc/cargo/testdata/crates/bitvec/RUSTSEC-2020-0007.toml
@@ -1,0 +1,19 @@
+[advisory]
+id = "RUSTSEC-2020-0007"
+package = "bitvec"
+date = "2020-03-27"
+title = "use-after or double free of allocated memory"
+url = "https://github.com/myrrlyn/bitvec/issues/55"
+categories = ["memory-corruption"]
+description = """
+Conversion of `BitVec` to `BitBox` did not account for allocation movement.
+
+The flaw was corrected by using the address after resizing, rather than the original base address.
+"""
+
+[affected.functions]
+"bitvec::vec::BitVec::into_boxed_bitslice" = ["< 0.17.4, >= 0.11.0"]
+
+[versions]
+patched = [">= 0.17.4"]
+unaffected = ["< 0.11.0"]


### PR DESCRIPTION
[Issue](https://github.com/aquasecurity/trivy-db/issues/66)