### PR TITLE
fix(vulnerability): use pointer of time.Time

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/BurntSushi/toml v0.3.1
-	github.com/aquasecurity/bolt-fixtures v0.0.0-20200825112230-c0f517aea2ed // indirect
+	github.com/aquasecurity/bolt-fixtures v0.0.0-20200825112230-c0f517aea2ed
 	github.com/aquasecurity/vuln-list-update v0.0.0-20191016075347-3d158c2bf9a2
 	github.com/briandowns/spinner v0.0.0-20190319032542-ac46072a5a91
 	github.com/fatih/color v1.9.0

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -83,19 +83,19 @@ type LastUpdated struct {
 	Date time.Time
 }
 type VulnerabilityDetail struct {
-	ID               string    `json:",omitempty"` // e.g. CVE-2019-8331, OSVDB-104365
-	CvssScore        float64   `json:",omitempty"`
-	CvssVector       string    `json:",omitempty"`
-	CvssScoreV3      float64   `json:",omitempty"`
-	CvssVectorV3     string    `json:",omitempty"`
-	Severity         Severity  `json:",omitempty"`
-	SeverityV3       Severity  `json:",omitempty"`
-	CweIDs           []string  `json:",omitempty"` // e.g. CWE-78, CWE-89
-	References       []string  `json:",omitempty"`
-	Title            string    `json:",omitempty"`
-	Description      string    `json:",omitempty"`
-	PublishedDate    time.Time `json:",omitempty"`
-	LastModifiedDate time.Time `json:",omitempty"`
+	ID               string     `json:",omitempty"` // e.g. CVE-2019-8331, OSVDB-104365
+	CvssScore        float64    `json:",omitempty"`
+	CvssVector       string     `json:",omitempty"`
+	CvssScoreV3      float64    `json:",omitempty"`
+	CvssVectorV3     string     `json:",omitempty"`
+	Severity         Severity   `json:",omitempty"`
+	SeverityV3       Severity   `json:",omitempty"`
+	CweIDs           []string   `json:",omitempty"` // e.g. CWE-78, CWE-89
+	References       []string   `json:",omitempty"`
+	Title            string     `json:",omitempty"`
+	Description      string     `json:",omitempty"`
+	PublishedDate    *time.Time `json:",omitempty"`
+	LastModifiedDate *time.Time `json:",omitempty"`
 }
 
 type AdvisoryDetail struct {
@@ -126,8 +126,8 @@ type Vulnerability struct {
 	VendorVectors    VendorVectors  `json:",omitempty"` // Deprecated: VendorVectors is only for backwards compatibility. Use CVSS instead.
 	CVSS             VendorCVSS     `json:",omitempty"`
 	References       []string       `json:",omitempty"`
-	PublishedDate    time.Time      `json:",omitempty"`
-	LastModifiedDate time.Time      `json:",omitempty"`
+	PublishedDate    *time.Time     `json:",omitempty"`
+	LastModifiedDate *time.Time     `json:",omitempty"`
 }
 
 type VulnSrc interface {

--- a/pkg/utils/time.go
+++ b/pkg/utils/time.go
@@ -1,0 +1,15 @@
+package utils
+
+import (
+	"log"
+	"time"
+)
+
+func MustTimeParse(value string) *time.Time {
+	t, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	return &t
+}

--- a/pkg/vulnsrc/nvd/nvd.go
+++ b/pkg/vulnsrc/nvd/nvd.go
@@ -104,8 +104,8 @@ func (vs VulnSrc) commit(tx *bolt.Tx, items []Item) error {
 			References:       references,
 			Title:            "",
 			Description:      description,
-			PublishedDate:    publishedDate,
-			LastModifiedDate: lastModifiedDate,
+			PublishedDate:    &publishedDate,
+			LastModifiedDate: &lastModifiedDate,
 		}
 
 		if err := vs.dbc.PutVulnerabilityDetail(tx, cveID, vulnerability.Nvd, vuln); err != nil {

--- a/pkg/vulnsrc/nvd/nvd_test.go
+++ b/pkg/vulnsrc/nvd/nvd_test.go
@@ -4,7 +4,8 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
-	"time"
+
+	"github.com/aquasecurity/trivy-db/pkg/utils"
 
 	"github.com/stretchr/testify/require"
 
@@ -38,8 +39,8 @@ func TestVulnSrc_Update(t *testing.T) {
 				SeverityV3:       types.SeverityHigh,
 				CweIDs:           []string{"CWE-269"},
 				References:       []string{"https://source.android.com/security/bulletin/2020-01-01"},
-				LastModifiedDate: time.Date(2020, 01, 01, 01, 01, 00, 00, time.UTC),
-				PublishedDate:    time.Date(2001, 01, 01, 01, 01, 00, 00, time.UTC),
+				LastModifiedDate: utils.MustTimeParse("2020-01-01T01:01:00Z"),
+				PublishedDate:    utils.MustTimeParse("2001-01-01T01:01:00Z"),
 			},
 		},
 		{
@@ -126,6 +127,8 @@ func TestVulnSrc_Commit(t *testing.T) {
 							},
 						},
 					},
+					PublishedDate:    "2006-01-02T15:04Z",
+					LastModifiedDate: "2020-01-02T15:04Z",
 				},
 			},
 			putVulnerabilityDetail: []db.OperationPutVulnerabilityDetailExpectation{
@@ -135,14 +138,16 @@ func TestVulnSrc_Commit(t *testing.T) {
 						VulnerabilityID: "CVE-2017-0012",
 						Source:          vulnerability.Nvd,
 						Vulnerability: types.VulnerabilityDetail{
-							CvssScore:    4.3,
-							CvssVector:   "AV:N/AC:M/Au:N/C:N/I:P/A:N",
-							CvssScoreV3:  9.4,
-							CvssVectorV3: "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N",
-							Severity:     types.SeverityMedium,
-							SeverityV3:   types.SeverityHigh,
-							References:   []string{"https://example.com"},
-							Description:  "some description",
+							CvssScore:        4.3,
+							CvssVector:       "AV:N/AC:M/Au:N/C:N/I:P/A:N",
+							CvssScoreV3:      9.4,
+							CvssVectorV3:     "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N",
+							Severity:         types.SeverityMedium,
+							SeverityV3:       types.SeverityHigh,
+							References:       []string{"https://example.com"},
+							Description:      "some description",
+							PublishedDate:    utils.MustTimeParse("2006-01-02T15:04:00Z"),
+							LastModifiedDate: utils.MustTimeParse("2020-01-02T15:04:00Z"),
 						},
 					},
 				},
@@ -190,6 +195,8 @@ func TestVulnSrc_Commit(t *testing.T) {
 							},
 						},
 					},
+					PublishedDate:    "2006-01-02T15:04Z",
+					LastModifiedDate: "2020-01-02T15:04Z",
 				},
 			},
 			putVulnerabilityDetail: []db.OperationPutVulnerabilityDetailExpectation{
@@ -199,14 +206,16 @@ func TestVulnSrc_Commit(t *testing.T) {
 						VulnerabilityID: "CVE-2017-0012",
 						Source:          vulnerability.Nvd,
 						Vulnerability: types.VulnerabilityDetail{
-							CvssScore:    4.3,
-							CvssVector:   "AV:N/AC:M/Au:N/C:N/I:P/A:N",
-							CvssScoreV3:  9.4,
-							CvssVectorV3: "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N",
-							Severity:     types.SeverityMedium,
-							SeverityV3:   types.SeverityHigh,
-							References:   []string{"https://example.com"},
-							Description:  "** REJECT ** test description",
+							CvssScore:        4.3,
+							CvssVector:       "AV:N/AC:M/Au:N/C:N/I:P/A:N",
+							CvssScoreV3:      9.4,
+							CvssVectorV3:     "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N",
+							Severity:         types.SeverityMedium,
+							SeverityV3:       types.SeverityHigh,
+							References:       []string{"https://example.com"},
+							Description:      "** REJECT ** test description",
+							PublishedDate:    utils.MustTimeParse("2006-01-02T15:04:00Z"),
+							LastModifiedDate: utils.MustTimeParse("2020-01-02T15:04:00Z"),
 						},
 					},
 				},
@@ -229,6 +238,7 @@ func TestVulnSrc_Commit(t *testing.T) {
 
 			switch {
 			case tc.expectedErrorMsg != "":
+				require.NotNil(t, err)
 				assert.Contains(t, err.Error(), tc.expectedErrorMsg, tc.name)
 			default:
 				assert.NoError(t, err, tc.name)

--- a/pkg/vulnsrc/vulnerability/vulnerability_test.go
+++ b/pkg/vulnsrc/vulnerability/vulnerability_test.go
@@ -2,7 +2,8 @@ package vulnerability
 
 import (
 	"testing"
-	"time"
+
+	"github.com/aquasecurity/trivy-db/pkg/utils"
 
 	"golang.org/x/xerrors"
 
@@ -33,8 +34,8 @@ func TestGetDetails(t *testing.T) {
 							CvssVectorV3:     "CVSS:3.0/AV:A/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
 							SeverityV3:       types.SeverityMedium,
 							CweIDs:           []string{"CWE-125", "CWE-200"},
-							LastModifiedDate: time.Date(2020, 01, 01, 01, 01, 01, 01, time.UTC),
-							PublishedDate:    time.Date(2001, 01, 01, 01, 01, 01, 01, time.UTC),
+							LastModifiedDate: utils.MustTimeParse("2020-01-01T01:02:03Z"),
+							PublishedDate:    utils.MustTimeParse("2001-01-01T01:02:03Z"),
 						},
 						RedHat: {
 							CvssScoreV3:  6.7,
@@ -55,8 +56,8 @@ func TestGetDetails(t *testing.T) {
 					CvssVectorV3:     "CVSS:3.0/AV:A/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
 					SeverityV3:       types.SeverityMedium,
 					CweIDs:           []string{"CWE-125", "CWE-200"},
-					LastModifiedDate: time.Date(2020, 01, 01, 01, 01, 01, 01, time.UTC),
-					PublishedDate:    time.Date(2001, 01, 01, 01, 01, 01, 01, time.UTC),
+					LastModifiedDate: utils.MustTimeParse("2020-01-01T01:02:03Z"),
+					PublishedDate:    utils.MustTimeParse("2001-01-01T01:02:03Z"),
 				},
 				RedHat: {
 					CvssScoreV3:  6.7,
@@ -181,8 +182,8 @@ func TestNormalize(t *testing.T) {
 					CvssVectorV3:     "CVSS:3.0/AV:A/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
 					SeverityV3:       types.SeverityMedium,
 					CweIDs:           []string{"CWE-125", "CWE-200"},
-					LastModifiedDate: time.Date(2020, 01, 01, 01, 01, 01, 01, time.UTC),
-					PublishedDate:    time.Date(2001, 01, 01, 01, 01, 01, 01, time.UTC),
+					LastModifiedDate: utils.MustTimeParse("2020-01-01T01:02:03Z"),
+					PublishedDate:    utils.MustTimeParse("2001-01-01T01:02:03Z"),
 				},
 				RedHat: {
 					CvssScoreV3:  6.7,
@@ -223,8 +224,8 @@ func TestNormalize(t *testing.T) {
 				},
 				CweIDs:           []string{"CWE-125", "CWE-200"},
 				References:       []string{"http://foo-bar.com/baz"},
-				LastModifiedDate: time.Date(2020, 01, 01, 01, 01, 01, 01, time.UTC),
-				PublishedDate:    time.Date(2001, 01, 01, 01, 01, 01, 01, time.UTC),
+				LastModifiedDate: utils.MustTimeParse("2020-01-01T01:02:03Z"),
+				PublishedDate:    utils.MustTimeParse("2001-01-01T01:02:03Z"),
 			},
 		},
 		{


### PR DESCRIPTION
When NVD doesn't have information, it displays "0001-01-01T00:00:00" now, but I think we should omit it.