### PR TITLE
feat: insert fixed versions from Debian Security Tracker

### DIFF
--- a/pkg/vulnsrc/debian/debian.go
+++ b/pkg/vulnsrc/debian/debian.go
@@ -92,11 +92,11 @@ func (vs VulnSrc) commit(tx *bolt.Tx, cves []DebianCVE) error {
 					continue
 				}
 				platformName := fmt.Sprintf(platformFormat, majorVersion)
-				if release.Status != "open" {
+				if release.Status != "open" && release.Status != "resolved" {
 					continue
 				}
 				advisory := types.Advisory{
-					VulnerabilityID: cve.VulnerabilityID,
+					FixedVersion: release.FixedVersion,
 				}
 				if err := vs.dbc.PutAdvisoryDetail(tx, cve.VulnerabilityID, platformName, cve.Package, advisory); err != nil {
 					return xerrors.Errorf("failed to save Debian advisory: %w", err)

--- a/pkg/vulnsrc/debian/types.go
+++ b/pkg/vulnsrc/debian/types.go
@@ -11,5 +11,6 @@ type DebianCVE struct {
 type Release struct {
 	Repositories map[string]string `json:"repositories"`
 	Status       string            `json:"status"`
+	FixedVersion string            `json:"fixed_version"`
 	Urgency      string            `json:"urgency"`
 }


### PR DESCRIPTION
When it comes to Debian, trivy-db used to insert fixed versions from OVAL and unfixed versions from Debian Security Tracker since Debian Security Tracker didn't contain `epoch` which is necessary for vulnerability detection before. But I found OVAL was sometimes wrong.

In the case of CVE-2017-10965, the following page says 1.0.2-1+deb9u2 is the fixed version on stretch.
https://security-tracker.debian.org/tracker/CVE-2017-10965

The change log also says so.
https://launchpad.net/debian/+source/irssi/+changelog

But OVAL says 1.0.2-1+deb9u3 as follows.

```
$ curl https://www.debian.org/security/oval/oval-definitions-stretch.xml | grep -A 50 CVE-2017-10965
<criterion comment="irssi DPKG is earlier than 1.0.2-1+deb9u3" test_ref="oval:org.debian.oval:tst:13567"/>
```

I asked Debian team and they answered Debian Security Tracker is the source of truth. In addition, Debian Security Tracker contains `epoch` now. We should unify two sources into Debian Security Tracker and deprecate OVAL.