### PR TITLE
CSharp constant in const.go

### DIFF
--- a/pkg/vulnsrc/vulnerability/const.go
+++ b/pkg/vulnsrc/vulnerability/const.go
@@ -34,4 +34,5 @@ const (
 	Pip      = "pip"
 	RubyGems = "rubygems"
 	Cargo    = "cargo"
+	Dotnet   = "dotnet"
 )


### PR DESCRIPTION
As a part in https://github.com/aquasecurity/trivy/pull/686, this pull request adds `CSharp` constant in the `vulnsrc/vulnerability/const.go` file.