### PR TITLE
fix: rename bucket prefixes

### DIFF
--- a/pkg/db/advisory_test.go
+++ b/pkg/db/advisory_test.go
@@ -41,7 +41,7 @@ func TestConfig_ForEachAdvisory(t *testing.T) {
 		{
 			name: "prefix scan",
 			args: args{
-				source:  "php::",
+				source:  "composer::",
 				pkgName: "symfony/symfony",
 			},
 			fixtures: []string{"testdata/fixtures/multiple-buckets.yaml"},
@@ -155,7 +155,7 @@ func TestConfig_GetAdvisories(t *testing.T) {
 		{
 			name: "prefix scan",
 			args: args{
-				source:  "php::",
+				source:  "composer::",
 				pkgName: "symfony/symfony",
 			},
 			fixtures: []string{"testdata/fixtures/multiple-buckets.yaml"},

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -207,7 +207,7 @@ func (dbc Config) forEach(rootBucket, nestedBucket string) (value map[string][]b
 		var rootBuckets []string
 
 		if strings.Contains(rootBucket, "::") {
-			// e.g. "python::", "php::"
+			// e.g. "pip::", "rubygems::"
 			prefix := []byte(rootBucket)
 			c := tx.Cursor()
 			for k, _ := c.Seek(prefix); k != nil && bytes.HasPrefix(k, prefix); k, _ = c.Next() {

--- a/pkg/db/testdata/fixtures/multiple-buckets.yaml
+++ b/pkg/db/testdata/fixtures/multiple-buckets.yaml
@@ -1,4 +1,4 @@
-- bucket: "php::GitHub Security Advisory Composer"
+- bucket: "composer::GitHub Security Advisory Composer"
   pairs:
     - bucket: symfony/symfony
       pairs:
@@ -8,7 +8,7 @@
               - 4.2.7
             VulnerableVersions:
               - ">= 4.2.0, < 4.2.7"
-- bucket: "php::php-security-advisories"
+- bucket: "composer::php-security-advisories"
   pairs:
     - bucket: symfony/symfony
       pairs:

--- a/pkg/vulnsrc/vulnerability/const.go
+++ b/pkg/vulnsrc/vulnerability/const.go
@@ -28,10 +28,10 @@ const (
 	GHSAPip               = "ghsa-pip"
 	GHSARubygems          = "ghsa-rubygems"
 
-	// Language
-	Nodejs = "nodejs"
-	PHP    = "php"
-	Python = "python"
-	Ruby   = "ruby"
-	Rust   = "rust"
+	// Ecosystem
+	Npm      = "npm"
+	Composer = "composer"
+	Pip      = "pip"
+	RubyGems = "rubygems"
+	Cargo    = "cargo"
 )


### PR DESCRIPTION
Use ecosystem names instead of languages as a bucket prefix.

- nodejs => npm
- php => composer
- python => pip
- ruby => rubygems
- rust => cargo