### PR TITLE
Fix github cron workflow

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v1
 
     - name: Download vuln-list and advisories
-      run: make db-fetch
+      run: make db-fetch-langs db-fetch-vuln-list-main
 
     - name: Build the binary
       run: make build


### PR DESCRIPTION
The Makefile targets were renamed in this PR https://github.com/aquasecurity/trivy-db/pull/65 but the github cron workflow is trying to call the old one and failing.

fixes #87