### PR TITLE
Added dotnet as a constant in vulnerability sources.

### DIFF
--- a/pkg/vulnsrc/vulnerability/const.go
+++ b/pkg/vulnsrc/vulnerability/const.go
@@ -34,4 +34,5 @@ const (
 	Pip      = "pip"
 	RubyGems = "rubygems"
 	Cargo    = "cargo"
+	Dotnet   = "dotnet"
 )


### PR DESCRIPTION
Replace https://github.com/aquasecurity/trivy-db/pull/83