### PR TITLE
fix: replace dotnet with nuget

### DIFF
--- a/pkg/vulnsrc/vulnerability/const.go
+++ b/pkg/vulnsrc/vulnerability/const.go
@@ -34,5 +34,5 @@ const (
 	Pip      = "pip"
 	RubyGems = "rubygems"
 	Cargo    = "cargo"
-	Dotnet   = "dotnet"
+	NuGet    = "nuget"
 )


### PR DESCRIPTION
Replace dotnet with nuget to align with GitHub Advisory Database.
https://github.com/advisories