### PR TITLE
refactor: update a comment

### DIFF
--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -119,7 +119,7 @@ type Advisory struct {
 type Vulnerability struct {
 	Title            string         `json:",omitempty"`
 	Description      string         `json:",omitempty"`
-	Severity         string         `json:",omitempty"` // Deprecated: Severity is only for backwards compatibility. Use VendorSeverity instead.
+	Severity         string         `json:",omitempty"` // Selected from VendorSeverity, depending on a scan target
 	CweIDs           []string       `json:",omitempty"` // e.g. CWE-78, CWE-89
 	VendorSeverity   VendorSeverity `json:",omitempty"`
 	CVSS             VendorCVSS     `json:",omitempty"`


### PR DESCRIPTION
I've added the deprecated label to `Severity` by mistake. `Severity` is not filled in `trivy-db`, but is supposed to be selected from `VendorSeverity` depending on a scan target in `trivy`. If `trivy` scans a `debian:9` image, `Severity` should be Debian's one. In short, this field is necessary.