### PR TITLE
Read Vshield/vpatch heuristic id available in trivy bolt db

### DIFF
--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -115,6 +115,7 @@ type Advisory struct {
 	VulnerableVersions []string `json:",omitempty"`
 	PatchedVersions    []string `json:",omitempty"`
 	UnaffectedVersions []string `json:",omitempty"`
+	Hid                int64    `json:",omitempty"`
 }
 
 type Vulnerability struct {


### PR DESCRIPTION
This commit adds the ability to get the heuristic id from boltdb which is
modified & enhanced by cybercenter vshield/vpatch tracker required for
trivy integration in CSP.