### PR TITLE
Add security advisory details to vulnerability details bucket

### DIFF
--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -55,7 +55,11 @@ type Operation interface {
 	GetAdvisoryDetails(cveID string) ([]types.AdvisoryDetail, error)
 	PutAdvisoryDetail(tx *bolt.Tx, vulnerabilityID string, source string, pkgName string,
 		advisory interface{}) (err error)
+	GetAdvisoryDetail(tx *bolt.Tx, cveID string, platformName string, pkgName string) (types.AdvisoryDetail, error)
 	DeleteAdvisoryDetailBucket() error
+	GetSecurityAdvisoryDetails(cveId string) (types.SecurityAdvisories, error)
+	PutSecurityAdvisoryDetails(tx *bolt.Tx, platform string, advisoryId string, securityAdvisory map[string]types.SecurityAdvisory) error
+	DeleteSecurityAdvisoryBucket() error
 }
 
 type Metadata struct {

--- a/pkg/db/mock_operation.go
+++ b/pkg/db/mock_operation.go
@@ -858,3 +858,173 @@ func (_m *MockOperation) PutVulnerabilityDetail(tx *bbolt.Tx, vulnerabilityID st
 
 	return r0
 }
+
+type OperationDeleteSecurityAdvisoryBucketReturns struct {
+	Err error
+}
+
+type OperationDeleteSecurityAdvisoryBucketExpectation struct {
+	Returns OperationDeleteSecurityAdvisoryBucketReturns
+}
+
+func (_m *MockOperation) ApplyDeleteSecurityAdvisoryBucketExpectation(e OperationDeleteSecurityAdvisoryBucketExpectation) {
+	_m.On("DeleteSecurityAdvisoryBucket").Return(e.Returns.Err)
+}
+
+// DeleteSecurityAdvisoryBucket provides a mock function with given fields:
+func (_m *MockOperation) DeleteSecurityAdvisoryBucket() error {
+	ret := _m.Called()
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func() error); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+type OperationGetSecurityAdvisoryDetailsArgs struct {
+	CveID         string
+	CveIDAnything bool
+}
+
+type OperationGetSecurityAdvisoryDetailsReturns struct {
+	Details types.SecurityAdvisories
+	Err     error
+}
+
+type OperationGetSecurityAdvisoryDetailsExpectation struct {
+	Args    OperationGetSecurityAdvisoryDetailsArgs
+	Returns OperationGetSecurityAdvisoryDetailsReturns
+}
+
+func (_m *MockOperation) ApplyGetSecurityAdvisoryDetailsExpectation(e OperationGetSecurityAdvisoryDetailsExpectation) {
+	var args []interface{}
+	if e.Args.CveIDAnything {
+		args = append(args, mock.Anything)
+	} else {
+		args = append(args, e.Args.CveID)
+	}
+	_m.On("GetSecurityAdvisoryDetails", args...).Return(e.Returns.Details, e.Returns.Err)
+}
+
+// SecurityAdvisoryDetails provides a mock function with given fields: cveID
+func (_m *MockOperation) GetSecurityAdvisoryDetails(cveID string) (types.SecurityAdvisories, error) {
+	ret := _m.Called(cveID)
+
+	var r0 types.SecurityAdvisories
+	if rf, ok := ret.Get(0).(func(string) types.SecurityAdvisories); ok {
+		r0 = rf(cveID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(types.SecurityAdvisories)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(cveID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+type OperationGetAdvisoryDetailArgs struct {
+	CveID         string
+	CveIDAnything bool
+	PlatformName  string
+	PkgName       string
+}
+
+type OperationGetAdvisoryDetailReturns struct {
+	Details types.AdvisoryDetail
+	Err     error
+}
+
+type OperationGetAdvisoryDetailExpectation struct {
+	Args    OperationGetAdvisoryDetailArgs
+	Returns OperationGetAdvisoryDetailReturns
+}
+
+func (_m *MockOperation) ApplyGetAdvisoryDetailExpectation(e OperationGetAdvisoryDetailExpectation) {
+	var args []interface{}
+	if e.Args.CveIDAnything {
+		args = append(args, mock.Anything)
+	} else {
+		args = append(args, e.Args.CveID, e.Args.PlatformName, e.Args.PkgName)
+	}
+	_m.On("GetAdvisoryDetail", args...).Return(e.Returns.Details, e.Returns.Err)
+}
+
+// GetAdvisoryDetail provides a mock function with given fields: cveID
+func (_m *MockOperation) GetAdvisoryDetail(tx *bbolt.Tx, cveID string, platformName string, pkgName string) (types.AdvisoryDetail, error) {
+	ret := _m.Called(cveID, platformName, pkgName)
+
+	var r0 types.AdvisoryDetail
+	if rf, ok := ret.Get(0).(func(string) types.AdvisoryDetail); ok {
+		r0 = rf(cveID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(types.AdvisoryDetail)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(cveID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+type OperationPutSecurityAdvisoryDetailsArgs struct {
+	Tx               *bbolt.Tx
+	TxAnything       bool
+	CveID            string
+	Source           string
+	SecurityAdvisory map[string]types.SecurityAdvisory
+}
+
+type OperationPutSecurityAdvisoryDetailsReturns struct {
+	Details []types.AdvisoryDetail
+	Err     error
+}
+
+type OperationPutSecurityAdvisoryDetailsExpectation struct {
+	Args    OperationPutSecurityAdvisoryDetailsArgs
+	Returns OperationPutSecurityAdvisoryDetailsReturns
+}
+
+func (_m *MockOperation) ApplyPutSecurityAdvisoryDetailsExpectation(e OperationPutSecurityAdvisoryDetailsExpectation) {
+	var args []interface{}
+
+	if e.Args.TxAnything {
+		args = append(args, mock.Anything)
+	} else {
+		args = append(args, e.Args.Tx)
+	}
+
+	args = append(args, e.Args.CveID, e.Args.Source, e.Args.SecurityAdvisory)
+
+	_m.On("PutSecurityAdvisoryDetails", args...).Return(e.Returns.Err)
+}
+
+// PutSecurityAdvisoryDetails provides a mock function with given fields: tx, vulnerabilityID, source, pkgName, advisory
+func (_m *MockOperation) PutSecurityAdvisoryDetails(tx *bbolt.Tx, platform string, advisoryId string, securityAdvisory map[string]types.SecurityAdvisory) error {
+	ret := _m.Called(tx, platform, advisoryId, securityAdvisory)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*bbolt.Tx, string, string, map[string]types.SecurityAdvisory) error); ok {
+		r0 = rf(tx, platform, advisoryId, securityAdvisory)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}

--- a/pkg/db/security_advisory.go
+++ b/pkg/db/security_advisory.go
@@ -1,0 +1,82 @@
+package db
+
+import (
+	"encoding/json"
+
+	"github.com/aquasecurity/trivy-db/pkg/types"
+	bolt "go.etcd.io/bbolt"
+	"golang.org/x/xerrors"
+)
+
+const (
+	securityAdvisoryBucket = "security-advisory"
+)
+
+func (dbc Config) GetSecurityAdvisoryDetails(cveId string) (types.SecurityAdvisories, error) {
+	SecurityAdvisories := types.SecurityAdvisories{}
+	err := db.View(func(tx *bolt.Tx) error {
+		root := tx.Bucket([]byte(securityAdvisoryBucket))
+		if root == nil {
+			return nil
+		}
+		cveBucket := root.Bucket([]byte(cveId))
+		if cveBucket == nil {
+			return nil
+		}
+		err := cveBucket.ForEach(func(platform, v []byte) error {
+			securityAdvisory := make(map[string]types.SecurityAdvisory)
+			advisoryBucket := cveBucket.Bucket(platform)
+			if advisoryBucket == nil {
+				return nil
+			}
+			err := advisoryBucket.ForEach(func(advisoryID, v []byte) error {
+				detail := types.SecurityAdvisory{}
+				if err := json.Unmarshal(v, &detail); err != nil {
+					return xerrors.Errorf("failed to unmarshall advisory_detail: %w", err)
+				}
+				securityAdvisory[string(advisoryID)] = detail
+				return nil
+			})
+			SecurityAdvisories[string(platform)] = securityAdvisory
+			return err
+		})
+		if err != nil {
+			return xerrors.Errorf("error in db foreach: %w", err)
+		}
+		return nil
+	})
+	return SecurityAdvisories, err
+}
+
+func (dbc Config) PutSecurityAdvisoryDetails(tx *bolt.Tx, cveId string, osName string, securityAdvisory map[string]types.SecurityAdvisory) error {
+	root, err := tx.CreateBucketIfNotExists([]byte(securityAdvisoryBucket))
+	if err != nil {
+		return err
+	}
+
+	cveBucket, err := root.CreateBucketIfNotExists([]byte(cveId))
+	if err != nil {
+		return err
+	}
+
+	osBucket, err := cveBucket.CreateBucketIfNotExists([]byte(osName))
+	if err != nil {
+		return err
+	}
+
+	for secAdvId, advisoryDetail := range securityAdvisory {
+		jsonVal, err := json.Marshal(advisoryDetail)
+		if err != nil {
+			return xerrors.Errorf("failed to marshal JSON: %w", err)
+		}
+		err = osBucket.Put([]byte(secAdvId), jsonVal)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (dbc Config) DeleteSecurityAdvisoryBucket() error {
+	return dbc.deleteBucket(securityAdvisoryBucket)
+}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -10,6 +10,7 @@ import (
 type Severity int
 
 type VendorSeverity map[string]Severity
+type SecurityAdvisories map[string]map[string]SecurityAdvisory
 
 type CVSS struct {
 	V2Vector string  `json:"V2Vector,omitempty"`
@@ -82,25 +83,33 @@ type LastUpdated struct {
 	Date time.Time
 }
 type VulnerabilityDetail struct {
-	ID               string     `json:",omitempty"` // e.g. CVE-2019-8331, OSVDB-104365
-	CvssScore        float64    `json:",omitempty"`
-	CvssVector       string     `json:",omitempty"`
-	CvssScoreV3      float64    `json:",omitempty"`
-	CvssVectorV3     string     `json:",omitempty"`
-	Severity         Severity   `json:",omitempty"`
-	SeverityV3       Severity   `json:",omitempty"`
-	CweIDs           []string   `json:",omitempty"` // e.g. CWE-78, CWE-89
-	References       []string   `json:",omitempty"`
-	Title            string     `json:",omitempty"`
-	Description      string     `json:",omitempty"`
-	PublishedDate    *time.Time `json:",omitempty"`
-	LastModifiedDate *time.Time `json:",omitempty"`
+	ID               string             `json:",omitempty"` // e.g. CVE-2019-8331, OSVDB-104365
+	CvssScore        float64            `json:",omitempty"`
+	CvssVector       string             `json:",omitempty"`
+	CvssScoreV3      float64            `json:",omitempty"`
+	CvssVectorV3     string             `json:",omitempty"`
+	Severity         Severity           `json:",omitempty"`
+	SeverityV3       Severity           `json:",omitempty"`
+	CweIDs           []string           `json:",omitempty"` // e.g. CWE-78, CWE-89
+	References       []string           `json:",omitempty"`
+	Title            string             `json:",omitempty"`
+	Description      string             `json:",omitempty"`
+	PublishedDate    *time.Time         `json:",omitempty"`
+	LastModifiedDate *time.Time         `json:",omitempty"`
+	AdvisoryDetails  SecurityAdvisories `json:",omitempty"`
 }
 
 type AdvisoryDetail struct {
 	PlatformName string
 	PackageName  string
 	AdvisoryItem interface{}
+}
+
+type SecurityAdvisory struct {
+	SecurityAdvisoryId string    `json:"security_advisory_id,omitempty"`
+	Severity           string    `json:"severity,omitempty"`
+	PublishDate        time.Time `json:"publish_date,omitempty"`
+	Description        string    `json:"description,omitempty"`
 }
 
 type Advisory struct {
@@ -110,23 +119,29 @@ type Advisory struct {
 	FixedVersion    string `json:",omitempty"`
 	AffectedVersion string `json:",omitempty"` // Only for Arch Linux
 
+	WillNotFix bool `json:"will_not_fix,omitempty"`
+
 	// Version ranges for language-specific package
 	// Some advisories provide VulnerableVersions only, others provide PatchedVersions and UnaffectedVersions
 	VulnerableVersions []string `json:",omitempty"`
 	PatchedVersions    []string `json:",omitempty"`
 	UnaffectedVersions []string `json:",omitempty"`
+
+	// Security Advisories
+	SecurityAdvisory []string `json:",omitempty"`
 }
 
 type Vulnerability struct {
-	Title            string         `json:",omitempty"`
-	Description      string         `json:",omitempty"`
-	Severity         string         `json:",omitempty"` // Selected from VendorSeverity, depending on a scan target
-	CweIDs           []string       `json:",omitempty"` // e.g. CWE-78, CWE-89
-	VendorSeverity   VendorSeverity `json:",omitempty"`
-	CVSS             VendorCVSS     `json:",omitempty"`
-	References       []string       `json:",omitempty"`
-	PublishedDate    *time.Time     `json:",omitempty"`
-	LastModifiedDate *time.Time     `json:",omitempty"`
+	Title            string             `json:",omitempty"`
+	Description      string             `json:",omitempty"`
+	Severity         string             `json:",omitempty"` // Selected from VendorSeverity, depending on a scan target
+	CweIDs           []string           `json:",omitempty"` // e.g. CWE-78, CWE-89
+	VendorSeverity   VendorSeverity     `json:",omitempty"`
+	CVSS             VendorCVSS         `json:",omitempty"`
+	References       []string           `json:",omitempty"`
+	PublishedDate    *time.Time         `json:",omitempty"`
+	LastModifiedDate *time.Time         `json:",omitempty"`
+	AdvisoryDetails  SecurityAdvisories `json:",omitempty"`
 }
 
 type VulnSrc interface {

--- a/pkg/vulnsrc/ubuntu/ubuntu.go
+++ b/pkg/vulnsrc/ubuntu/ubuntu.go
@@ -22,7 +22,7 @@ const (
 )
 
 var (
-	targetStatus          = []string{"needed", "deferred", "released"}
+	targetStatus          = []string{"needed", "deferred", "released", "needs-triage"}
 	UbuntuReleasesMapping = map[string]string{
 		"precise": "12.04",
 		"quantal": "12.10",

--- a/pkg/vulnsrc/vulnerability/vulnerability.go
+++ b/pkg/vulnsrc/vulnerability/vulnerability.go
@@ -222,3 +222,14 @@ func scoreToSeverity(score float64) types.Severity {
 		return types.SeverityUnknown
 	}
 }
+
+func (v Vulnerability) GetSecurityAdvisoryDetails(vulnID string) types.SecurityAdvisories {
+	securityAdvisories, err := v.dbc.GetSecurityAdvisoryDetails(vulnID)
+	if err != nil {
+		log.Println(err)
+		return nil
+	} else if len(securityAdvisories) == 0 {
+		return nil
+	}
+	return securityAdvisories
+}


### PR DESCRIPTION
1. CVE and advisory relation is captured in advisory bucket. If a CVE is fixed inside a advisory, that advisory ID is saved along with CVE.
2. All advisory details are saved in vulnerability bucket.
 --> This process stores advisory details in a temporary bucket called "security-advisory". Once completion of adding advisory details to vulnerability bucket, we delete this temporary bucket.
3. In ubuntu needs-triage status CVEs are also captured into bolt DB now.
![packages_bucket](https://user-images.githubusercontent.com/84763859/126645838-108047ee-c123-4cf5-9375-b1e6852e9adc.png)
![vuln_bucket](https://user-images.githubusercontent.com/84763859/126645851-b5a106b2-ad50-4612-98ca-b80628b48cd4.png)
