### PR TITLE
add debian bullseye

### DIFF
--- a/pkg/vulnsrc/debian/debian.go
+++ b/pkg/vulnsrc/debian/debian.go
@@ -26,12 +26,13 @@ var (
 	platformFormat        = "debian %s"
 	DebianReleasesMapping = map[string]string{
 		// Code names
-		"squeeze": "6",
-		"wheezy":  "7",
-		"jessie":  "8",
-		"stretch": "9",
-		"buster":  "10",
-		"sid":     "unstable",
+		"squeeze":  "6",
+		"wheezy":   "7",
+		"jessie":   "8",
+		"stretch":  "9",
+		"buster":   "10",
+		"bullseye": "11",
+		"sid":      "unstable",
 	}
 )
 


### PR DESCRIPTION
Adds `debian 11`/`bullseye` to the `debian` source, ahead of the future release scheduled for 2021-08-14 ([click here for announcement](https://lists.debian.org/debian-devel-announce/2021/07/msg00003.html)).

<details>
<summary>pre</summary>
<p>

```shell
$ trivy image debian:bullseye-slim@sha256:9bfa0f4fb6d32116de4a6172f89a9266f7c73d1b8dae46f765bed703e541175e
2021-08-08T06:22:59.992-0400	INFO	Detected OS: debian
2021-08-08T06:22:59.992-0400	INFO	Detecting Debian vulnerabilities...
2021-08-08T06:22:59.992-0400	INFO	Number of language-specific files: 0

debian:bullseye-slim@sha256:9bfa0f4fb6d32116de4a6172f89a9266f7c73d1b8dae46f765bed703e541175e (debian 11.0)
==========================================================================================================
Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)

```

</p>
</details>  

<details>
<summary>post</summary>
<p>

```shell
$ trivy image debian:bullseye-slim@sha256:9bfa0f4fb6d32116de4a6172f89a9266f7c73d1b8dae46f765bed703e541175e
2021-08-08T06:24:54.974-0400	INFO	Detected OS: debian
2021-08-08T06:24:54.974-0400	INFO	Detecting Debian vulnerabilities...
2021-08-08T06:24:54.976-0400	INFO	Number of language-specific files: 0

debian:bullseye-slim@sha256:9bfa0f4fb6d32116de4a6172f89a9266f7c73d1b8dae46f765bed703e541175e (debian 11.0)
==========================================================================================================
Total: 62 (UNKNOWN: 0, LOW: 60, MEDIUM: 0, HIGH: 0, CRITICAL: 2)

+------------------+---------------------+----------+-------------------+---------------+------------------------------------------------------------+
|     LIBRARY      |  VULNERABILITY ID   | SEVERITY | INSTALLED VERSION | FIXED VERSION |                           TITLE                            |
+------------------+---------------------+----------+-------------------+---------------+------------------------------------------------------------+
| apt              | CVE-2011-3374       | LOW      | 2.2.4             |               | It was found that apt-key in apt,                          |
|                  |                     |          |                   |               | all versions, do not correctly...                          |
|                  |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2011-3374                       |
+------------------+---------------------+          +-------------------+---------------+------------------------------------------------------------+
| bash             | TEMP-0841856-B18BAF |          | 5.1-2             |               | -->security-tracker.debian.org/tracker/TEMP-0841856-B18BAF |
+------------------+---------------------+          +-------------------+---------------+------------------------------------------------------------+
| coreutils        | CVE-2016-2781       |          | 8.32-4            |               | coreutils: Non-privileged                                  |
|                  |                     |          |                   |               | session can escape to the                                  |
|                  |                     |          |                   |               | parent session in chroot                                   |
|                  |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2016-2781                       |
+                  +---------------------+          +                   +---------------+------------------------------------------------------------+
|                  | CVE-2017-18018      |          |                   |               | coreutils: race condition                                  |
|                  |                     |          |                   |               | vulnerability in chown and chgrp                           |
|                  |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2017-18018                      |
+------------------+---------------------+          +-------------------+---------------+------------------------------------------------------------+
| libapt-pkg6.0    | CVE-2011-3374       |          | 2.2.4             |               | It was found that apt-key in apt,                          |
|                  |                     |          |                   |               | all versions, do not correctly...                          |
|                  |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2011-3374                       |
+------------------+---------------------+----------+-------------------+---------------+------------------------------------------------------------+
| libc-bin         | CVE-2021-33574      | CRITICAL | 2.31-12           |               | glibc: mq_notify does                                      |
|                  |                     |          |                   |               | not handle separately                                      |
|                  |                     |          |                   |               | allocated thread attributes                                |
|                  |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-33574                      |
+                  +---------------------+----------+                   +---------------+------------------------------------------------------------+
|                  | CVE-2010-4051       | LOW      |                   |               | CVE-2010-4052 glibc: De-recursivise                        |
|                  |                     |          |                   |               | regular expression engine                                  |
|                  |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2010-4051                       |
+                  +---------------------+          +                   +---------------+------------------------------------------------------------+
|                  | CVE-2010-4052       |          |                   |               | CVE-2010-4051 CVE-2010-4052                                |
|                  |                     |          |                   |               | glibc: De-recursivise                                      |
|                  |                     |          |                   |               | regular expression engine                                  |
|                  |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2010-4052                       |
+                  +---------------------+          +                   +---------------+------------------------------------------------------------+
|                  | CVE-2010-4756       |          |                   |               | glibc: glob implementation                                 |
|                  |                     |          |                   |               | can cause excessive CPU and                                |
|                  |                     |          |                   |               | memory consumption due to...                               |
|                  |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2010-4756                       |
+                  +---------------------+          +                   +---------------+------------------------------------------------------------+
|                  | CVE-2018-20796      |          |                   |               | glibc: uncontrolled recursion in                           |
|                  |                     |          |                   |               | function check_dst_limits_calc_pos_1                       |
|                  |                     |          |                   |               | in posix/regexec.c                                         |
|                  |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2018-20796                      |
+                  +---------------------+          +                   +---------------+------------------------------------------------------------+
|                  | CVE-2019-1010022    |          |                   |               | glibc: stack guard protection bypass                       |
|                  |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2019-1010022                    |
+                  +---------------------+          +                   +---------------+------------------------------------------------------------+
|                  | CVE-2019-1010023    |          |                   |               | glibc: running ldd on malicious ELF                        |
|                  |                     |          |                   |               | leads to code execution because of...                      |
|                  |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2019-1010023                    |
+                  +---------------------+          +                   +---------------+------------------------------------------------------------+
|                  | CVE-2019-1010024    |          |                   |               | glibc: ASLR bypass using                                   |
|                  |                     |          |                   |               | cache of thread stack and heap                             |
|                  |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2019-1010024                    |
+                  +---------------------+          +                   +---------------+------------------------------------------------------------+
|                  | CVE-2019-1010025    |          |                   |               | glibc: information disclosure of heap                      |
|                  |                     |          |                   |               | addresses of pthread_created thread                        |
|                  |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2019-1010025                    |
+                  +---------------------+          +                   +---------------+------------------------------------------------------------+
|                  | CVE-2019-9192       |          |                   |               | glibc: uncontrolled recursion in                           |
|                  |                     |          |                   |               | function check_dst_limits_calc_pos_1                       |
|                  |                     |          |                   |               | in posix/regexec.c                                         |
|                  |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2019-9192                       |
+------------------+---------------------+----------+                   +---------------+------------------------------------------------------------+
| libc6            | CVE-2021-33574      | CRITICAL |                   |               | glibc: mq_notify does                                      |
|                  |                     |          |                   |               | not handle separately                                      |
|                  |                     |          |                   |               | allocated thread attributes                                |
|                  |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-33574                      |
+                  +---------------------+----------+                   +---------------+------------------------------------------------------------+
|                  | CVE-2010-4051       | LOW      |                   |               | CVE-2010-4052 glibc: De-recursivise                        |
|                  |                     |          |                   |               | regular expression engine                                  |
|                  |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2010-4051                       |
+                  +---------------------+          +                   +---------------+------------------------------------------------------------+
|                  | CVE-2010-4052       |          |                   |               | CVE-2010-4051 CVE-2010-4052                                |
|                  |                     |          |                   |               | glibc: De-recursivise                                      |
|                  |                     |          |                   |               | regular expression engine                                  |
|                  |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2010-4052                       |
+                  +---------------------+          +                   +---------------+------------------------------------------------------------+
|                  | CVE-2010-4756       |          |                   |               | glibc: glob implementation                                 |
|                  |                     |          |                   |               | can cause excessive CPU and                                |
|                  |                     |          |                   |               | memory consumption due to...                               |
|                  |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2010-4756                       |
+                  +---------------------+          +                   +---------------+------------------------------------------------------------+
|                  | CVE-2018-20796      |          |                   |               | glibc: uncontrolled recursion in                           |
|                  |                     |          |                   |               | function check_dst_limits_calc_pos_1                       |
|                  |                     |          |                   |               | in posix/regexec.c                                         |
|                  |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2018-20796                      |
+                  +---------------------+          +                   +---------------+------------------------------------------------------------+
|                  | CVE-2019-1010022    |          |                   |               | glibc: stack guard protection bypass                       |
|                  |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2019-1010022                    |
+                  +---------------------+          +                   +---------------+------------------------------------------------------------+
|                  | CVE-2019-1010023    |          |                   |               | glibc: running ldd on malicious ELF                        |
|                  |                     |          |                   |               | leads to code execution because of...                      |
|                  |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2019-1010023                    |
+                  +---------------------+          +                   +---------------+------------------------------------------------------------+
|                  | CVE-2019-1010024    |          |                   |               | glibc: ASLR bypass using                                   |
|                  |                     |          |                   |               | cache of thread stack and heap                             |
|                  |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2019-1010024                    |
+                  +---------------------+          +                   +---------------+------------------------------------------------------------+
|                  | CVE-2019-1010025    |          |                   |               | glibc: information disclosure of heap                      |
|                  |                     |          |                   |               | addresses of pthread_created thread                        |
|                  |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2019-1010025                    |
+                  +---------------------+          +                   +---------------+------------------------------------------------------------+
|                  | CVE-2019-9192       |          |                   |               | glibc: uncontrolled recursion in                           |
|                  |                     |          |                   |               | function check_dst_limits_calc_pos_1                       |
|                  |                     |          |                   |               | in posix/regexec.c                                         |
|                  |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2019-9192                       |
+------------------+---------------------+          +-------------------+---------------+------------------------------------------------------------+
| libgcrypt20      | CVE-2018-6829       |          | 1.8.7-6           |               | libgcrypt: ElGamal implementation                          |
|                  |                     |          |                   |               | doesn't have semantic security due                         |
|                  |                     |          |                   |               | to incorrectly encoded plaintexts...                       |
|                  |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2018-6829                       |
+------------------+---------------------+          +-------------------+---------------+------------------------------------------------------------+
| libgnutls30      | CVE-2011-3389       |          | 3.7.1-5           |               | HTTPS: block-wise chosen-plaintext                         |
|                  |                     |          |                   |               | attack against SSL/TLS (BEAST)                             |
|                  |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2011-3389                       |
+------------------+---------------------+          +-------------------+---------------+------------------------------------------------------------+
| libgssapi-krb5-2 | CVE-2004-0971       |          | 1.18.3-5          |               | security flaw                                              |
|                  |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2004-0971                       |
+                  +---------------------+          +                   +---------------+------------------------------------------------------------+
|                  | CVE-2018-5709       |          |                   |               | krb5: integer overflow                                     |
|                  |                     |          |                   |               | in dbentry->n_key_data                                     |
|                  |                     |          |                   |               | in kadmin/dbutil/dump.c                                    |
|                  |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2018-5709                       |
+------------------+---------------------+          +                   +---------------+------------------------------------------------------------+
| libk5crypto3     | CVE-2004-0971       |          |                   |               | security flaw                                              |
|                  |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2004-0971                       |
+                  +---------------------+          +                   +---------------+------------------------------------------------------------+
|                  | CVE-2018-5709       |          |                   |               | krb5: integer overflow                                     |
|                  |                     |          |                   |               | in dbentry->n_key_data                                     |
|                  |                     |          |                   |               | in kadmin/dbutil/dump.c                                    |
|                  |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2018-5709                       |
+------------------+---------------------+          +                   +---------------+------------------------------------------------------------+
| libkrb5-3        | CVE-2004-0971       |          |                   |               | security flaw                                              |
|                  |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2004-0971                       |
+                  +---------------------+          +                   +---------------+------------------------------------------------------------+
|                  | CVE-2018-5709       |          |                   |               | krb5: integer overflow                                     |
|                  |                     |          |                   |               | in dbentry->n_key_data                                     |
|                  |                     |          |                   |               | in kadmin/dbutil/dump.c                                    |
|                  |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2018-5709                       |
+------------------+---------------------+          +                   +---------------+------------------------------------------------------------+
| libkrb5support0  | CVE-2004-0971       |          |                   |               | security flaw                                              |
|                  |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2004-0971                       |
+                  +---------------------+          +                   +---------------+------------------------------------------------------------+
|                  | CVE-2018-5709       |          |                   |               | krb5: integer overflow                                     |
|                  |                     |          |                   |               | in dbentry->n_key_data                                     |
|                  |                     |          |                   |               | in kadmin/dbutil/dump.c                                    |
|                  |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2018-5709                       |
+------------------+---------------------+          +-------------------+---------------+------------------------------------------------------------+
| libpcre3         | CVE-2017-11164      |          | 2:8.39-13         |               | pcre: OP_KETRMAX feature in the                            |
|                  |                     |          |                   |               | match function in pcre_exec.c                              |
|                  |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2017-11164                      |
+                  +---------------------+          +                   +---------------+------------------------------------------------------------+
|                  | CVE-2017-16231      |          |                   |               | pcre: self-recursive call                                  |
|                  |                     |          |                   |               | in match() in pcre_exec.c                                  |
|                  |                     |          |                   |               | leads to denial of service...                              |
|                  |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2017-16231                      |
+                  +---------------------+          +                   +---------------+------------------------------------------------------------+
|                  | CVE-2017-7245       |          |                   |               | pcre: stack-based buffer overflow                          |
|                  |                     |          |                   |               | write in pcre32_copy_substring                             |
|                  |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2017-7245                       |
+                  +---------------------+          +                   +---------------+------------------------------------------------------------+
|                  | CVE-2017-7246       |          |                   |               | pcre: stack-based buffer overflow                          |
|                  |                     |          |                   |               | write in pcre32_copy_substring                             |
|                  |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2017-7246                       |
+                  +---------------------+          +                   +---------------+------------------------------------------------------------+
|                  | CVE-2019-20838      |          |                   |               | pcre: buffer over-read in                                  |
|                  |                     |          |                   |               | JIT when UTF is disabled                                   |
|                  |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2019-20838                      |
+------------------+---------------------+          +-------------------+---------------+------------------------------------------------------------+
| libsepol1        | CVE-2021-36084      |          | 3.1-1             |               | libsepol: use-after-free in                                |
|                  |                     |          |                   |               | __cil_verify_classperms()                                  |
|                  |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-36084                      |
+                  +---------------------+          +                   +---------------+------------------------------------------------------------+
|                  | CVE-2021-36085      |          |                   |               | libsepol: use-after-free in                                |
|                  |                     |          |                   |               | __cil_verify_classperms()                                  |
|                  |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-36085                      |
+                  +---------------------+          +                   +---------------+------------------------------------------------------------+
|                  | CVE-2021-36086      |          |                   |               | libsepol: use-after-free in                                |
|                  |                     |          |                   |               | cil_reset_classpermission()                                |
|                  |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-36086                      |
+                  +---------------------+          +                   +---------------+------------------------------------------------------------+
|                  | CVE-2021-36087      |          |                   |               | libsepol: heap-based buffer                                |
|                  |                     |          |                   |               | overflow in ebitmap_match_any()                            |
|                  |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-36087                      |
+------------------+---------------------+          +-------------------+---------------+------------------------------------------------------------+
| libssl1.1        | CVE-2007-6755       |          | 1.1.1k-1          |               | Dual_EC_DRBG: weak pseudo                                  |
|                  |                     |          |                   |               | random number generator                                    |
|                  |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2007-6755                       |
+                  +---------------------+          +                   +---------------+------------------------------------------------------------+
|                  | CVE-2010-0928       |          |                   |               | openssl: RSA authentication weakness                       |
|                  |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2010-0928                       |
+------------------+---------------------+          +-------------------+---------------+------------------------------------------------------------+
| libsystemd0      | CVE-2013-4392       |          | 247.3-5           |               | systemd: TOCTOU race condition                             |
|                  |                     |          |                   |               | when updating file permissions                             |
|                  |                     |          |                   |               | and SELinux security contexts...                           |
|                  |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2013-4392                       |
+                  +---------------------+          +                   +---------------+------------------------------------------------------------+
|                  | CVE-2020-13529      |          |                   |               | systemd: DHCP FORCERENEW                                   |
|                  |                     |          |                   |               | authentication not implemented                             |
|                  |                     |          |                   |               | can cause a system running the...                          |
|                  |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2020-13529                      |
+------------------+---------------------+          +                   +---------------+------------------------------------------------------------+
| libudev1         | CVE-2013-4392       |          |                   |               | systemd: TOCTOU race condition                             |
|                  |                     |          |                   |               | when updating file permissions                             |
|                  |                     |          |                   |               | and SELinux security contexts...                           |
|                  |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2013-4392                       |
+                  +---------------------+          +                   +---------------+------------------------------------------------------------+
|                  | CVE-2020-13529      |          |                   |               | systemd: DHCP FORCERENEW                                   |
|                  |                     |          |                   |               | authentication not implemented                             |
|                  |                     |          |                   |               | can cause a system running the...                          |
|                  |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2020-13529                      |
+------------------+---------------------+          +-------------------+---------------+------------------------------------------------------------+
| login            | CVE-2007-5686       |          | 1:4.8.1-1         |               | initscripts in rPath Linux 1                               |
|                  |                     |          |                   |               | sets insecure permissions for                              |
|                  |                     |          |                   |               | the /var/log/btmp file,...                                 |
|                  |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2007-5686                       |
+                  +---------------------+          +                   +---------------+------------------------------------------------------------+
|                  | CVE-2013-4235       |          |                   |               | shadow-utils: TOCTOU race                                  |
|                  |                     |          |                   |               | conditions by copying and                                  |
|                  |                     |          |                   |               | removing directory trees                                   |
|                  |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2013-4235                       |
+                  +---------------------+          +                   +---------------+------------------------------------------------------------+
|                  | CVE-2019-19882      |          |                   |               | shadow-utils: local users can                              |
|                  |                     |          |                   |               | obtain root access because setuid                          |
|                  |                     |          |                   |               | programs are misconfigured...                              |
|                  |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2019-19882                      |
+                  +---------------------+          +                   +---------------+------------------------------------------------------------+
|                  | TEMP-0628843-DBAD28 |          |                   |               | -->security-tracker.debian.org/tracker/TEMP-0628843-DBAD28 |
+------------------+---------------------+          +                   +---------------+------------------------------------------------------------+
| passwd           | CVE-2007-5686       |          |                   |               | initscripts in rPath Linux 1                               |
|                  |                     |          |                   |               | sets insecure permissions for                              |
|                  |                     |          |                   |               | the /var/log/btmp file,...                                 |
|                  |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2007-5686                       |
+                  +---------------------+          +                   +---------------+------------------------------------------------------------+
|                  | CVE-2013-4235       |          |                   |               | shadow-utils: TOCTOU race                                  |
|                  |                     |          |                   |               | conditions by copying and                                  |
|                  |                     |          |                   |               | removing directory trees                                   |
|                  |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2013-4235                       |
+                  +---------------------+          +                   +---------------+------------------------------------------------------------+
|                  | CVE-2019-19882      |          |                   |               | shadow-utils: local users can                              |
|                  |                     |          |                   |               | obtain root access because setuid                          |
|                  |                     |          |                   |               | programs are misconfigured...                              |
|                  |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2019-19882                      |
+                  +---------------------+          +                   +---------------+------------------------------------------------------------+
|                  | TEMP-0628843-DBAD28 |          |                   |               | -->security-tracker.debian.org/tracker/TEMP-0628843-DBAD28 |
+------------------+---------------------+          +-------------------+---------------+------------------------------------------------------------+
| perl-base        | CVE-2011-4116       |          | 5.32.1-4          |               | perl: File::Temp insecure                                  |
|                  |                     |          |                   |               | temporary file handling                                    |
|                  |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2011-4116                       |
+------------------+---------------------+          +-------------------+---------------+------------------------------------------------------------+
| sysvinit-utils   | TEMP-0517018-A83CE6 |          | 2.96-7            |               | -->security-tracker.debian.org/tracker/TEMP-0517018-A83CE6 |
+------------------+---------------------+          +-------------------+---------------+------------------------------------------------------------+
| tar              | CVE-2005-2541       |          | 1.34+dfsg-1       |               | tar: does not properly warn the user                       |
|                  |                     |          |                   |               | when extracting setuid or setgid...                        |
|                  |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2005-2541                       |
+                  +---------------------+          +                   +---------------+------------------------------------------------------------+
|                  | TEMP-0290435-0B57B5 |          |                   |               | -->security-tracker.debian.org/tracker/TEMP-0290435-0B57B5 |
+------------------+---------------------+----------+-------------------+---------------+------------------------------------------------------------+
```

I followed a few from CVE to Debian security to verify, here are links if you want to too:
* https://security-tracker.debian.org/tracker/CVE-2021-33574
* https://security-tracker.debian.org/tracker/CVE-2007-5686
</p>
</details>  


Closes https://github.com/aquasecurity/trivy-db/issues/138
❤️ thanks for building all this!