### PR TITLE
feat(redhat): add Out of support scope

### DIFF
--- a/pkg/vulnsrc/redhat/redhat.go
+++ b/pkg/vulnsrc/redhat/redhat.go
@@ -28,7 +28,7 @@ const (
 var (
 	targetPlatforms = []string{"Red Hat Enterprise Linux 5", "Red Hat Enterprise Linux 6",
 		"Red Hat Enterprise Linux 7", "Red Hat Enterprise Linux 8"}
-	targetStatus = []string{"Affected", "Fix deferred", "Will not fix"}
+	targetStatus = []string{"Affected", "Fix deferred", "Will not fix", "Out of support scope"}
 )
 
 type VulnSrc struct {


### PR DESCRIPTION
From Red Hat website

>My product is listed as "Out of Support Scope". What does this mean?
>When a product is listed as "Out of Support Scope", it means a vulnerability with the impact level assigned to this CVE is no longer covered by its current support lifecycle phase. The product has been identified to contain the impacted component, but analysis to determine whether it is affected or not by this vulnerability was not performed. The product should be assumed to be affected. Customers are advised to apply any mitigation options documented on this page, consider removing or disabling the impacted component, or upgrade to a supported version of the product that has an update available.
