### PR TITLE
fix(ruby): remove advisories from OSVDB

### DIFF
--- a/pkg/vulnsrc/bundler/bundler.go
+++ b/pkg/vulnsrc/bundler/bundler.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 
 	bolt "go.etcd.io/bbolt"
 	"golang.org/x/xerrors"
@@ -108,12 +109,13 @@ func (vs VulnSrc) walkFunc(err error, info os.FileInfo, path string, tx *bolt.Tx
 	if err != nil {
 		return xerrors.Errorf("failed to unmarshal YAML: %w", err)
 	}
+	if advisory.Osvdb != "" || strings.Contains(advisory.Url, "osvdb.org") {
+		return nil
+	}
 
 	var vulnerabilityID string
 	if advisory.Cve != "" {
 		vulnerabilityID = fmt.Sprintf("CVE-%s", advisory.Cve)
-	} else if advisory.Osvdb != "" {
-		return nil
 	} else if advisory.Ghsa != "" {
 		vulnerabilityID = fmt.Sprintf("GHSA-%s", advisory.Ghsa)
 	} else {

--- a/pkg/vulnsrc/bundler/bundler.go
+++ b/pkg/vulnsrc/bundler/bundler.go
@@ -113,7 +113,7 @@ func (vs VulnSrc) walkFunc(err error, info os.FileInfo, path string, tx *bolt.Tx
 	if advisory.Cve != "" {
 		vulnerabilityID = fmt.Sprintf("CVE-%s", advisory.Cve)
 	} else if advisory.Osvdb != "" {
-		vulnerabilityID = fmt.Sprintf("OSVDB-%s", advisory.Osvdb)
+		return nil
 	} else if advisory.Ghsa != "" {
 		vulnerabilityID = fmt.Sprintf("GHSA-%s", advisory.Ghsa)
 	} else {

--- a/pkg/vulnsrc/bundler/bundler.go
+++ b/pkg/vulnsrc/bundler/bundler.go
@@ -99,6 +99,10 @@ func (vs VulnSrc) walkFunc(err error, info os.FileInfo, path string, tx *bolt.Tx
 	if info.IsDir() {
 		return nil
 	}
+	if strings.HasPrefix(strings.ToUpper(info.Name()), "OSVDB") {
+		return nil
+	}
+
 	buf, err := ioutil.ReadFile(path)
 	if err != nil {
 		return xerrors.Errorf("failed to read a file: %w", err)
@@ -109,8 +113,8 @@ func (vs VulnSrc) walkFunc(err error, info os.FileInfo, path string, tx *bolt.Tx
 	if err != nil {
 		return xerrors.Errorf("failed to unmarshal YAML: %w", err)
 	}
-	if advisory.Osvdb != "" || strings.Contains(advisory.Url, "osvdb.org") {
-		return nil
+	if strings.Contains(strings.ToLower(advisory.Url), "osvdb.org") {
+		advisory.Url = ""
 	}
 
 	var vulnerabilityID string


### PR DESCRIPTION
OSVDB doesn't allow commercial usage without agreement.
Skipping OSVDB* files so that Trivy can be used in commercials.
    
also remove the defunct `osvdb.org` website from URL.

Fixes [aquasecurity/trivy/#1208](https://github.com/aquasecurity/trivy/issues/1208)