### PR TITLE
feat(rocky): support Rocky Linux

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"io/fs"
 	"log"
@@ -117,4 +118,18 @@ func Uniq(strings []string) []string {
 func IsInt(s string) bool {
 	_, err := strconv.Atoi(s)
 	return err == nil
+}
+
+func ConstructVersion(epoch, version, release string) string {
+	verStr := ""
+	if epoch != "0" && epoch != "" {
+		verStr += fmt.Sprintf("%s:", epoch)
+	}
+	verStr += version
+
+	if release != "" {
+		verStr += fmt.Sprintf("-%s", release)
+
+	}
+	return verStr
 }

--- a/pkg/vulnsrc/alma/alma.go
+++ b/pkg/vulnsrc/alma/alma.go
@@ -116,7 +116,7 @@ func (vs VulnSrc) commit(tx *bolt.Tx, platformName string, errata []Erratum) err
 				}
 
 				advisory := types.Advisory{
-					FixedVersion: constructVersion(pkg.Epoch, pkg.Version, pkg.Release),
+					FixedVersion: utils.ConstructVersion(pkg.Epoch, pkg.Version, pkg.Release),
 				}
 
 				if adv, ok := advisories[pkgName]; ok {
@@ -173,18 +173,4 @@ func generalizeSeverity(severity string) types.Severity {
 		return types.SeverityCritical
 	}
 	return types.SeverityUnknown
-}
-
-func constructVersion(epoch, version, release string) string {
-	verStr := ""
-	if epoch != "0" && epoch != "" {
-		verStr += fmt.Sprintf("%s:", epoch)
-	}
-	verStr += version
-
-	if release != "" {
-		verStr += fmt.Sprintf("-%s", release)
-
-	}
-	return verStr
 }

--- a/pkg/vulnsrc/amazon/amazon.go
+++ b/pkg/vulnsrc/amazon/amazon.go
@@ -120,7 +120,7 @@ func (vs VulnSrc) commit(tx *bolt.Tx) error {
 				for _, pkg := range alas.Packages {
 					platformName := fmt.Sprintf(platformFormat, majorVersion)
 					advisory := types.Advisory{
-						FixedVersion: constructVersion(pkg.Epoch, pkg.Version, pkg.Release),
+						FixedVersion: utils.ConstructVersion(pkg.Epoch, pkg.Version, pkg.Release),
 					}
 					if err := vs.dbc.PutAdvisoryDetail(tx, cveID, platformName, pkg.Name, advisory); err != nil {
 						return xerrors.Errorf("failed to save Amazon advisory: %w", err)
@@ -175,18 +175,4 @@ func severityFromPriority(priority string) types.Severity {
 	default:
 		return types.SeverityUnknown
 	}
-}
-
-func constructVersion(epoch, version, release string) string {
-	verStr := ""
-	if epoch != "0" && epoch != "" {
-		verStr += fmt.Sprintf("%s:", epoch)
-	}
-	verStr += version
-
-	if release != "" {
-		verStr += fmt.Sprintf("-%s", release)
-
-	}
-	return verStr
 }

--- a/pkg/vulnsrc/rocky/rocky.go
+++ b/pkg/vulnsrc/rocky/rocky.go
@@ -119,7 +119,7 @@ func (vs VulnSrc) commit(tx *bolt.Tx, platformName string, errata []RLSA) error 
 				}
 
 				advisory := types.Advisory{
-					FixedVersion: constructVersion(pkg.Epoch, pkg.Version, pkg.Release),
+					FixedVersion: utils.ConstructVersion(pkg.Epoch, pkg.Version, pkg.Release),
 				}
 				if err := vs.dbc.PutAdvisoryDetail(tx, cveID, platformName, pkg.Name, advisory); err != nil {
 					return xerrors.Errorf("failed to save Rocky advisory: %w", err)
@@ -159,20 +159,6 @@ func (vs VulnSrc) Get(release, pkgName string) ([]types.Advisory, error) {
 		return nil, xerrors.Errorf("failed to get Rocky advisories: %w", err)
 	}
 	return advisories, nil
-}
-
-func constructVersion(epoch, version, release string) string {
-	verStr := ""
-	if epoch != "0" && epoch != "" {
-		verStr += fmt.Sprintf("%s:", epoch)
-	}
-	verStr += version
-
-	if release != "" {
-		verStr += fmt.Sprintf("-%s", release)
-
-	}
-	return verStr
 }
 
 func generalizeSeverity(severity string) types.Severity {

--- a/pkg/vulnsrc/rocky/rocky.go
+++ b/pkg/vulnsrc/rocky/rocky.go
@@ -110,7 +110,12 @@ func (vs VulnSrc) save(errataVer map[string][]RLSA) error {
 func (vs VulnSrc) commit(tx *bolt.Tx, platformName string, errata []RLSA) error {
 	for _, erratum := range errata {
 		for _, cveID := range erratum.CveIDs {
+			putAdvisoryCount := 0
 			for _, pkg := range erratum.Packages {
+				if strings.Contains(pkg.Release, ".module+el") {
+					continue
+				}
+
 				advisory := types.Advisory{
 					FixedVersion: constructVersion(pkg.Epoch, pkg.Version, pkg.Release),
 				}
@@ -118,6 +123,9 @@ func (vs VulnSrc) commit(tx *bolt.Tx, platformName string, errata []RLSA) error 
 					return xerrors.Errorf("failed to save Rocky advisory: %w", err)
 				}
 
+				putAdvisoryCount++
+			}
+			if putAdvisoryCount > 0 {
 				var references []string
 				for _, ref := range erratum.References {
 					references = append(references, ref.Href)

--- a/pkg/vulnsrc/rocky/rocky.go
+++ b/pkg/vulnsrc/rocky/rocky.go
@@ -52,22 +52,21 @@ func (vs VulnSrc) Update(dir string) error {
 
 		dirs := strings.Split(path, string(filepath.Separator))
 		if len(dirs) < 5 {
-			log.Printf("invalid path: %s\n", path)
+			log.Printf("Invalid path: %s", path)
 			return nil
 		}
 
-		majorVer := dirs[len(dirs)-5]
-		repo := dirs[len(dirs)-4]
+		majorVer, repo, arch := dirs[len(dirs)-5], dirs[len(dirs)-4], dirs[len(dirs)-3]
 		if !utils.StringInSlice(repo, targetRepos) {
-			log.Printf("unsupported Rocky repo: %s\n", repo)
+			log.Printf("Unsupported Rocky repo: %s", repo)
 			return nil
 		}
-		arch := dirs[len(dirs)-3]
+
 		if !utils.StringInSlice(arch, targetArches) {
 			switch arch {
 			case "aarch64":
 			default:
-				log.Printf("unsupported Rocky arch: %s\n", arch)
+				log.Printf("Unsupported Rocky arch: %s", arch)
 			}
 			return nil
 		}
@@ -79,7 +78,7 @@ func (vs VulnSrc) Update(dir string) error {
 		return xerrors.Errorf("error in Rocky walk: %w", err)
 	}
 
-	if err := vs.save(errata); err != nil {
+	if err = vs.save(errata); err != nil {
 		return xerrors.Errorf("error in Rocky save: %w", err)
 	}
 
@@ -122,6 +121,7 @@ func (vs VulnSrc) commit(tx *bolt.Tx, platformName string, errata []RLSA) error 
 
 				putAdvisoryCount++
 			}
+
 			if putAdvisoryCount > 0 {
 				var references []string
 				for _, ref := range erratum.References {

--- a/pkg/vulnsrc/rocky/rocky.go
+++ b/pkg/vulnsrc/rocky/rocky.go
@@ -24,7 +24,7 @@ const (
 var (
 	platformFormat = "rocky %s"
 	targetReleases = []string{"8"}
-	targetRepos    = []string{"BaseOS", "AppStream", "Devel"}
+	targetRepos    = []string{"BaseOS", "AppStream", "extras"}
 	targetArches   = []string{"x86_64"}
 )
 

--- a/pkg/vulnsrc/rocky/rocky.go
+++ b/pkg/vulnsrc/rocky/rocky.go
@@ -50,13 +50,13 @@ func (vs VulnSrc) Update(dir string) error {
 			return xerrors.Errorf("failed to decode Rocky erratum: %w", err)
 		}
 
-		dirs := strings.Split(path, string(filepath.Separator))
-		if len(dirs) < 5 {
+		dirs := strings.Split(strings.TrimPrefix(path, rootDir), string(filepath.Separator))[1:]
+		if len(dirs) != 5 {
 			log.Printf("Invalid path: %s", path)
 			return nil
 		}
 
-		majorVer, repo, arch := dirs[len(dirs)-5], dirs[len(dirs)-4], dirs[len(dirs)-3]
+		majorVer, repo, arch := dirs[0], dirs[1], dirs[2]
 		if !utils.StringInSlice(repo, targetRepos) {
 			log.Printf("Unsupported Rocky repo: %s", repo)
 			return nil

--- a/pkg/vulnsrc/rocky/rocky.go
+++ b/pkg/vulnsrc/rocky/rocky.go
@@ -23,7 +23,6 @@ const (
 
 var (
 	platformFormat = "rocky %s"
-	targetReleases = []string{"8"}
 	targetRepos    = []string{"BaseOS", "AppStream", "extras"}
 	targetArches   = []string{"x86_64"}
 )
@@ -58,10 +57,6 @@ func (vs VulnSrc) Update(dir string) error {
 		}
 
 		majorVer := dirs[len(dirs)-5]
-		if !utils.StringInSlice(majorVer, targetReleases) {
-			log.Printf("unsupported Rocky version: %s\n", majorVer)
-			return nil
-		}
 		repo := dirs[len(dirs)-4]
 		if !utils.StringInSlice(repo, targetRepos) {
 			log.Printf("unsupported Rocky repo: %s\n", repo)

--- a/pkg/vulnsrc/rocky/rocky.go
+++ b/pkg/vulnsrc/rocky/rocky.go
@@ -112,6 +112,8 @@ func (vs VulnSrc) commit(tx *bolt.Tx, platformName string, errata []RLSA) error 
 		for _, cveID := range erratum.CveIDs {
 			putAdvisoryCount := 0
 			for _, pkg := range erratum.Packages {
+				// Skip the modular packages until the following bug is fixed.
+				// https://forums.rockylinux.org/t/some-errata-missing-in-comparison-with-rhel-and-almalinux/3843/8
 				if strings.Contains(pkg.Release, ".module+el") {
 					continue
 				}

--- a/pkg/vulnsrc/rocky/rocky.go
+++ b/pkg/vulnsrc/rocky/rocky.go
@@ -1,0 +1,180 @@
+package rocky
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"path/filepath"
+	"strings"
+
+	bolt "go.etcd.io/bbolt"
+	"golang.org/x/xerrors"
+
+	"github.com/aquasecurity/trivy-db/pkg/db"
+	"github.com/aquasecurity/trivy-db/pkg/types"
+	"github.com/aquasecurity/trivy-db/pkg/utils"
+	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/vulnerability"
+)
+
+const (
+	rockyDir = "rocky"
+)
+
+var (
+	platformFormat = "rocky %s"
+	targetReleases = []string{"8"}
+	targetRepos    = []string{"BaseOS", "AppStream", "Devel"}
+	targetArches   = []string{"x86_64"}
+)
+
+type VulnSrc struct {
+	dbc db.Operation
+}
+
+func NewVulnSrc() VulnSrc {
+	return VulnSrc{
+		dbc: db.Config{},
+	}
+}
+
+func (vs VulnSrc) Name() string {
+	return vulnerability.Rocky
+}
+
+func (vs VulnSrc) Update(dir string) error {
+	rootDir := filepath.Join(dir, "vuln-list", rockyDir)
+	errata := map[string][]RLSA{}
+	err := utils.FileWalk(rootDir, func(r io.Reader, path string) error {
+		var erratum RLSA
+		if err := json.NewDecoder(r).Decode(&erratum); err != nil {
+			return xerrors.Errorf("failed to decode Rocky erratum: %w", err)
+		}
+
+		dirs := strings.Split(path, string(filepath.Separator))
+		if len(dirs) < 5 {
+			log.Printf("invalid path: %s\n", path)
+			return nil
+		}
+
+		majorVer := dirs[len(dirs)-5]
+		if !utils.StringInSlice(majorVer, targetReleases) {
+			log.Printf("unsupported Rocky version: %s\n", majorVer)
+			return nil
+		}
+		repo := dirs[len(dirs)-4]
+		if !utils.StringInSlice(repo, targetRepos) {
+			log.Printf("unsupported Rocky repo: %s\n", repo)
+			return nil
+		}
+		arch := dirs[len(dirs)-3]
+		if !utils.StringInSlice(arch, targetArches) {
+			switch arch {
+			case "aarch64":
+			default:
+				log.Printf("unsupported Rocky arch: %s\n", arch)
+			}
+			return nil
+		}
+
+		errata[majorVer] = append(errata[majorVer], erratum)
+		return nil
+	})
+	if err != nil {
+		return xerrors.Errorf("error in Rocky walk: %w", err)
+	}
+
+	if err := vs.save(errata); err != nil {
+		return xerrors.Errorf("error in Rocky save: %w", err)
+	}
+
+	return nil
+}
+
+func (vs VulnSrc) save(errataVer map[string][]RLSA) error {
+	err := vs.dbc.BatchUpdate(func(tx *bolt.Tx) error {
+		for majorVer, errata := range errataVer {
+			platformName := fmt.Sprintf(platformFormat, majorVer)
+			if err := vs.commit(tx, platformName, errata); err != nil {
+				return xerrors.Errorf("error in save Rocky %s: %w", majorVer, err)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return xerrors.Errorf("error in db batch update: %w", err)
+	}
+	return nil
+}
+
+func (vs VulnSrc) commit(tx *bolt.Tx, platformName string, errata []RLSA) error {
+	for _, erratum := range errata {
+		for _, cveID := range erratum.CveIDs {
+			for _, pkg := range erratum.Packages {
+				advisory := types.Advisory{
+					FixedVersion: constructVersion(pkg.Epoch, pkg.Version, pkg.Release),
+				}
+				if err := vs.dbc.PutAdvisoryDetail(tx, cveID, platformName, pkg.Name, advisory); err != nil {
+					return xerrors.Errorf("failed to save Rocky advisory: %w", err)
+				}
+
+				var references []string
+				for _, ref := range erratum.References {
+					references = append(references, ref.Href)
+				}
+
+				vuln := types.VulnerabilityDetail{
+					Severity:    generalizeSeverity(erratum.Severity),
+					References:  references,
+					Title:       erratum.Title,
+					Description: erratum.Description,
+				}
+				if err := vs.dbc.PutVulnerabilityDetail(tx, cveID, vulnerability.Rocky, vuln); err != nil {
+					return xerrors.Errorf("failed to save Rocky vulnerability: %w", err)
+				}
+
+				if err := vs.dbc.PutVulnerabilityID(tx, cveID); err != nil {
+					return xerrors.Errorf("failed to save the vulnerability ID: %w", err)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (vs VulnSrc) Get(release, pkgName string) ([]types.Advisory, error) {
+	bucket := fmt.Sprintf(platformFormat, release)
+	advisories, err := vs.dbc.GetAdvisories(bucket, pkgName)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to get Rocky advisories: %w", err)
+	}
+	return advisories, nil
+}
+
+func constructVersion(epoch, version, release string) string {
+	verStr := ""
+	if epoch != "0" && epoch != "" {
+		verStr += fmt.Sprintf("%s:", epoch)
+	}
+	verStr += version
+
+	if release != "" {
+		verStr += fmt.Sprintf("-%s", release)
+
+	}
+	return verStr
+}
+
+func generalizeSeverity(severity string) types.Severity {
+	switch strings.ToLower(severity) {
+	case "low":
+		return types.SeverityLow
+	case "moderate":
+		return types.SeverityMedium
+	case "important":
+		return types.SeverityHigh
+	case "critical":
+		return types.SeverityCritical
+	}
+	return types.SeverityUnknown
+}

--- a/pkg/vulnsrc/rocky/rocky_test.go
+++ b/pkg/vulnsrc/rocky/rocky_test.go
@@ -41,6 +41,11 @@ func TestVulnSrc_Update(t *testing.T) {
 			},
 		},
 		{
+			name:       "skip advisories for modular package",
+			dir:        filepath.Join("testdata", "modular"),
+			wantValues: []want{},
+		},
+		{
 			name:    "sad path",
 			dir:     filepath.Join("testdata", "sad"),
 			wantErr: "failed to decode Rocky erratum",

--- a/pkg/vulnsrc/rocky/rocky_test.go
+++ b/pkg/vulnsrc/rocky/rocky_test.go
@@ -4,17 +4,19 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/aquasecurity/trivy-db/pkg/db"
 	"github.com/aquasecurity/trivy-db/pkg/dbtest"
 	"github.com/aquasecurity/trivy-db/pkg/types"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/vulnerability"
 )
 
 func TestVulnSrc_Update(t *testing.T) {
 	type want struct {
 		key   []string
-		value types.Advisory
+		value interface{}
 	}
 	tests := []struct {
 		name       string
@@ -37,6 +39,21 @@ func TestVulnSrc_Update(t *testing.T) {
 					value: types.Advisory{
 						FixedVersion: "32:9.11.26-4.el8_4",
 					},
+				},
+				{
+					key: []string{"vulnerability-detail", "CVE-2021-25215", vulnerability.Rocky},
+					value: types.VulnerabilityDetail{
+						Severity: types.SeverityHigh,
+						References: []string{
+							"https://access.redhat.com/hydra/rest/securitydata/cve/CVE-2021-25215.json",
+						},
+						Title:       "Important: bind security update",
+						Description: "For more information visit https://errata.rockylinux.org/RLSA-2021:1989",
+					},
+				},
+				{
+					key:   []string{"vulnerability-id", "CVE-2021-25215"},
+					value: map[string]interface{}{},
 				},
 			},
 		},
@@ -62,7 +79,7 @@ func TestVulnSrc_Update(t *testing.T) {
 			vs := NewVulnSrc()
 			err = vs.Update(tt.dir)
 			if tt.wantErr != "" {
-				require.NotNil(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)
 				return
 			}

--- a/pkg/vulnsrc/rocky/rocky_test.go
+++ b/pkg/vulnsrc/rocky/rocky_test.go
@@ -1,0 +1,72 @@
+package rocky
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/aquasecurity/trivy-db/pkg/db"
+	"github.com/aquasecurity/trivy-db/pkg/dbtest"
+	"github.com/aquasecurity/trivy-db/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVulnSrc_Update(t *testing.T) {
+	type want struct {
+		key   []string
+		value types.Advisory
+	}
+	tests := []struct {
+		name       string
+		dir        string
+		wantValues []want
+		wantErr    string
+	}{
+		{
+			name: "happy path",
+			dir:  filepath.Join("testdata", "happy"),
+			wantValues: []want{
+				{
+					key: []string{"advisory-detail", "CVE-2021-25215", "rocky 8", "bind-export-libs"},
+					value: types.Advisory{
+						FixedVersion: "32:9.11.26-4.el8_4",
+					},
+				},
+				{
+					key: []string{"advisory-detail", "CVE-2021-25215", "rocky 8", "bind-export-devel"},
+					value: types.Advisory{
+						FixedVersion: "32:9.11.26-4.el8_4",
+					},
+				},
+			},
+		},
+		{
+			name:    "sad path",
+			dir:     filepath.Join("testdata", "sad"),
+			wantErr: "failed to decode Rocky erratum",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+
+			err := db.Init(tempDir)
+			require.NoError(t, err)
+			defer db.Close()
+
+			vs := NewVulnSrc()
+			err = vs.Update(tt.dir)
+			if tt.wantErr != "" {
+				require.NotNil(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NoError(t, db.Close()) // Need to close before dbtest.JSONEq is called
+			for _, want := range tt.wantValues {
+				dbtest.JSONEq(t, db.Path(tempDir), want.key, want.value)
+			}
+		})
+	}
+}

--- a/pkg/vulnsrc/rocky/testdata/happy/vuln-list/rocky/8/BaseOS/x86_64/2021/RLSA-2021-1989.json
+++ b/pkg/vulnsrc/rocky/testdata/happy/vuln-list/rocky/8/BaseOS/x86_64/2021/RLSA-2021-1989.json
@@ -1,0 +1,57 @@
+{
+  "id": "RLSA-2021:1989",
+  "title": "Important: bind security update",
+  "issued": {
+    "date": "2021-07-22 03:17:17"
+  },
+  "updated": {
+    "date": "2021-05-18 00:00:00"
+  },
+  "severity": "Important",
+  "description": "For more information visit https://errata.rockylinux.org/RLSA-2021:1989",
+  "packages": [
+    {
+      "name": "bind-export-libs",
+      "epoch": "32",
+      "version": "9.11.26",
+      "release": "4.el8_4",
+      "arch": "i686",
+      "filename": "bind-export-libs-9.11.26-4.el8_4.i686.rpm"
+    },
+    {
+      "name": "bind-export-libs",
+      "epoch": "32",
+      "version": "9.11.26",
+      "release": "4.el8_4",
+      "arch": "x86_64",
+      "filename": "bind-export-libs-9.11.26-4.el8_4.x86_64.rpm"
+    },
+    {
+      "name": "bind-export-devel",
+      "epoch": "32",
+      "version": "9.11.26",
+      "release": "4.el8_4",
+      "arch": "x86_64",
+      "filename": "bind-export-devel-9.11.26-4.el8_4.x86_64.rpm"
+    },
+    {
+      "name": "bind-export-devel",
+      "epoch": "32",
+      "version": "9.11.26",
+      "release": "4.el8_4",
+      "arch": "i686",
+      "filename": "bind-export-devel-9.11.26-4.el8_4.i686.rpm"
+    }
+  ],
+  "references": [
+    {
+      "href": "https://access.redhat.com/hydra/rest/securitydata/cve/CVE-2021-25215.json",
+      "id": "CVE-2021-25215",
+      "title": "Update information for CVE-2021-25215 is retrieved from Red Hat",
+      "type": "cve"
+    }
+  ],
+  "cveids": [
+    "CVE-2021-25215"
+  ]
+}

--- a/pkg/vulnsrc/rocky/testdata/modular/vuln-list/rocky/8/BaseOS/x86_64/2021/RLSA-2021-1979.json
+++ b/pkg/vulnsrc/rocky/testdata/modular/vuln-list/rocky/8/BaseOS/x86_64/2021/RLSA-2021-1979.json
@@ -1,0 +1,39 @@
+{
+  "id": "RLSA-2021:1979",
+  "title": "Important: squid:4 security update",
+  "issued": {
+    "date": "2021-07-22 03:16:49"
+  },
+  "updated": {
+    "date": "2021-05-18 00:00:00"
+  },
+  "severity": "Important",
+  "description": "For more information visit https://errata.rockylinux.org/RLSA-2021:1979",
+  "packages": [
+    {
+      "name": "libecap",
+      "epoch": "0",
+      "version": "1.0.1",
+      "release": "2.module+el8.4.0+404+316a0dc5",
+      "arch": "x86_64",
+      "filename": "libecap-1.0.1-2.module+el8.4.0+404+316a0dc5.x86_64.rpm"
+    },
+    {
+      "name": "libecap-devel",
+      "epoch": "0",
+      "version": "1.0.1",
+      "release": "2.module+el8.4.0+404+316a0dc5",
+      "arch": "x86_64",
+      "filename": "libecap-devel-1.0.1-2.module+el8.4.0+404+316a0dc5.x86_64.rpm"
+    }
+  ],
+  "references": [
+    {
+      "href": "https://access.redhat.com/hydra/rest/securitydata/cve/CVE-2020-25097.json",
+      "id": "CVE-2020-25097",
+      "title": "Update information for CVE-2020-25097 is retrieved from Red Hat",
+      "type": "cve"
+    }
+  ],
+  "cveids": ["CVE-2020-25097"]
+}

--- a/pkg/vulnsrc/rocky/testdata/sad/vuln-list/rocky/8/BaseOS/x86_64/2021/RLSA-2021-1989.json
+++ b/pkg/vulnsrc/rocky/testdata/sad/vuln-list/rocky/8/BaseOS/x86_64/2021/RLSA-2021-1989.json
@@ -1,0 +1,57 @@
+{
+  "id": "RLSA-2021:1989"
+  "title": "Important: bind security update",
+  "issued": {
+    "date": "2021-07-22 03:17:17"
+  },
+  "updated": {
+    "date": "2021-05-18 00:00:00"
+  },
+  "severity": "Important",
+  "description": "For more information visit https://errata.rockylinux.org/RLSA-2021:1989",
+  "packages": [
+    {
+      "name": "bind-export-libs",
+      "epoch": "32",
+      "version": "9.11.26",
+      "release": "4.el8_4",
+      "arch": "i686",
+      "filename": "bind-export-libs-9.11.26-4.el8_4.i686.rpm"
+    },
+    {
+      "name": "bind-export-libs",
+      "epoch": "32",
+      "version": "9.11.26",
+      "release": "4.el8_4",
+      "arch": "x86_64",
+      "filename": "bind-export-libs-9.11.26-4.el8_4.x86_64.rpm"
+    },
+    {
+      "name": "bind-export-devel",
+      "epoch": "32",
+      "version": "9.11.26",
+      "release": "4.el8_4",
+      "arch": "x86_64",
+      "filename": "bind-export-devel-9.11.26-4.el8_4.x86_64.rpm"
+    },
+    {
+      "name": "bind-export-devel",
+      "epoch": "32",
+      "version": "9.11.26",
+      "release": "4.el8_4",
+      "arch": "i686",
+      "filename": "bind-export-devel-9.11.26-4.el8_4.i686.rpm"
+    }
+  ],
+  "references": [
+    {
+      "href": "https://access.redhat.com/hydra/rest/securitydata/cve/CVE-2021-25215.json",
+      "id": "CVE-2021-25215",
+      "title": "Update information for CVE-2021-25215 is retrieved from Red Hat",
+      "type": "cve"
+    }
+  ],
+  "cveids": [
+    "CVE-2021-25215"
+  ]
+}

--- a/pkg/vulnsrc/rocky/types.go
+++ b/pkg/vulnsrc/rocky/types.go
@@ -2,36 +2,29 @@ package rocky
 
 // RLSA has detailed data of RLSA
 type RLSA struct {
-	ID          string      `xml:"id" json:"id,omitempty"`
-	Title       string      `xml:"title" json:"title,omitempty"`
-	Issued      Date        `xml:"issued" json:"issued,omitempty"`
-	Updated     Date        `xml:"updated" json:"updated,omitempty"`
-	Severity    string      `xml:"severity" json:"severity,omitempty"`
-	Description string      `xml:"description" json:"description,omitempty"`
-	Packages    []Package   `xml:"pkglist>collection>package" json:"packages,omitempty"`
-	References  []Reference `xml:"references>reference" json:"references,omitempty"`
+	ID          string      `json:"id,omitempty"`
+	Title       string      `json:"title,omitempty"`
+	Severity    string      `json:"severity,omitempty"`
+	Description string      `json:"description,omitempty"`
+	Packages    []Package   `json:"packages,omitempty"`
+	References  []Reference `json:"references,omitempty"`
 	CveIDs      []string    `json:"cveids,omitempty"`
-}
-
-// Date has time information
-type Date struct {
-	Date string `xml:"date,attr" json:"date,omitempty"`
 }
 
 // Reference has reference information
 type Reference struct {
-	Href  string `xml:"href,attr" json:"href,omitempty"`
-	ID    string `xml:"id,attr" json:"id,omitempty"`
-	Title string `xml:"title,attr" json:"title,omitempty"`
-	Type  string `xml:"type,attr" json:"type,omitempty"`
+	Href  string `json:"href,omitempty"`
+	ID    string `json:"id,omitempty"`
+	Title string `json:"title,omitempty"`
+	Type  string `json:"type,omitempty"`
 }
 
 // Package has affected package information
 type Package struct {
-	Name     string `xml:"name,attr" json:"name,omitempty"`
-	Epoch    string `xml:"epoch,attr" json:"epoch,omitempty"`
-	Version  string `xml:"version,attr" json:"version,omitempty"`
-	Release  string `xml:"release,attr" json:"release,omitempty"`
-	Arch     string `xml:"arch,attr" json:"arch,omitempty"`
-	Filename string `xml:"filename" json:"filename,omitempty"`
+	Name     string `json:"name,omitempty"`
+	Epoch    string `json:"epoch,omitempty"`
+	Version  string `json:"version,omitempty"`
+	Release  string `json:"release,omitempty"`
+	Arch     string `json:"arch,omitempty"`
+	Filename string `json:"filename,omitempty"`
 }

--- a/pkg/vulnsrc/rocky/types.go
+++ b/pkg/vulnsrc/rocky/types.go
@@ -1,0 +1,37 @@
+package rocky
+
+// RLSA has detailed data of RLSA
+type RLSA struct {
+	ID          string      `xml:"id" json:"id,omitempty"`
+	Title       string      `xml:"title" json:"title,omitempty"`
+	Issued      Date        `xml:"issued" json:"issued,omitempty"`
+	Updated     Date        `xml:"updated" json:"updated,omitempty"`
+	Severity    string      `xml:"severity" json:"severity,omitempty"`
+	Description string      `xml:"description" json:"description,omitempty"`
+	Packages    []Package   `xml:"pkglist>collection>package" json:"packages,omitempty"`
+	References  []Reference `xml:"references>reference" json:"references,omitempty"`
+	CveIDs      []string    `json:"cveids,omitempty"`
+}
+
+// Date has time information
+type Date struct {
+	Date string `xml:"date,attr" json:"date,omitempty"`
+}
+
+// Reference has reference information
+type Reference struct {
+	Href  string `xml:"href,attr" json:"href,omitempty"`
+	ID    string `xml:"id,attr" json:"id,omitempty"`
+	Title string `xml:"title,attr" json:"title,omitempty"`
+	Type  string `xml:"type,attr" json:"type,omitempty"`
+}
+
+// Package has affected package information
+type Package struct {
+	Name     string `xml:"name,attr" json:"name,omitempty"`
+	Epoch    string `xml:"epoch,attr" json:"epoch,omitempty"`
+	Version  string `xml:"version,attr" json:"version,omitempty"`
+	Release  string `xml:"release,attr" json:"release,omitempty"`
+	Arch     string `xml:"arch,attr" json:"arch,omitempty"`
+	Filename string `xml:"filename" json:"filename,omitempty"`
+}

--- a/pkg/vulnsrc/vulnerability/const.go
+++ b/pkg/vulnsrc/vulnerability/const.go
@@ -9,6 +9,7 @@ const (
 	DebianOVAL            = "debian-oval"
 	Ubuntu                = "ubuntu"
 	CentOS                = "centos"
+	Rocky                 = "rocky"
 	Fedora                = "fedora"
 	Amazon                = "amazon"
 	OracleOVAL            = "oracle-oval"

--- a/pkg/vulnsrc/vulnerability/vulnerability.go
+++ b/pkg/vulnsrc/vulnerability/vulnerability.go
@@ -17,7 +17,7 @@ const (
 )
 
 var (
-	sources = []string{NVD, RedHat, Debian, DebianOVAL, Ubuntu, Alpine, Amazon, OracleOVAL, SuseCVRF, Photon, ArchLinux, Alma,
+	sources = []string{NVD, RedHat, Debian, DebianOVAL, Ubuntu, Alpine, Amazon, OracleOVAL, SuseCVRF, Photon, ArchLinux, Alma, Rocky,
 		RubySec, PhpSecurityAdvisories, NodejsSecurityWg,
 		GHSAComposer, GHSAMaven, GHSANpm, GHSANuget, GHSAPip, GHSARubygems, GLAD, OSVPyPI, OSVGo, OSVCratesio,
 	}

--- a/pkg/vulnsrc/vulnsrc.go
+++ b/pkg/vulnsrc/vulnsrc.go
@@ -18,6 +18,7 @@ import (
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/photon"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/redhat"
 	redhatoval "github.com/aquasecurity/trivy-db/pkg/vulnsrc/redhat-oval"
+	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/rocky"
 	susecvrf "github.com/aquasecurity/trivy-db/pkg/vulnsrc/suse-cvrf"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/ubuntu"
 )
@@ -43,6 +44,7 @@ var (
 		ubuntu.NewVulnSrc(),
 		amazon.NewVulnSrc(),
 		oracleoval.NewVulnSrc(),
+		rocky.NewVulnSrc(),
 		susecvrf.NewVulnSrc(susecvrf.SUSEEnterpriseLinux),
 		susecvrf.NewVulnSrc(susecvrf.OpenSUSE),
 		photon.NewVulnSrc(),


### PR DESCRIPTION
# Overview
This PR(https://github.com/aquasecurity/vuln-list-update/pull/107) adds Rocky Linux to the vuln-list.
So, let's add Rocky Linux to trivy-db.

```console
$ ./trivy-db build --cache-dir ~/.cache/vuln-list-update --only-update rocky
2021/09/22 13:42:57 Updating vulnerability database...
2021/09/22 13:42:57 Updating rocky data...
```

refs. https://github.com/aquasecurity/trivy/issues/1053

# PRs
Need to merge the below PRs first
- https://github.com/aquasecurity/vuln-list-update/pull/107