### PR TITLE
fix(safety-db): use pyup id instead of PVE-ID

### DIFF
--- a/pkg/vulnsrc/python/python.go
+++ b/pkg/vulnsrc/python/python.go
@@ -92,10 +92,12 @@ func (vs VulnSrc) update(repoPath string) error {
 func (vs VulnSrc) commit(tx *bolt.Tx, advisoryDB AdvisoryDB) error {
 	for pkgName, advisories := range advisoryDB {
 		for _, advisory := range advisories {
-			vulnerabilityIDs := strings.Split(advisory.Cve, ",")
-			for _, vulnerabilityID := range vulnerabilityIDs {
-				vulnerabilityID := strings.TrimSpace(vulnerabilityID)
-				if vulnerabilityID == "" {
+			cveIDs := strings.Split(advisory.Cve, ",")
+			for _, cveID := range cveIDs {
+				vulnerabilityID := strings.TrimSpace(cveID)
+				if strings.HasPrefix(vulnerabilityID, "PVE-") {
+					continue
+				} else if vulnerabilityID == "" {
 					vulnerabilityID = advisory.ID
 				}
 

--- a/pkg/vulnsrc/python/python.go
+++ b/pkg/vulnsrc/python/python.go
@@ -95,9 +95,7 @@ func (vs VulnSrc) commit(tx *bolt.Tx, advisoryDB AdvisoryDB) error {
 			cveIDs := strings.Split(advisory.Cve, ",")
 			for _, cveID := range cveIDs {
 				vulnerabilityID := strings.TrimSpace(cveID)
-				if strings.HasPrefix(vulnerabilityID, "PVE-") {
-					continue
-				} else if vulnerabilityID == "" {
+				if strings.HasPrefix(vulnerabilityID, "PVE-") || vulnerabilityID == "" {
 					vulnerabilityID = advisory.ID
 				}
 


### PR DESCRIPTION
## Description
Some advisories in safety-db have the prefix of "PVE-" and it doesn't make sense. We should use pyup id in that case.