### PR TITLE
chore: move to GitHub Packages Container registry

### DIFF
--- a/.github/workflows/cron-gh-releases.yml
+++ b/.github/workflows/cron-gh-releases.yml
@@ -1,0 +1,71 @@
+---
+# Trivy DB was migrated from GitHub Releases to GitHub Packages Container registry,
+# but we still need to publish it in GitHub Releases for backward compatibility.
+# This workflow is planned to be removed on May 2022.
+name: Trivy DB - GitHub Releases
+on:
+  schedule:
+    - cron: '30 */6 * * *'
+  workflow_dispatch:
+jobs:
+  build:
+    name: Build DB
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
+        id: go
+
+      - name: Install bbolt
+        run: go install go.etcd.io/bbolt/cmd/bbolt@v1.3.5
+
+      # Checkout "github-releases" branch
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+        with:
+          ref: "github-releases"
+
+      - name: Download vuln-list and advisories
+        run: make db-fetch-langs db-fetch-vuln-list-main
+
+      - name: Build the binary
+        run: make build
+      #
+      # Full DB
+      #
+      - name: Build full database
+        run: make db-build
+
+      - name: Compact DB
+        run: make db-compact
+
+      - name: Compress assets
+        run: make db-compress
+
+      #
+      # Light DB
+      #
+      - name: Build light database
+        run: make db-build
+        env:
+          DB_TYPE: trivy-light
+
+      - name: Compact DB
+        run: make db-compact
+        env:
+          DB_TYPE: trivy-light
+
+      - name: Compress assets
+        run: make db-compress
+        env:
+          DB_TYPE: trivy-light
+
+      #
+      # Upload
+      #
+      - name: Upload assets
+        run: ./trivy-db upload --dir assets
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -51,8 +51,9 @@ jobs:
 
       - name: Upload assets to GHCR
         run: |
-          oras push ghcr.io/${{ github.repository }}:${{ env.VERSION }} \
-            --manifest-config /dev/null:application/vnd.aquasec.trivy.config.v1+json \
-            db.tar.gz:application/vnd.aquasec.trivy.db.layer.v1.tar+gzip
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          tags=(latest ${{ env.VERSION }})
+          for tag in ${tags[@]}; do
+            oras push ghcr.io/${{ github.repository }}:${tag} \
+              --manifest-config /dev/null:application/vnd.aquasec.trivy.config.v1+json \
+              db.tar.gz:application/vnd.aquasec.trivy.db.layer.v1.tar+gzip
+          done

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: '0 */6 * * *'
   workflow_dispatch:
+env:
+  GH_USER: aqua-bot
+  VERSION: 1
 jobs:
   build:
     name: Build DB
@@ -19,17 +22,15 @@ jobs:
         run: go install go.etcd.io/bbolt/cmd/bbolt@v1.3.5
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: Download vuln-list and advisories
         run: make db-fetch-langs db-fetch-vuln-list-main
 
       - name: Build the binary
         run: make build
-      #
-      # Full DB
-      #
-      - name: Build full database
+
+      - name: Build database
         run: make db-build
 
       - name: Compact DB
@@ -38,28 +39,20 @@ jobs:
       - name: Compress assets
         run: make db-compress
 
-      #
-      # Light DB
-      #
-      - name: Build light database
-        run: make db-build
-        env:
-          DB_TYPE: trivy-light
+      - name: Rename
+        run: mv assets/trivy-offline.db.tgz db.tar.gz
 
-      - name: Compact DB
-        run: make db-compact
-        env:
-          DB_TYPE: trivy-light
+      - name: Login to GitHub Packages Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ env.GH_USER }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Compress assets
-        run: make db-compress
-        env:
-          DB_TYPE: trivy-light
-
-      #
-      # Upload
-      #
-      - name: Upload assets
-        run: ./trivy-db upload --dir assets
+      - name: Upload assets to GHCR
+        run: |
+          oras push ghcr.io/${{ github.repository }}:${{ env.VERSION }} \
+            --manifest-config /dev/null:application/vnd.aquasec.trivy.config.v1+json \
+            db.tar.gz:application/vnd.aquasec.trivy.db.layer.v1.tar+gzip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Overview
We move Trivy DB from GitHub Releases to GitHub Packages Container registry. There are many benefits.

- Tagging like container images
  - Trivy client easily switch schema versions. For instance, ghcr.io/aquasecurity/trivy-db:v1 to ghcr.io/aquasecurity/trivy-db:v2. It is really helpful when we add breaking change.
- No need GITHUB_TOKEN
  - Organizations who download Trivy DB from GitHub Releases many times currently need to set GITHUB_TOKEN for rate limiting. GHCR doesn't need it at the moment.
- Update the same tag
  - GitHub Releases doesn't support replacing assets in the same tag/release. That's why we needed to create a unique tag/release such as `v1-2021110312` every time. See [Releases](https://github.com/aquasecurity/trivy-db/releases). It is a workaround.
  - GHCR allows it so that we can continue to update the same tag.
- Statistics
  - GHCR provides statistics like download activity per day/week/30 days
- Flexible
  - GHCR is compatible with OCI registry and provides manifest and config as well as container images. We can change the behavior of the client according to the specification in the future.
- The same endpoint as [AppShield](https://github.com/aquasecurity/appshield/pkgs/container/appshield)
  - Users under any proxy need to add URLs to allow list. They can add only https://ghcr.io/aquasecurity for both AppShield and Trivy DB.