### PR TITLE
chore: bump up Go to 1.17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15-alpine as builder
+FROM golang:1.17-alpine as builder
 
 ARG DB_TYPE=trivy
 


### PR DESCRIPTION
The job is failing now due to the old Go version in Dockerfile.
https://github.com/aquasecurity/trivy-db/runs/4589164324?check_suite_focus=true