### PR TITLE
chore(release): rename the target name

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Download vuln-list and advisories
-        run: make db-fetch-langs db-fetch-vuln-list-main
+        run: make db-fetch-langs db-fetch-vuln-list
 
       - name: Build the binary
         run: make build


### PR DESCRIPTION
## Description
`db-fetch-vuln-list-main` no longer exists. Fix the following error.
https://github.com/aquasecurity/trivy-db/actions/runs/1662893170
