### PR TITLE
Improve error messaging when vulnerability details are missing

### DIFF
--- a/pkg/db/vulnerability.go
+++ b/pkg/db/vulnerability.go
@@ -25,7 +25,7 @@ func (dbc Config) GetVulnerability(cveID string) (vuln types.Vulnerability, err 
 		bucket := tx.Bucket([]byte(vulnerabilityBucket))
 		value := bucket.Get([]byte(cveID))
 		if value == nil {
-			return xerrors.New("no extra details for this vulnerability")
+			return xerrors.Errorf("no vulnerability details for %s", cveID)
 		}
 		if err = json.Unmarshal(value, &vuln); err != nil {
 			return xerrors.Errorf("failed to unmarshal JSON: %w", err)

--- a/pkg/db/vulnerability.go
+++ b/pkg/db/vulnerability.go
@@ -24,13 +24,16 @@ func (dbc Config) GetVulnerability(cveID string) (vuln types.Vulnerability, err 
 	err = db.View(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket([]byte(vulnerabilityBucket))
 		value := bucket.Get([]byte(cveID))
+		if value == nil {
+			return xerrors.New("no extra details for this vulnerability")
+		}
 		if err = json.Unmarshal(value, &vuln); err != nil {
-			return xerrors.Errorf("failed to marshal JSON: %w", err)
+			return xerrors.Errorf("failed to unmarshal JSON: %w", err)
 		}
 		return nil
 	})
 	if err != nil {
-		return types.Vulnerability{}, xerrors.Errorf("failed to get the vulnerability: %w", err)
+		return types.Vulnerability{}, xerrors.Errorf("failed to get the vulnerability %q: %w", cveID, err)
 	}
 	return vuln, nil
 }


### PR DESCRIPTION
When a vulnerability does not exist in the vulnerabilities bucket, `bucket.Get` returns an empty byte array, which cannot be parsed by `json.Unmarshal`. This causes warnings to appear in the Trivy output for vulnerabilities which don't have an item in the `vulnerabilities` bucket. 

```
$ trivy i registry.gitlab.com/gitlab-org/security-products/dast/webgoat-8.0@sha256:bc09fe2e0721dfaeee79364115aeedf2174cce0947b9ae5fe7c33312ee019a4e | head -n 28
2022-02-14T08:22:03.170-0600    INFO    Detected OS: debian
2022-02-14T08:22:03.170-0600    INFO    Detecting Debian vulnerabilities...
2022-02-14T08:22:03.184-0600    INFO    Number of language-specific files: 1
2022-02-14T08:22:03.184-0600    INFO    Detecting jar vulnerabilities...
2022-02-14T08:22:03.189-0600    WARN    Error while getting vulnerability details: failed to get the vulnerability: failed to marshal JSON: unexpected end of JSON input

2022-02-14T08:22:03.192-0600    WARN    Error while getting vulnerability details: failed to get the vulnerability: failed to marshal JSON: unexpected end of JSON input

2022-02-14T08:22:03.194-0600    WARN    Error while getting vulnerability details: failed to get the vulnerability: failed to marshal JSON: unexpected end of JSON input

2022-02-14T08:22:03.196-0600    WARN    Error while getting vulnerability details: failed to get the vulnerability: failed to marshal JSON: unexpected end of JSON input

2022-02-14T08:22:03.197-0600    WARN    Error while getting vulnerability details: failed to get the vulnerability: failed to marshal JSON: unexpected end of JSON input

2022-02-14T08:22:03.199-0600    WARN    Error while getting vulnerability details: failed to get the vulnerability: failed to marshal JSON: unexpected end of JSON input

2022-02-14T08:22:03.203-0600    WARN    Error while getting vulnerability details: failed to get the vulnerability: failed to marshal JSON: unexpected end of JSON input

2022-02-14T08:22:03.203-0600    WARN    Error while getting vulnerability details: failed to get the vulnerability: failed to marshal JSON: unexpected end of JSON input

2022-02-14T08:22:03.203-0600    WARN    Error while getting vulnerability details: failed to get the vulnerability: failed to marshal JSON: unexpected end of JSON input

2022-02-14T08:22:03.203-0600    WARN    Error while getting vulnerability details: failed to get the vulnerability: failed to marshal JSON: unexpected end of JSON input


registry.gitlab.com/gitlab-org/security-products/dast/webgoat-8.0@sha256:bc09fe2e0721dfaeee79364115aeedf2174cce0947b9ae5fe7c33312ee019a4e (debian 9.4)
======================================================================================================================================================
```

I believe that returning an error here is correct, because Trivy expects `types.Vulnerability` to be filled if there is no error: https://github.com/aquasecurity/trivy/blob/219b71b4fd080ea90bdc13abb530946dc10b55d6/pkg/result/result.go#L61

However, I think that the error message could be more helpful. This MR adds the vulnerability ID to the error message so that the user can check to see if they are affected by the missing data. Additionally, when the vulnerability isn't in the DB, we state that instead of showing a JSON parse error. 