### PR TITLE
fix(suse): added vulnerabilities for SUSE Enterprise Server

### DIFF
--- a/pkg/vulnsrc/suse-cvrf/suse-cvrf.go
+++ b/pkg/vulnsrc/suse-cvrf/suse-cvrf.go
@@ -55,14 +55,10 @@ func NewVulnSrc(dist Distribution) VulnSrc {
 }
 
 func (vs VulnSrc) Name() types.SourceID {
-	suffix := ""
-	switch vs.dist {
-	case SUSEEnterpriseLinux:
-		suffix = "suse"
-	case OpenSUSE:
-		suffix = "opensuse"
+	if vs.dist == OpenSUSE {
+		return "opensuse-cvrf"
 	}
-	return types.SourceID(fmt.Sprintf("%s-%s", source.ID, suffix))
+	return source.ID
 }
 
 func (vs VulnSrc) Update(dir string) error {

--- a/pkg/vulnsrc/suse-cvrf/suse-cvrf.go
+++ b/pkg/vulnsrc/suse-cvrf/suse-cvrf.go
@@ -55,7 +55,14 @@ func NewVulnSrc(dist Distribution) VulnSrc {
 }
 
 func (vs VulnSrc) Name() types.SourceID {
-	return source.ID
+	suffix := ""
+	switch vs.dist {
+	case SUSEEnterpriseLinux:
+		suffix = "suse"
+	case OpenSUSE:
+		suffix = "opensuse"
+	}
+	return types.SourceID(fmt.Sprintf("%s-%s", source.ID, suffix))
 }
 
 func (vs VulnSrc) Update(dir string) error {


### PR DESCRIPTION
## Reason
Method `Name()` of `VulnSrc` returns the same `SourceID`("suse-cvrf") for all SUSE sources.

## Solution
Return "opensuse-cvrf" for openSUSE.

Fixes #193 