### PR TITLE
feat(ubuntu): added Ubuntu ESM versions

### DIFF
--- a/pkg/vulnsrc/ubuntu/ubuntu.go
+++ b/pkg/vulnsrc/ubuntu/ubuntu.go
@@ -45,6 +45,10 @@ var (
 		"groovy":  "20.10",
 		"hirsute": "21.04",
 		"impish":  "21.10",
+		// ESM versions:
+		"precise/esm":      "12.04-ESM",
+		"trusty/esm":       "14.04-ESM",
+		"esm-infra/xenial": "16.04-ESM",
 	}
 
 	source = types.DataSource{


### PR DESCRIPTION
## Description
Added support [Ubuntu ESM versions](https://ubuntu.com/security/esm).

ESM versions format is `{version}-ESM`. e.g.: `14.04-ESM`