### PR TITLE
chore(deps): bump golangci-lint from 1.41 to 1.45.2

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,9 +18,9 @@ jobs:
       - name: yaml-lint
         uses: ibiqlik/action-yamllint@v3
       - name: Lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3.1.0
         with:
-          version: v1.41
+          version: v1.45.2
           args: -D errcheck
 
       - name: Test

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/urfave/cli v1.22.5
 	go.etcd.io/bbolt v1.3.5
+	golang.org/x/text v0.3.2
 	golang.org/x/vuln v0.0.0-20211221130724-9d39a965865f
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 	gopkg.in/cheggaaa/pb.v1 v1.0.28

--- a/go.sum
+++ b/go.sum
@@ -131,6 +131,7 @@ golang.org/x/sys v0.0.0-20211213223007-03aa0b5f6827 h1:A0Qkn7Z/n8zC1xd9LTw17AiKl
 golang.org/x/sys v0.0.0-20211213223007-03aa0b5f6827/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=

--- a/pkg/vulnsrc/ghsa/ghsa.go
+++ b/pkg/vulnsrc/ghsa/ghsa.go
@@ -3,6 +3,8 @@ package ghsa
 import (
 	"encoding/json"
 	"fmt"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 	"io"
 	"log"
 	"path/filepath"
@@ -85,7 +87,8 @@ func (vs VulnSrc) save(ecosystem types.Ecosystem, entries []Entry) error {
 }
 
 func (vs VulnSrc) commit(tx *bolt.Tx, ecosystem types.Ecosystem, entries []Entry) error {
-	sourceName := fmt.Sprintf(platformFormat, strings.Title(string(ecosystem)))
+	ecosystemName := cases.Title(language.English).String(string(ecosystem))
+	sourceName := fmt.Sprintf(platformFormat, ecosystemName)
 	bucketName := bucket.Name(string(ecosystem), sourceName)
 	err := vs.dbc.PutDataSource(tx, bucketName, types.DataSource{
 		ID:   sourceID,

--- a/pkg/vulnsrc/redhat/redhat.go
+++ b/pkg/vulnsrc/redhat/redhat.go
@@ -3,6 +3,8 @@ package redhat
 import (
 	"encoding/json"
 	"fmt"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 	"io"
 	"io/ioutil"
 	"log"
@@ -150,7 +152,8 @@ func (vs VulnSrc) putVulnerabilityDetail(tx *bolt.Tx, cve RedhatCVE) error {
 }
 
 func severityFromThreat(sev string) types.Severity {
-	switch strings.Title(sev) {
+	severity := cases.Title(language.English).String(sev)
+	switch severity {
 	case "Low":
 		return types.SeverityLow
 	case "Moderate":


### PR DESCRIPTION
## Description
Bump [golangci-lint](https://github.com/golangci/golangci-lint) from v1.41 to v1.45.2.
`Strings.Title` function [has been deprecated](https://pkg.go.dev/strings#Title). This linter error has been fixed.