### PR TITLE
feat(Ubuntu ): support Ubuntu version 22.04

### DIFF
--- a/pkg/vulnsrc/ubuntu/ubuntu.go
+++ b/pkg/vulnsrc/ubuntu/ubuntu.go
@@ -45,6 +45,7 @@ var (
 		"groovy":  "20.10",
 		"hirsute": "21.04",
 		"impish":  "21.10",
+		"jammy":   "22.04",
 		// ESM versions:
 		"precise/esm":      "12.04-ESM",
 		"trusty/esm":       "14.04-ESM",


### PR DESCRIPTION
Add latest Ubuntu LTS version Jammy Jellyfish 22.04.
This should contribute to https://github.com/aquasecurity/trivy/issues/2043
