### PR TITLE
feat(rpm): added arch field to db

### DIFF
--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -100,7 +100,7 @@ type Advisory struct {
 
 	// Rpm packages have advisories for different architectures with same package name
 	// This field is required to separate these packages.
-	Arch string `json:"-"`
+	Arch []string `json:"-"`
 
 	// It is filled only when FixedVersion is empty since it is obvious the state is "Fixed" when FixedVersion is not empty.
 	// e.g. Will not fix and Affected

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -100,7 +100,7 @@ type Advisory struct {
 
 	// Rpm packages have advisories for different architectures with same package name
 	// This field is required to separate these packages.
-	Arch []string `json:"-"`
+	Arches []string `json:"-"`
 
 	// It is filled only when FixedVersion is empty since it is obvious the state is "Fixed" when FixedVersion is not empty.
 	// e.g. Will not fix and Affected

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -98,6 +98,10 @@ type Advisory struct {
 	VulnerabilityID string   `json:",omitempty"` // CVE-ID or vendor ID
 	VendorIDs       []string `json:",omitempty"` // e.g. RHSA-ID and DSA-ID
 
+	// Rpm packages have advisories for different architectures with same package name
+	// This field is required to separate these packages.
+	Arch string `json:"-"`
+
 	// It is filled only when FixedVersion is empty since it is obvious the state is "Fixed" when FixedVersion is not empty.
 	// e.g. Will not fix and Affected
 	State string `json:",omitempty"`

--- a/pkg/vulnsrc/redhat-oval/redhat-oval.go
+++ b/pkg/vulnsrc/redhat-oval/redhat-oval.go
@@ -414,7 +414,7 @@ func walkCriterion(cri criteria, tests map[string]rpmInfoTest) (string, []pkg) {
 		packages = append(packages, pkg{
 			Name:         t.Name,
 			FixedVersion: t.FixedVersion,
-			Arch:         t.Arch,
+			Arch:         strings.Split(t.Arch, "|"), // affected arches are merged with '|'(e.g. 'aarch64|ppc64le|x86_64')
 		})
 	}
 

--- a/pkg/vulnsrc/redhat-oval/redhat-oval.go
+++ b/pkg/vulnsrc/redhat-oval/redhat-oval.go
@@ -411,10 +411,15 @@ func walkCriterion(cri criteria, tests map[string]rpmInfoTest) (string, []pkg) {
 			continue
 		}
 
+		var arch []string
+		if t.Arch != "" {
+			arch = strings.Split(t.Arch, "|") // affected arches are merged with '|'(e.g. 'aarch64|ppc64le|x86_64')
+		}
+
 		packages = append(packages, pkg{
 			Name:         t.Name,
 			FixedVersion: t.FixedVersion,
-			Arch:         strings.Split(t.Arch, "|"), // affected arches are merged with '|'(e.g. 'aarch64|ppc64le|x86_64')
+			Arch:         arch,
 		})
 	}
 

--- a/pkg/vulnsrc/redhat-oval/redhat-oval.go
+++ b/pkg/vulnsrc/redhat-oval/redhat-oval.go
@@ -474,18 +474,12 @@ func severityFromImpact(sev string) types.Severity {
 }
 
 func archSliceEqual(a, b []string) bool {
-	switch {
-	case a == nil && b == nil:
-		return true
-	case a == nil || b == nil:
+	if len(a) != len(b) {
 		return false
-	case len(a) != len(b):
-		return false
-	default:
-		for i := range a {
-			if a[i] != b[i] {
-				return false
-			}
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
 		}
 	}
 	return true

--- a/pkg/vulnsrc/redhat-oval/redhat-oval.go
+++ b/pkg/vulnsrc/redhat-oval/redhat-oval.go
@@ -270,6 +270,7 @@ func (vs VulnSrc) Get(pkgName string, repositories, nvrs []string) ([]types.Advi
 				advisory := types.Advisory{
 					Severity:     cve.Severity,
 					FixedVersion: entry.FixedVersion,
+					Arch:         entry.Arch,
 				}
 
 				if strings.HasPrefix(vulnID, "CVE-") {
@@ -357,6 +358,7 @@ func parseDefinitions(advisories []redhatOVAL, tests map[string]rpmInfoTest, uni
 						Cves:            cveEntries,
 						FixedVersion:    affectedPkg.FixedVersion,
 						AffectedCPEList: advisory.Metadata.Advisory.AffectedCpeList,
+						Arch:            affectedPkg.Arch,
 					},
 				}
 			} else { // For unpatched vulnerabilities
@@ -374,6 +376,7 @@ func parseDefinitions(advisories []redhatOVAL, tests map[string]rpmInfoTest, uni
 							},
 							FixedVersion:    affectedPkg.FixedVersion,
 							AffectedCPEList: advisory.Metadata.Advisory.AffectedCpeList,
+							Arch:            affectedPkg.Arch,
 						},
 					}
 				}
@@ -411,6 +414,7 @@ func walkCriterion(cri criteria, tests map[string]rpmInfoTest) (string, []pkg) {
 		packages = append(packages, pkg{
 			Name:         t.Name,
 			FixedVersion: t.FixedVersion,
+			Arch:         t.Arch,
 		})
 	}
 

--- a/pkg/vulnsrc/redhat-oval/redhat-oval.go
+++ b/pkg/vulnsrc/redhat-oval/redhat-oval.go
@@ -146,8 +146,8 @@ func (vs VulnSrc) mergeAdvisories(advisories map[bucket]Advisory, defs map[bucke
 		if old, ok := advisories[bkt]; ok {
 			found := false
 			for i := range old.Entries {
-				// New advisory should contain a single fixed version.
-				if old.Entries[i].FixedVersion == def.Entry.FixedVersion {
+				// New advisory should contain a single fixed version and list of arches.
+				if old.Entries[i].FixedVersion == def.Entry.FixedVersion && archSliceEqual(old.Entries[i].Arch, def.Entry.Arch) {
 					found = true
 					old.Entries[i].AffectedCPEList = ustrings.Merge(old.Entries[i].AffectedCPEList, def.Entry.AffectedCPEList)
 				}
@@ -471,4 +471,22 @@ func severityFromImpact(sev string) types.Severity {
 		return types.SeverityCritical
 	}
 	return types.SeverityUnknown
+}
+
+func archSliceEqual(a, b []string) bool {
+	switch {
+	case a == nil && b == nil:
+		return true
+	case a == nil || b == nil:
+		return false
+	case len(a) != len(b):
+		return false
+	default:
+		for i := range a {
+			if a[i] != b[i] {
+				return false
+			}
+		}
+	}
+	return true
 }

--- a/pkg/vulnsrc/redhat-oval/redhat-oval.go
+++ b/pkg/vulnsrc/redhat-oval/redhat-oval.go
@@ -147,7 +147,7 @@ func (vs VulnSrc) mergeAdvisories(advisories map[bucket]Advisory, defs map[bucke
 			found := false
 			for i := range old.Entries {
 				// New advisory should contain a single fixed version and list of arches.
-				if old.Entries[i].FixedVersion == def.Entry.FixedVersion && archSliceEqual(old.Entries[i].Arch, def.Entry.Arch) {
+				if old.Entries[i].FixedVersion == def.Entry.FixedVersion && archesEqual(old.Entries[i].Arches, def.Entry.Arches) {
 					found = true
 					old.Entries[i].AffectedCPEList = ustrings.Merge(old.Entries[i].AffectedCPEList, def.Entry.AffectedCPEList)
 				}
@@ -270,7 +270,7 @@ func (vs VulnSrc) Get(pkgName string, repositories, nvrs []string) ([]types.Advi
 				advisory := types.Advisory{
 					Severity:     cve.Severity,
 					FixedVersion: entry.FixedVersion,
-					Arch:         entry.Arch,
+					Arches:       entry.Arches,
 				}
 
 				if strings.HasPrefix(vulnID, "CVE-") {
@@ -358,7 +358,7 @@ func parseDefinitions(advisories []redhatOVAL, tests map[string]rpmInfoTest, uni
 						Cves:            cveEntries,
 						FixedVersion:    affectedPkg.FixedVersion,
 						AffectedCPEList: advisory.Metadata.Advisory.AffectedCpeList,
-						Arch:            affectedPkg.Arch,
+						Arches:          affectedPkg.Arches,
 					},
 				}
 			} else { // For unpatched vulnerabilities
@@ -376,7 +376,7 @@ func parseDefinitions(advisories []redhatOVAL, tests map[string]rpmInfoTest, uni
 							},
 							FixedVersion:    affectedPkg.FixedVersion,
 							AffectedCPEList: advisory.Metadata.Advisory.AffectedCpeList,
-							Arch:            affectedPkg.Arch,
+							Arches:          affectedPkg.Arches,
 						},
 					}
 				}
@@ -411,15 +411,15 @@ func walkCriterion(cri criteria, tests map[string]rpmInfoTest) (string, []pkg) {
 			continue
 		}
 
-		var arch []string
+		var arches []string
 		if t.Arch != "" {
-			arch = strings.Split(t.Arch, "|") // affected arches are merged with '|'(e.g. 'aarch64|ppc64le|x86_64')
+			arches = strings.Split(t.Arch, "|") // affected arches are merged with '|'(e.g. 'aarch64|ppc64le|x86_64')
 		}
 
 		packages = append(packages, pkg{
 			Name:         t.Name,
 			FixedVersion: t.FixedVersion,
-			Arch:         arch,
+			Arches:       arches,
 		})
 	}
 
@@ -473,7 +473,7 @@ func severityFromImpact(sev string) types.Severity {
 	return types.SeverityUnknown
 }
 
-func archSliceEqual(a, b []string) bool {
+func archesEqual(a, b []string) bool {
 	if len(a) != len(b) {
 		return false
 	}

--- a/pkg/vulnsrc/redhat-oval/redhat-oval_test.go
+++ b/pkg/vulnsrc/redhat-oval/redhat-oval_test.go
@@ -86,7 +86,7 @@ func TestVulnSrc_Update(t *testing.T) {
 							{
 								FixedVersion:       "0:78.6.0-1.el8_3",
 								AffectedCPEIndices: []int{1, 2, 6},
-								Arch:               "aarch64|ppc64le|x86_64",
+								Arch:               []string{"aarch64", "ppc64le", "x86_64"},
 								Cves: []redhat.CveEntry{
 									{
 										ID:       "CVE-2020-16042",
@@ -108,7 +108,7 @@ func TestVulnSrc_Update(t *testing.T) {
 							{
 								FixedVersion:       "0:78.6.0-1.el8_3",
 								AffectedCPEIndices: []int{1, 2, 6},
-								Arch:               "aarch64|ppc64le|x86_64",
+								Arch:               []string{"aarch64", "ppc64le", "x86_64"},
 								Cves: []redhat.CveEntry{
 									{
 										ID:       "CVE-2020-16042",
@@ -130,7 +130,7 @@ func TestVulnSrc_Update(t *testing.T) {
 							{
 								FixedVersion:       "0:2.4.37-30.module+el7.3.0+7001+0766b9e7",
 								AffectedCPEIndices: []int{0, 5},
-								Arch:               "aarch64|ppc64le|s390x|x86_64",
+								Arch:               []string{"aarch64", "ppc64le", "s390x", "x86_64"},
 								Cves: []redhat.CveEntry{
 									{
 										ID:       "CVE-2018-17189",
@@ -141,7 +141,7 @@ func TestVulnSrc_Update(t *testing.T) {
 							{
 								FixedVersion:       "0:2.4.37-30.module+el8.3.0+7001+0766b9e7",
 								AffectedCPEIndices: []int{1, 2},
-								Arch:               "aarch64|ppc64le|s390x|x86_64",
+								Arch:               []string{"aarch64", "ppc64le", "s390x", "x86_64"},
 								Cves: []redhat.CveEntry{
 									{
 										ID:       "CVE-2018-17189",
@@ -159,6 +159,7 @@ func TestVulnSrc_Update(t *testing.T) {
 							{
 								FixedVersion:       "",
 								AffectedCPEIndices: []int{3, 5},
+								Arch:               []string{""},
 								Cves: []redhat.CveEntry{
 									{
 										Severity: types.SeverityLow,
@@ -175,7 +176,7 @@ func TestVulnSrc_Update(t *testing.T) {
 							{
 								FixedVersion:       "0:999.el8_3",
 								AffectedCPEIndices: []int{4},
-								Arch:               "aarch64|ppc64le|x86_64",
+								Arch:               []string{"aarch64", "ppc64le", "x86_64"},
 								Cves: []redhat.CveEntry{
 									{
 										ID:       "CVE-2020-26971",
@@ -251,7 +252,7 @@ func TestVulnSrc_Get(t *testing.T) {
 					VendorIDs:       []string{"RHSA-2018:0488"},
 					Severity:        types.SeverityHigh,
 					FixedVersion:    "32:9.9.4-29.el7_2.8",
-					Arch:            "i386|ppc64|x86_64",
+					Arch:            []string{"i386", "ppc64", "x86_64"},
 				},
 				{
 					VulnerabilityID: "CVE-2020-8625",
@@ -272,7 +273,28 @@ func TestVulnSrc_Get(t *testing.T) {
 					VendorIDs:       []string{"RHSA-2018:0488"},
 					Severity:        types.SeverityHigh,
 					FixedVersion:    "32:9.9.4-29.el7_2.8",
-					Arch:            "i386|ppc64|x86_64",
+					Arch:            []string{"i386", "ppc64", "x86_64"},
+				},
+				{
+					VulnerabilityID: "CVE-2020-8625",
+					Severity:        types.SeverityLow,
+				},
+			},
+		},
+		{
+			name: "nvr",
+			args: args{
+				pkgName: "bind",
+				nvrs:    []string{"ubi8-init-container-8.0-7-x86_64"},
+			},
+			fixtures: []string{"testdata/fixtures/happy.yaml", "testdata/fixtures/cpe.yaml"},
+			want: []types.Advisory{
+				{
+					VulnerabilityID: "CVE-2017-3145",
+					VendorIDs:       []string{"RHSA-2018:0488"},
+					Severity:        types.SeverityHigh,
+					FixedVersion:    "32:9.9.4-29.el7_2.8",
+					Arch:            []string{"i386", "ppc64", "x86_64"},
 				},
 				{
 					VulnerabilityID: "CVE-2020-8625",

--- a/pkg/vulnsrc/redhat-oval/redhat-oval_test.go
+++ b/pkg/vulnsrc/redhat-oval/redhat-oval_test.go
@@ -159,7 +159,6 @@ func TestVulnSrc_Update(t *testing.T) {
 							{
 								FixedVersion:       "",
 								AffectedCPEIndices: []int{3, 5},
-								Arch:               []string{""},
 								Cves: []redhat.CveEntry{
 									{
 										Severity: types.SeverityLow,

--- a/pkg/vulnsrc/redhat-oval/redhat-oval_test.go
+++ b/pkg/vulnsrc/redhat-oval/redhat-oval_test.go
@@ -1,11 +1,12 @@
 package redhatoval_test
 
 import (
-	"github.com/aquasecurity/trivy-db/pkg/vulnsrctest"
 	"os"
 	"path/filepath"
 	"sort"
 	"testing"
+
+	"github.com/aquasecurity/trivy-db/pkg/vulnsrctest"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -85,6 +86,7 @@ func TestVulnSrc_Update(t *testing.T) {
 							{
 								FixedVersion:       "0:78.6.0-1.el8_3",
 								AffectedCPEIndices: []int{1, 2, 6},
+								Arch:               "aarch64|ppc64le|x86_64",
 								Cves: []redhat.CveEntry{
 									{
 										ID:       "CVE-2020-16042",
@@ -106,6 +108,7 @@ func TestVulnSrc_Update(t *testing.T) {
 							{
 								FixedVersion:       "0:78.6.0-1.el8_3",
 								AffectedCPEIndices: []int{1, 2, 6},
+								Arch:               "aarch64|ppc64le|x86_64",
 								Cves: []redhat.CveEntry{
 									{
 										ID:       "CVE-2020-16042",
@@ -127,6 +130,7 @@ func TestVulnSrc_Update(t *testing.T) {
 							{
 								FixedVersion:       "0:2.4.37-30.module+el7.3.0+7001+0766b9e7",
 								AffectedCPEIndices: []int{0, 5},
+								Arch:               "aarch64|ppc64le|s390x|x86_64",
 								Cves: []redhat.CveEntry{
 									{
 										ID:       "CVE-2018-17189",
@@ -137,6 +141,7 @@ func TestVulnSrc_Update(t *testing.T) {
 							{
 								FixedVersion:       "0:2.4.37-30.module+el8.3.0+7001+0766b9e7",
 								AffectedCPEIndices: []int{1, 2},
+								Arch:               "aarch64|ppc64le|s390x|x86_64",
 								Cves: []redhat.CveEntry{
 									{
 										ID:       "CVE-2018-17189",
@@ -170,6 +175,7 @@ func TestVulnSrc_Update(t *testing.T) {
 							{
 								FixedVersion:       "0:999.el8_3",
 								AffectedCPEIndices: []int{4},
+								Arch:               "aarch64|ppc64le|x86_64",
 								Cves: []redhat.CveEntry{
 									{
 										ID:       "CVE-2020-26971",
@@ -245,6 +251,7 @@ func TestVulnSrc_Get(t *testing.T) {
 					VendorIDs:       []string{"RHSA-2018:0488"},
 					Severity:        types.SeverityHigh,
 					FixedVersion:    "32:9.9.4-29.el7_2.8",
+					Arch:            "i386|ppc64|x86_64",
 				},
 				{
 					VulnerabilityID: "CVE-2020-8625",
@@ -265,6 +272,7 @@ func TestVulnSrc_Get(t *testing.T) {
 					VendorIDs:       []string{"RHSA-2018:0488"},
 					Severity:        types.SeverityHigh,
 					FixedVersion:    "32:9.9.4-29.el7_2.8",
+					Arch:            "i386|ppc64|x86_64",
 				},
 				{
 					VulnerabilityID: "CVE-2020-8625",

--- a/pkg/vulnsrc/redhat-oval/redhat-oval_test.go
+++ b/pkg/vulnsrc/redhat-oval/redhat-oval_test.go
@@ -86,7 +86,7 @@ func TestVulnSrc_Update(t *testing.T) {
 							{
 								FixedVersion:       "0:78.6.0-1.el8_3",
 								AffectedCPEIndices: []int{1, 2, 6},
-								Arch:               []string{"aarch64", "ppc64le", "x86_64"},
+								Arches:             []string{"aarch64", "ppc64le", "x86_64"},
 								Cves: []redhat.CveEntry{
 									{
 										ID:       "CVE-2020-16042",
@@ -108,7 +108,7 @@ func TestVulnSrc_Update(t *testing.T) {
 							{
 								FixedVersion:       "0:78.6.0-1.el8_3",
 								AffectedCPEIndices: []int{1, 2, 6},
-								Arch:               []string{"aarch64", "ppc64le", "x86_64"},
+								Arches:             []string{"aarch64", "ppc64le", "x86_64"},
 								Cves: []redhat.CveEntry{
 									{
 										ID:       "CVE-2020-16042",
@@ -130,7 +130,7 @@ func TestVulnSrc_Update(t *testing.T) {
 							{
 								FixedVersion:       "0:2.4.37-30.module+el7.3.0+7001+0766b9e7",
 								AffectedCPEIndices: []int{0, 5},
-								Arch:               []string{"aarch64", "ppc64le", "s390x", "x86_64"},
+								Arches:             []string{"aarch64", "ppc64le", "s390x", "x86_64"},
 								Cves: []redhat.CveEntry{
 									{
 										ID:       "CVE-2018-17189",
@@ -141,7 +141,7 @@ func TestVulnSrc_Update(t *testing.T) {
 							{
 								FixedVersion:       "0:2.4.37-30.module+el8.3.0+7001+0766b9e7",
 								AffectedCPEIndices: []int{1, 2},
-								Arch:               []string{"aarch64", "ppc64le", "s390x", "x86_64"},
+								Arches:             []string{"aarch64", "ppc64le", "s390x", "x86_64"},
 								Cves: []redhat.CveEntry{
 									{
 										ID:       "CVE-2018-17189",
@@ -175,7 +175,7 @@ func TestVulnSrc_Update(t *testing.T) {
 							{
 								FixedVersion:       "0:999.el8_3",
 								AffectedCPEIndices: []int{4},
-								Arch:               []string{"aarch64", "ppc64le", "x86_64"},
+								Arches:             []string{"aarch64", "ppc64le", "x86_64"},
 								Cves: []redhat.CveEntry{
 									{
 										ID:       "CVE-2020-26971",
@@ -251,7 +251,7 @@ func TestVulnSrc_Get(t *testing.T) {
 					VendorIDs:       []string{"RHSA-2018:0488"},
 					Severity:        types.SeverityHigh,
 					FixedVersion:    "32:9.9.4-29.el7_2.8",
-					Arch:            []string{"i386", "ppc64", "x86_64"},
+					Arches:          []string{"i386", "ppc64", "x86_64"},
 				},
 				{
 					VulnerabilityID: "CVE-2020-8625",
@@ -272,7 +272,7 @@ func TestVulnSrc_Get(t *testing.T) {
 					VendorIDs:       []string{"RHSA-2018:0488"},
 					Severity:        types.SeverityHigh,
 					FixedVersion:    "32:9.9.4-29.el7_2.8",
-					Arch:            []string{"i386", "ppc64", "x86_64"},
+					Arches:          []string{"i386", "ppc64", "x86_64"},
 				},
 				{
 					VulnerabilityID: "CVE-2020-8625",
@@ -293,7 +293,7 @@ func TestVulnSrc_Get(t *testing.T) {
 					VendorIDs:       []string{"RHSA-2018:0488"},
 					Severity:        types.SeverityHigh,
 					FixedVersion:    "32:9.9.4-29.el7_2.8",
-					Arch:            []string{"i386", "ppc64", "x86_64"},
+					Arches:          []string{"i386", "ppc64", "x86_64"},
 				},
 				{
 					VulnerabilityID: "CVE-2020-8625",

--- a/pkg/vulnsrc/redhat-oval/testdata/fixtures/happy.yaml
+++ b/pkg/vulnsrc/redhat-oval/testdata/fixtures/happy.yaml
@@ -20,7 +20,10 @@
                 Cves:
                   - ID: CVE-2017-3145
                     Severity: 3
-                Arch: i386|ppc64|x86_64
+                Arch:
+                  - i386
+                  - ppc64
+                  - x86_64
               - FixedVersion: 32:9.9.4-50.el7_3.3
                 Affected:
                   - 3

--- a/pkg/vulnsrc/redhat-oval/testdata/fixtures/happy.yaml
+++ b/pkg/vulnsrc/redhat-oval/testdata/fixtures/happy.yaml
@@ -20,6 +20,7 @@
                 Cves:
                   - ID: CVE-2017-3145
                     Severity: 3
+                Arch: i386|ppc64|x86_64
               - FixedVersion: 32:9.9.4-50.el7_3.3
                 Affected:
                   - 3

--- a/pkg/vulnsrc/redhat-oval/types.go
+++ b/pkg/vulnsrc/redhat-oval/types.go
@@ -140,7 +140,7 @@ type evr struct {
 type pkg struct {
 	Name         string
 	FixedVersion string
-	Arch         string
+	Arch         []string
 }
 
 type bucket struct {
@@ -160,7 +160,7 @@ type Definition struct {
 type Entry struct {
 	FixedVersion string `json:",omitempty"`
 	Cves         []CveEntry
-	Arch         string `json:"Arch,omitempty"`
+	Arch         []string `json:"Arch,omitempty"`
 
 	// For DB size optimization, CPE names will not be stored.
 	// CPE indices are stored instead.

--- a/pkg/vulnsrc/redhat-oval/types.go
+++ b/pkg/vulnsrc/redhat-oval/types.go
@@ -140,6 +140,7 @@ type evr struct {
 type pkg struct {
 	Name         string
 	FixedVersion string
+	Arch         string
 }
 
 type bucket struct {
@@ -159,6 +160,7 @@ type Definition struct {
 type Entry struct {
 	FixedVersion string `json:",omitempty"`
 	Cves         []CveEntry
+	Arch         string `json:"Arch,omitempty"`
 
 	// For DB size optimization, CPE names will not be stored.
 	// CPE indices are stored instead.

--- a/pkg/vulnsrc/redhat-oval/types.go
+++ b/pkg/vulnsrc/redhat-oval/types.go
@@ -140,7 +140,7 @@ type evr struct {
 type pkg struct {
 	Name         string
 	FixedVersion string
-	Arch         []string
+	Arches       []string
 }
 
 type bucket struct {
@@ -160,7 +160,7 @@ type Definition struct {
 type Entry struct {
 	FixedVersion string `json:",omitempty"`
 	Cves         []CveEntry
-	Arch         []string `json:"Arch,omitempty"`
+	Arches       []string `json:"Arch,omitempty"`
 
 	// For DB size optimization, CPE names will not be stored.
 	// CPE indices are stored instead.


### PR DESCRIPTION
## Description
RedHat Oval database may contain advisories with same `package name` and `affected cpe list` but with different architectures.
We can get false positive for this packages.
These packages should be separated.
For this `Arch` field [was added](https://github.com/aquasecurity/trivy-db/compare/main...DmitriyLewen:feat/rpm-oval-arch?expand=1#diff-8e49337a1417a39a62ebf427e84fb2faa566c96e37ae627ac484c05dbe65c483R103) to types.Advisory structure.

Example:
`RHSA-2016:2098` and `RHSA-2017:0372` advisories have same package name(`kernel`), affected cpe list( `cpe:/o:redhat:enterprise_linux:7`), but different architectures(`ppc64|ppc64le|s390x|x86_64` and `aarch64`)
- [RHSA-2016:2098](https://www.redhat.com/security/data/oval/com.redhat.rhsa-20162098.xml): 
```xml
...
<!--line 44-56-->
<affected_cpe_list>
  <cpe>cpe:/o:redhat:enterprise_linux:7</cpe>
  <cpe>cpe:/o:redhat:enterprise_linux:7::client</cpe>
  <cpe>cpe:/o:redhat:enterprise_linux:7::computenode</cpe>
  <cpe>cpe:/o:redhat:enterprise_linux:7::server</cpe>
  <cpe>cpe:/o:redhat:enterprise_linux:7::workstation</cpe>
</affected_cpe_list>
...
<!--line 276-280-->
<criterion comment="kernel is earlier than 0:3.10.0-327.36.3.el7" test_ref="oval:com.redhat.rhsa:tst:20162098001"/>
...
<!--line 88-->
<tests>
  <rpminfo_test check="at least one" comment="kernel is earlier than 0:3.10.0-327.36.3.el7"
    id="oval:com.redhat.rhsa:tst:20162098001" version="638">
    <object object_ref="oval:com.redhat.rhsa:obj:20162098001"/>
    <state state_ref="oval:com.redhat.rhsa:ste:20162098001"/>
  </rpminfo_test>
...
<!--line 415-418-->
<objects>
  <rpminfo_object id="oval:com.redhat.rhsa:obj:20162098001" version="638">
    <name>kernel</name>
  </rpminfo_object>
...
<!--line 483-487-->
<states>
  <rpminfo_state id="oval:com.redhat.rhsa:ste:20162098001" version="638">
    <arch datatype="string" operation="pattern match">ppc64|ppc64le|s390x|x86_64</arch>
    <evr datatype="evr_string" operation="less than">0:3.10.0-327.36.3.el7</evr>
  </rpminfo_state>
...
```

- [RHSA-2017:0372](https://www.redhat.com/security/data/oval/com.redhat.rhsa-20170372.xml):
``` xml
...
<!--line 66-72-->
<affected_cpe_list>
  <cpe>cpe:/o:redhat:enterprise_linux:7</cpe>
  <cpe>cpe:/o:redhat:enterprise_linux:7::server</cpe>
</affected_cpe_list>
...
<!--line 104-->
<criterion comment="kernel is earlier than 0:4.5.0-15.2.1.el7" test_ref="oval:com.redhat.rhsa:tst:20170372001"/>
...
<!--line 232-236-->
<tests>
  <rpminfo_test check="at least one" comment="kernel is earlier than 0:4.5.0-15.2.1.el7"   
    id="oval:com.redhat.rhsa:tst:20170372001" version="643">
    <object object_ref="oval:com.redhat.rhsa:obj:20170372001"/>
    <state state_ref="oval:com.redhat.rhsa:ste:20170372001"/>
  </rpminfo_test>
...
<!--line 331-334-->
<objects>
  <rpminfo_object id="oval:com.redhat.rhsa:obj:20170372001" version="643">
    <name>kernel</name>
  </rpminfo_object>
...
<!--line 384-388-->
<states>
  <rpminfo_state id="oval:com.redhat.rhsa:ste:20170372001" version="643">
    <arch datatype="string" operation="equals">aarch64</arch>
    <evr datatype="evr_string" operation="less than">0:4.5.0-15.2.1.el7</evr>
  </rpminfo_state>
...
```

## Related issues:
- https://github.com/aquasecurity/trivy/issues/1833