### PR TITLE
feat: add support GHSA prefix for GitLab

### DIFF
--- a/pkg/vulnsrc/glad/glad.go
+++ b/pkg/vulnsrc/glad/glad.go
@@ -33,7 +33,7 @@ const (
 var (
 	// TODO: support Conan, Npm, NuGet, PyPI and Packagist
 	supportedPkgTypes   = []packageType{Go, Maven}
-	supportedIDPrefixes = []string{"CVE", "GMS"}
+	supportedIDPrefixes = []string{"CVE", "GHSA", "GMS"}
 
 	source = types.DataSource{
 		ID:   vulnerability.GLAD,


### PR DESCRIPTION
Now advisories from GLAD without CVE-ID are defined via GHSA-ID (if they have it), so `trivy-db` has to support prefix `GHSA`.
