### PR TITLE
fix(redhat-oval): changed tag for Entry.Arches

### DIFF
--- a/pkg/vulnsrc/redhat-oval/testdata/fixtures/happy.yaml
+++ b/pkg/vulnsrc/redhat-oval/testdata/fixtures/happy.yaml
@@ -20,7 +20,7 @@
                 Cves:
                   - ID: CVE-2017-3145
                     Severity: 3
-                Arch:
+                Arches:
                   - i386
                   - ppc64
                   - x86_64

--- a/pkg/vulnsrc/redhat-oval/types.go
+++ b/pkg/vulnsrc/redhat-oval/types.go
@@ -160,7 +160,7 @@ type Definition struct {
 type Entry struct {
 	FixedVersion string `json:",omitempty"`
 	Cves         []CveEntry
-	Arches       []string `json:"Arch,omitempty"`
+	Arches       []string `json:"Arches,omitempty"`
 
 	// For DB size optimization, CPE names will not be stored.
 	// CPE indices are stored instead.

--- a/pkg/vulnsrc/redhat-oval/types.go
+++ b/pkg/vulnsrc/redhat-oval/types.go
@@ -160,7 +160,7 @@ type Definition struct {
 type Entry struct {
 	FixedVersion string `json:",omitempty"`
 	Cves         []CveEntry
-	Arches       []string `json:"Arches,omitempty"`
+	Arches       []string `json:",omitempty"`
 
 	// For DB size optimization, CPE names will not be stored.
 	// CPE indices are stored instead.


### PR DESCRIPTION
## Description
Json tag for `Entry.Arches` has been renamed from `Arch` to `Arches`