### PR TITLE
fix(oracle): added multiple fixed versions for one CVE

### DIFF
--- a/pkg/vulnsrc/oracle-oval/oracle-oval.go
+++ b/pkg/vulnsrc/oracle-oval/oracle-oval.go
@@ -146,9 +146,6 @@ func (vs VulnSrc) commit(tx *bolt.Tx, ovals []OracleOVAL) error {
 	}
 
 	for b, adv := range advisories {
-		if len(adv.FixedVersions) >= 4 {
-			fmt.Println()
-		}
 		if err := vs.dbc.PutAdvisoryDetail(tx, b.vulnID, b.pkgName, []string{b.platform}, adv); err != nil {
 			return xerrors.Errorf("failed to save Oracle Linux OVAL: %w", err)
 		}

--- a/pkg/vulnsrc/oracle-oval/oracle-oval_test.go
+++ b/pkg/vulnsrc/oracle-oval/oracle-oval_test.go
@@ -252,17 +252,18 @@ func TestVulnSrc_Update(t *testing.T) {
 						},
 					},
 				},
-				//{
-				//	Key: []string{"vulnerability-detail", "CVE-2021-20232", "oracle-oval"},
-				//	Value: types.VulnerabilityDetail{
-				//		Title:       "ELSA-2022-9221:  gnutls security update (MODERATE)",
-				//		Description: "[3.6.16-4.0.1_fips]\n- Allow RSA keygen with modulus sizes bigger than 3072 bits and validate the seed length\n  as defined in FIPS 186-4 section B.3.2 [Orabug: 33200526]\n- Allow bigger known RSA modulus sizes when calling\n  rsa_generate_fips186_4_keypair directly [Orabug: 33200526]\n- Change Epoch from 1 to 10\n\n[3.6.16-4]\n- p11tool: Document ID reuse behavior when importing certs (#1776250)\n\n[3.6.16-3]\n- Treat SHA-1 signed CA in the trusted set differently (#1965445)\n\n[3.6.16-2]\n- Filter certificate_types in TLS 1.2 CR based on signature algorithms (#1942216)\n\n[3.6.16-1]\n- Update to upstream 3.6.16 release (#1956783)\n- Fix potential use-after-free in key_share handling (#1927597)\n- Fix potential use-after-free in pre_shared_key handling (#1927593)\n- Stop gnutls-serv relying on AI_ADDRCONFIG to decide listening address (#1908334)\n- Fix cert expiration issue in tests (#1908110)\n\n[3.6.14-10]\n- Port fixes for potential miscalculation in ecdsa_verify (#1942931)\n\n[3.6.14-9]\n- Revert the previous change\", \"References\": []interface{}{\"https://linux.oracle.com/cve/CVE-2021-20232.html\", \"https://linux.oracle.com/errata/ELSA-2022-9221.html\"}, \"Severity\": 2, \"Title\": \"ELSA-2022-9221:  gnutls security update (MODERATE)",
-				//		References: []string{
-				//			"https://linux.oracle.com/errata/ELSA-2022-9221.html",
-				//		},
-				//		Severity: types.SeverityMedium,
-				//	},
-				//},
+				{
+					Key: []string{"vulnerability-detail", "CVE-2021-20232", "oracle-oval"},
+					Value: types.VulnerabilityDetail{
+						Title:       "ELSA-2022-9221:  gnutls security update (MODERATE)",
+						Description: "[3.6.16-4.0.1_fips]\n- Allow RSA keygen with modulus sizes bigger than 3072 bits and validate the seed length\n  as defined in FIPS 186-4 section B.3.2 [Orabug: 33200526]\n- Allow bigger known RSA modulus sizes when calling\n  rsa_generate_fips186_4_keypair directly [Orabug: 33200526]\n- Change Epoch from 1 to 10\n\n[3.6.16-4]\n- p11tool: Document ID reuse behavior when importing certs (#1776250)\n\n[3.6.16-3]\n- Treat SHA-1 signed CA in the trusted set differently (#1965445)\n\n[3.6.16-2]\n- Filter certificate_types in TLS 1.2 CR based on signature algorithms (#1942216)\n\n[3.6.16-1]\n- Update to upstream 3.6.16 release (#1956783)\n- Fix potential use-after-free in key_share handling (#1927597)\n- Fix potential use-after-free in pre_shared_key handling (#1927593)\n- Stop gnutls-serv relying on AI_ADDRCONFIG to decide listening address (#1908334)\n- Fix cert expiration issue in tests (#1908110)\n\n[3.6.14-10]\n- Port fixes for potential miscalculation in ecdsa_verify (#1942931)\n\n[3.6.14-9]\n- Revert the previous change",
+						References: []string{
+							"https://linux.oracle.com/cve/CVE-2021-20232.html",
+							"https://linux.oracle.com/errata/ELSA-2022-9221.html",
+						},
+						Severity: types.SeverityMedium,
+					},
+				},
 			},
 		},
 		{
@@ -328,6 +329,30 @@ func TestVulnSrc_Get(t *testing.T) {
 				{
 					VulnerabilityID: "ELSA-2019-1145",
 					FixedVersion:    "32:9.11.4-17.P2.el8_0",
+				},
+			},
+		},
+		{
+			name:     "happy path. Fips and ksplice packages",
+			fixtures: []string{"testdata/fixtures/happy.yaml"},
+			version:  "8",
+			pkgName:  "glibc",
+			want: []types.Advisory{
+				{
+					VulnerabilityID: "CVE-2016-10228",
+					FixedVersion:    "glibc-2.28-151.0.1.ksplice2.el8.src.rpm",
+				},
+				{
+					VulnerabilityID: "CVE-2016-10228",
+					FixedVersion:    "glibc-2.28-151.0.1.ksplice1.el8.src.rpm",
+				},
+				{
+					VulnerabilityID: "CVE-2016-10228",
+					FixedVersion:    "glibc-2.28-151.0.1.fips.el8.src.rpm",
+				},
+				{
+					VulnerabilityID: "CVE-2016-10228",
+					FixedVersion:    "glibc-2.28-151.0.1.el8.src.rpm",
 				},
 			},
 		},

--- a/pkg/vulnsrc/oracle-oval/oracle-oval_test.go
+++ b/pkg/vulnsrc/oracle-oval/oracle-oval_test.go
@@ -1,10 +1,11 @@
 package oracleoval
 
 import (
-	"github.com/aquasecurity/trivy-db/pkg/vulnsrctest"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/aquasecurity/trivy-db/pkg/vulnsrctest"
 
 	"github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy-db/pkg/utils"
@@ -37,26 +38,26 @@ func TestVulnSrc_Update(t *testing.T) {
 				},
 				{
 					Key: []string{"advisory-detail", "CVE-2007-0493", "Oracle Linux 5", "bind-devel"},
-					Value: types.Advisory{
-						FixedVersion: "30:9.3.3-8.el5",
+					Value: Advisory{
+						FixedVersions: []string{"30:9.3.3-8.el5"},
 					},
 				},
 				{
 					Key: []string{"advisory-detail", "CVE-2007-0494", "Oracle Linux 5", "bind-devel"},
-					Value: types.Advisory{
-						FixedVersion: "30:9.3.3-8.el5",
+					Value: Advisory{
+						FixedVersions: []string{"30:9.3.3-8.el5"},
 					},
 				},
 				{
 					Key: []string{"advisory-detail", "CVE-2007-0493", "Oracle Linux 5", "bind-sdb"},
-					Value: types.Advisory{
-						FixedVersion: "30:9.3.3-8.el5",
+					Value: Advisory{
+						FixedVersions: []string{"30:9.3.3-8.el5"},
 					},
 				},
 				{
 					Key: []string{"advisory-detail", "CVE-2007-0494", "Oracle Linux 5", "bind-sdb"},
-					Value: types.Advisory{
-						FixedVersion: "30:9.3.3-8.el5",
+					Value: Advisory{
+						FixedVersions: []string{"30:9.3.3-8.el5"},
 					},
 				},
 				{
@@ -115,50 +116,50 @@ func TestVulnSrc_Update(t *testing.T) {
 				},
 				{
 					Key: []string{"advisory-detail", "CVE-2018-1094", "Oracle Linux 6", "kernel-uek-doc"},
-					Value: types.Advisory{
-						FixedVersion: "4.1.12-124.24.3.el6uek",
+					Value: Advisory{
+						FixedVersions: []string{"4.1.12-124.24.3.el6uek"},
 					},
 				},
 				{
 					Key: []string{"advisory-detail", "CVE-2018-19824", "Oracle Linux 6", "kernel-uek-doc"},
-					Value: types.Advisory{
-						FixedVersion: "4.1.12-124.24.3.el6uek",
+					Value: Advisory{
+						FixedVersions: []string{"4.1.12-124.24.3.el6uek"},
 					},
 				},
 				{
 					Key: []string{"advisory-detail", "CVE-2018-1094", "Oracle Linux 6", "kernel-uek-firmware"},
-					Value: types.Advisory{
-						FixedVersion: "4.1.12-124.24.3.el6uek",
+					Value: Advisory{
+						FixedVersions: []string{"4.1.12-124.24.3.el6uek"},
 					},
 				},
 				{
 					Key: []string{"advisory-detail", "CVE-2018-19824", "Oracle Linux 6", "kernel-uek-firmware"},
-					Value: types.Advisory{
-						FixedVersion: "4.1.12-124.24.3.el6uek",
+					Value: Advisory{
+						FixedVersions: []string{"4.1.12-124.24.3.el6uek"},
 					},
 				},
 				{
 					Key: []string{"advisory-detail", "CVE-2018-1094", "Oracle Linux 7", "kernel-uek-doc"},
-					Value: types.Advisory{
-						FixedVersion: "4.1.12-124.24.3.el7uek",
+					Value: Advisory{
+						FixedVersions: []string{"4.1.12-124.24.3.el7uek"},
 					},
 				},
 				{
 					Key: []string{"advisory-detail", "CVE-2018-19824", "Oracle Linux 7", "kernel-uek-doc"},
-					Value: types.Advisory{
-						FixedVersion: "4.1.12-124.24.3.el7uek",
+					Value: Advisory{
+						FixedVersions: []string{"4.1.12-124.24.3.el7uek"},
 					},
 				},
 				{
 					Key: []string{"advisory-detail", "CVE-2018-1094", "Oracle Linux 7", "kernel-uek-firmware"},
-					Value: types.Advisory{
-						FixedVersion: "4.1.12-124.24.3.el7uek",
+					Value: Advisory{
+						FixedVersions: []string{"4.1.12-124.24.3.el7uek"},
 					},
 				},
 				{
 					Key: []string{"advisory-detail", "CVE-2018-19824", "Oracle Linux 7", "kernel-uek-firmware"},
-					Value: types.Advisory{
-						FixedVersion: "4.1.12-124.24.3.el7uek",
+					Value: Advisory{
+						FixedVersions: []string{"4.1.12-124.24.3.el7uek"},
 					},
 				},
 				{
@@ -209,8 +210,8 @@ func TestVulnSrc_Update(t *testing.T) {
 				},
 				{
 					Key: []string{"advisory-detail", "ELSA-2007-0057", "Oracle Linux 5", "bind-devel"},
-					Value: types.Advisory{
-						FixedVersion: "9.3.3-8.el5",
+					Value: Advisory{
+						FixedVersions: []string{"9.3.3-8.el5"},
 					},
 				},
 				{
@@ -228,6 +229,40 @@ func TestVulnSrc_Update(t *testing.T) {
 					Key:   []string{"vulnerability-id", "ELSA-2007-0057"},
 					Value: map[string]interface{}{},
 				},
+			},
+		},
+		{
+			name: "happy path fips and ksplice packages",
+			dir:  filepath.Join("testdata", "fips-and-ksplice"),
+			wantValues: []vulnsrctest.WantValues{
+				{
+					Key: []string{"data-source", "Oracle Linux 8"},
+					Value: types.DataSource{
+						ID:   vulnerability.OracleOVAL,
+						Name: "Oracle Linux OVAL definitions",
+						URL:  "https://linux.oracle.com/security/oval/",
+					},
+				},
+				{
+					Key: []string{"advisory-detail", "CVE-2021-20232", "Oracle Linux 8", "gnutls-c++"},
+					Value: Advisory{
+						FixedVersions: []string{
+							"3.6.16-4.el8",
+							"10:3.6.16-4.0.1.el8_fips",
+						},
+					},
+				},
+				//{
+				//	Key: []string{"vulnerability-detail", "CVE-2021-20232", "oracle-oval"},
+				//	Value: types.VulnerabilityDetail{
+				//		Title:       "ELSA-2022-9221:  gnutls security update (MODERATE)",
+				//		Description: "[3.6.16-4.0.1_fips]\n- Allow RSA keygen with modulus sizes bigger than 3072 bits and validate the seed length\n  as defined in FIPS 186-4 section B.3.2 [Orabug: 33200526]\n- Allow bigger known RSA modulus sizes when calling\n  rsa_generate_fips186_4_keypair directly [Orabug: 33200526]\n- Change Epoch from 1 to 10\n\n[3.6.16-4]\n- p11tool: Document ID reuse behavior when importing certs (#1776250)\n\n[3.6.16-3]\n- Treat SHA-1 signed CA in the trusted set differently (#1965445)\n\n[3.6.16-2]\n- Filter certificate_types in TLS 1.2 CR based on signature algorithms (#1942216)\n\n[3.6.16-1]\n- Update to upstream 3.6.16 release (#1956783)\n- Fix potential use-after-free in key_share handling (#1927597)\n- Fix potential use-after-free in pre_shared_key handling (#1927593)\n- Stop gnutls-serv relying on AI_ADDRCONFIG to decide listening address (#1908334)\n- Fix cert expiration issue in tests (#1908110)\n\n[3.6.14-10]\n- Port fixes for potential miscalculation in ecdsa_verify (#1942931)\n\n[3.6.14-9]\n- Revert the previous change\", \"References\": []interface{}{\"https://linux.oracle.com/cve/CVE-2021-20232.html\", \"https://linux.oracle.com/errata/ELSA-2022-9221.html\"}, \"Severity\": 2, \"Title\": \"ELSA-2022-9221:  gnutls security update (MODERATE)",
+				//		References: []string{
+				//			"https://linux.oracle.com/errata/ELSA-2022-9221.html",
+				//		},
+				//		Severity: types.SeverityMedium,
+				//	},
+				//},
 			},
 		},
 		{

--- a/pkg/vulnsrc/oracle-oval/testdata/fips-and-ksplice/vuln-list/oval/oracle/2021/ELSA-2021-4451.json
+++ b/pkg/vulnsrc/oracle-oval/testdata/fips-and-ksplice/vuln-list/oval/oracle/2021/ELSA-2021-4451.json
@@ -1,0 +1,71 @@
+{
+  "Title": "ELSA-2021-4451:  gnutls and nettle security, bug fix, and enhancement update (MODERATE)",
+  "Description": "gnutls\n[3.6.16-4]\n- p11tool: Document ID reuse behavior when importing certs (#1776250)\n\n[3.6.16-3]\n- Treat SHA-1 signed CA in the trusted set differently (#1965445)\n\n[3.6.16-2]\n- Filter certificate_types in TLS 1.2 CR based on signature algorithms (#1942216)\n\n[3.6.16-1]\n- Update to upstream 3.6.16 release (#1956783)\n- Fix potential use-after-free in key_share handling (#1927597)\n- Fix potential use-after-free in pre_shared_key handling (#1927593)\n- Stop gnutls-serv relying on AI_ADDRCONFIG to decide listening address (#1908334)\n- Fix cert expiration issue in tests (#1908110)\n\n[3.6.14-10]\n- Port fixes for potential miscalculation in ecdsa_verify (#1942931)\n\n[3.6.14-9]\n- Revert the previous change\n\nnettle\n[3.4.1-7]\n- Backport CVE-2021-3580 from upstream 3.7.3 release (#1967990)\n\n[3.4.1-6]\n- Enable CTR mode optimization when the block size is 16\n\n[3.4.1-5]\n- Backport powerpc64 optimization patches from upstream (#1855228)\n  Patch from Christopher M. Riedl.",
+  "Platform": [
+    "Oracle Linux 8"
+  ],
+  "References": [
+    {
+      "Source": "elsa",
+      "URI": "https://linux.oracle.com/errata/ELSA-2021-4451.html",
+      "ID": "ELSA-2021-4451"
+    },
+    {
+      "Source": "CVE",
+      "URI": "https://linux.oracle.com/cve/CVE-2021-20232.html",
+      "ID": "CVE-2021-20232"
+    }
+  ],
+  "Criteria": {
+    "Operator": "AND",
+    "Criterias": [
+      {
+        "Operator": "OR",
+        "Criterias": [
+          {
+            "Operator": "AND",
+            "Criterias": [
+              {
+                "Operator": "OR",
+                "Criterias": [
+                  {
+                    "Operator": "AND",
+                    "Criterias": null,
+                    "Criterions": [
+                      {
+                        "Comment": "gnutls-c++ is earlier than 0:3.6.16-4.el8"
+                      },
+                      {
+                        "Comment": "gnutls-c++ is signed with the Oracle Linux 8 key"
+                      }
+                    ]
+                  }
+                ],
+                "Criterions": null
+              }
+            ],
+            "Criterions": [
+              {
+                "Comment": "Oracle Linux arch is aarch64"
+              }
+            ]
+          }
+        ],
+        "Criterions": null
+      }
+    ],
+    "Criterions": [
+      {
+        "Comment": "Oracle Linux 8 is installed"
+      }
+    ]
+  },
+  "Severity": "MODERATE",
+  "Cves": [
+    {
+      "Impact": "",
+      "Href": "https://linux.oracle.com/cve/CVE-2021-20232.html",
+      "ID": "CVE-2021-20232"
+    }
+  ]
+}

--- a/pkg/vulnsrc/oracle-oval/testdata/fips-and-ksplice/vuln-list/oval/oracle/2022/ELSA-2022-9221.json
+++ b/pkg/vulnsrc/oracle-oval/testdata/fips-and-ksplice/vuln-list/oval/oracle/2022/ELSA-2022-9221.json
@@ -1,0 +1,74 @@
+{
+  "Title": "ELSA-2022-9221:  gnutls security update (MODERATE)",
+  "Description": "[3.6.16-4.0.1_fips]\n- Allow RSA keygen with modulus sizes bigger than 3072 bits and validate the seed length\n  as defined in FIPS 186-4 section B.3.2 [Orabug: 33200526]\n- Allow bigger known RSA modulus sizes when calling\n  rsa_generate_fips186_4_keypair directly [Orabug: 33200526]\n- Change Epoch from 1 to 10\n\n[3.6.16-4]\n- p11tool: Document ID reuse behavior when importing certs (#1776250)\n\n[3.6.16-3]\n- Treat SHA-1 signed CA in the trusted set differently (#1965445)\n\n[3.6.16-2]\n- Filter certificate_types in TLS 1.2 CR based on signature algorithms (#1942216)\n\n[3.6.16-1]\n- Update to upstream 3.6.16 release (#1956783)\n- Fix potential use-after-free in key_share handling (#1927597)\n- Fix potential use-after-free in pre_shared_key handling (#1927593)\n- Stop gnutls-serv relying on AI_ADDRCONFIG to decide listening address (#1908334)\n- Fix cert expiration issue in tests (#1908110)\n\n[3.6.14-10]\n- Port fixes for potential miscalculation in ecdsa_verify (#1942931)\n\n[3.6.14-9]\n- Revert the previous change",
+  "Platform": [
+    "Oracle Linux 8"
+  ],
+  "References": [
+    {
+      "Source": "elsa",
+      "URI": "https://linux.oracle.com/errata/ELSA-2022-9221.html",
+      "ID": "ELSA-2022-9221"
+    },
+    {
+      "Source": "CVE",
+      "URI": "https://linux.oracle.com/cve/CVE-2021-20232.html",
+      "ID": "CVE-2021-20232"
+    }
+  ],
+  "Criteria": {
+    "Operator": "AND",
+    "Criterias": [
+      {
+        "Operator": "OR",
+        "Criterias": [
+          {
+            "Operator": "AND",
+            "Criterias": [
+              {
+                "Operator": "OR",
+                "Criterias": [
+                  {
+                    "Operator": "AND",
+                    "Criterias": null,
+                    "Criterions": [
+                      {
+                        "Comment": "gnutls-c++ is earlier than 10:3.6.16-4.0.1.el8_fips"
+                      },
+                      {
+                        "Comment": "gnutls-c++ is signed with the Oracle Linux 8 key"
+                      },
+                      {
+                        "Comment": "gnutls-c++ is fips patched"
+                      }
+                    ]
+                  }
+                ],
+                "Criterions": null
+              }
+            ],
+            "Criterions": [
+              {
+                "Comment": "Oracle Linux arch is aarch64"
+              }
+            ]
+          }
+        ],
+        "Criterions": null
+      }
+    ],
+    "Criterions": [
+      {
+        "Comment": "Oracle Linux 8 is installed"
+      }
+    ]
+  },
+  "Severity": "MODERATE",
+  "Cves": [
+    {
+      "Impact": "",
+      "Href": "https://linux.oracle.com/cve/CVE-2021-20232.html",
+      "ID": "CVE-2021-20232"
+    }
+  ]
+}

--- a/pkg/vulnsrc/oracle-oval/testdata/fixtures/happy.yaml
+++ b/pkg/vulnsrc/oracle-oval/testdata/fixtures/happy.yaml
@@ -4,4 +4,14 @@
       pairs:
         - key: ELSA-2019-1145
           value:
-            FixedVersion: "32:9.11.4-17.P2.el8_0"
+            FixedVersions:
+              - "32:9.11.4-17.P2.el8_0"
+    - bucket: glibc
+      pairs:
+        - key: CVE-2016-10228
+          value:
+            FixedVersions:
+              - "glibc-2.28-151.0.1.ksplice2.el8.src.rpm"
+              - "glibc-2.28-151.0.1.ksplice1.el8.src.rpm"
+              - "glibc-2.28-151.0.1.fips.el8.src.rpm"
+              - "glibc-2.28-151.0.1.el8.src.rpm"

--- a/pkg/vulnsrc/oracle-oval/types.go
+++ b/pkg/vulnsrc/oracle-oval/types.go
@@ -41,3 +41,13 @@ type AffectedPackage struct {
 	Package Package
 	OSVer   string
 }
+
+type Advisory struct {
+	FixedVersions []string `json:",omitempty"`
+}
+
+type bucket struct {
+	platform string
+	pkgName  string
+	vulnID   string
+}


### PR DESCRIPTION
## Description 
`Oracle Linux` can has different packages for `fips`, `ksplice1` and `ksplice2` versions.
We need save all versions in order to correctly detect vulnerabilities for these packages.

before changes: saves the last found package:
![oracle-old](https://user-images.githubusercontent.com/91113035/172304985-657d04a7-93b1-4f5a-b3d8-cd3b1c171ad2.png)

after changes:
![oracle-new](https://user-images.githubusercontent.com/91113035/172305027-3e386474-80a7-4c5c-8aef-ef0c240dd582.png)

## Related Issues
- https://github.com/aquasecurity/trivy-db/issues/220

