### PR TITLE
fix(go): no lowercase for go packages

### DIFF
--- a/pkg/vulnsrc/vulnerability/vulnerability.go
+++ b/pkg/vulnsrc/vulnerability/vulnerability.go
@@ -210,9 +210,8 @@ func NormalizePkgName(ecosystem types.Ecosystem, pkgName string) string {
 		// and MUST consider hyphens and underscores to be equivalent.
 		pkgName = strings.ToLower(pkgName)
 		pkgName = strings.ReplaceAll(pkgName, "_", "-")
-	}
-	// Nuget is case-sensitive, Go has case-sensitive packages
-	if ecosystem != NuGet && ecosystem != Go {
+	} else if ecosystem != NuGet && ecosystem != Go {
+		// Nuget is case-sensitive, Go has case-sensitive packages
 		pkgName = strings.ToLower(pkgName)
 	}
 	return pkgName

--- a/pkg/vulnsrc/vulnerability/vulnerability.go
+++ b/pkg/vulnsrc/vulnerability/vulnerability.go
@@ -210,7 +210,9 @@ func NormalizePkgName(ecosystem types.Ecosystem, pkgName string) string {
 		// and MUST consider hyphens and underscores to be equivalent.
 		pkgName = strings.ToLower(pkgName)
 		pkgName = strings.ReplaceAll(pkgName, "_", "-")
-	} else if ecosystem != NuGet { // Nuget is case-sensitive
+	}
+	// Nuget is case-sensitive, Go has case-sensitive packages
+	if ecosystem != NuGet && ecosystem != Go {
 		pkgName = strings.ToLower(pkgName)
 	}
 	return pkgName


### PR DESCRIPTION
There are Go packages with names that contain letters in different cases, eg: `github.com/Masterminds/vcs`.
we shouldn't normalize them.