### PR TITLE
feat(amazon linux): add 2022 version support

### DIFF
--- a/pkg/vulnsrc/amazon/amazon.go
+++ b/pkg/vulnsrc/amazon/amazon.go
@@ -24,7 +24,7 @@ const (
 )
 
 var (
-	targetVersions = []string{"1", "2"}
+	targetVersions = []string{"1", "2", "2022"}
 
 	source = types.DataSource{
 		ID:   vulnerability.Amazon,

--- a/pkg/vulnsrc/amazon/amazon_test.go
+++ b/pkg/vulnsrc/amazon/amazon_test.go
@@ -1,10 +1,11 @@
 package amazon_test
 
 import (
-	"github.com/aquasecurity/trivy-db/pkg/vulnsrctest"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/aquasecurity/trivy-db/pkg/vulnsrctest"
 
 	"github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy-db/pkg/utils"
@@ -76,6 +77,20 @@ func TestVulnSrc_Update(t *testing.T) {
 						References:  []string{"http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-22543"},
 					},
 				},
+				{
+					Key: []string{"data-source", "amazon linux 2022"},
+					Value: types.DataSource{
+						ID:   vulnerability.Amazon,
+						Name: "Amazon Linux Security Center",
+						URL:  "https://alas.aws.amazon.com/",
+					},
+				},
+				{
+					Key: []string{"advisory-detail", "CVE-2021-44228", "amazon linux 2022", "log4j"},
+					Value: types.Advisory{
+						FixedVersion: "2.15.0-1.amzn2022.0.1",
+					},
+				},
 			},
 		},
 		{
@@ -125,7 +140,7 @@ func TestVulnSrc_Get(t *testing.T) {
 		},
 		{
 			name:     "GetAdvisories returns an error",
-			version:  "1",
+			version:  "2022",
 			pkgName:  "curl",
 			fixtures: []string{"testdata/fixtures/sad.yaml"},
 			wantErr:  "failed to unmarshal advisory JSON",

--- a/pkg/vulnsrc/amazon/amazon_test.go
+++ b/pkg/vulnsrc/amazon/amazon_test.go
@@ -140,7 +140,7 @@ func TestVulnSrc_Get(t *testing.T) {
 		},
 		{
 			name:     "GetAdvisories returns an error",
-			version:  "2022",
+			version:  "1",
 			pkgName:  "curl",
 			fixtures: []string{"testdata/fixtures/sad.yaml"},
 			wantErr:  "failed to unmarshal advisory JSON",

--- a/pkg/vulnsrc/amazon/testdata/happy/vuln-list/amazon/2022/ALAS2022-2021-003.json
+++ b/pkg/vulnsrc/amazon/testdata/happy/vuln-list/amazon/2022/ALAS2022-2021-003.json
@@ -1,0 +1,32 @@
+{
+  "id": "ALAS2022-2021-003",
+  "title": "Amazon Linux 2022 - ALAS2022-2021-003: critical priority package update for log4j",
+  "issued": {
+    "date": "2021-12-10 21:56"
+  },
+  "updated": {
+    "date": "2021-12-11 12:00"
+  },
+  "severity": "critical",
+  "description": "Package updates are available for Amazon Linux 2022 that fix the following vulnerabilities:\nCVE-2021-44228:\n\tA flaw was found in the Java logging library Apache Log4j 2 in versions from 2.0-beta9 and before and including 2.14.1. This could allow a remote attacker to execute code on the server if the system logs an attacker-controlled string value with the attacker's JNDI LDAP server lookup.\n",
+  "packages": [
+    {
+      "name": "log4j",
+      "epoch": "0",
+      "version": "2.15.0",
+      "release": "1.amzn2022.0.1",
+      "arch": "noarch",
+      "filename": "Packages/log4j-2.15.0-1.amzn2022.0.1.noarch.rpm"
+    }
+  ],
+  "references": [
+    {
+      "href": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228",
+      "id": "CVE-2021-44228",
+      "type": "cve"
+    }
+  ],
+  "cveids": [
+    "CVE-2021-44228"
+  ]
+}


### PR DESCRIPTION
## Description
Add advisories for Amazon Linux 2022

## Related PRs
- [x] https://github.com/aquasecurity/vuln-list-update/pull/166
