### PR TITLE
fix(alma): use id field to get cve-id

### DIFF
--- a/pkg/vulnsrc/alma/alma.go
+++ b/pkg/vulnsrc/alma/alma.go
@@ -114,7 +114,7 @@ func (vs VulnSrc) commit(tx *bolt.Tx, platformName string, errata []Erratum) err
 			// https://github.com/aquasecurity/fanal/issues/186#issuecomment-931523102
 			advisories := map[string]types.Advisory{}
 
-			cveID := ref.Title
+			cveID := ref.ID
 			for _, pkg := range erratum.Pkglist.Packages {
 				if pkg.Arch != "noarch" && pkg.Arch != "x86_64" {
 					continue


### PR DESCRIPTION
## Description
There are advisories with empty title field. For example: [ALSA-2022:0951](https://github.com/aquasecurity/vuln-list/blob/619fcebb428ad494d58355c38a5acbfb42d12a6c/alma/8/2022/ALSA-2022:0951.json#L94-L95).
`ID` field is always fill.
Use [Reference.ID](https://github.com/aquasecurity/trivy-db/blob/930461748b6307590f4718daeab37cec51fe78b3/pkg/vulnsrc/alma/types.go#L64) field to get cve-id.