### PR TITLE
bugfix: handle zero version event

### DIFF
--- a/pkg/vulnsrc/govulndb/govulndb.go
+++ b/pkg/vulnsrc/govulndb/govulndb.go
@@ -117,6 +117,9 @@ func (vs VulnSrc) commit(tx *bolt.Tx, item Entry) error {
 				if vulnerable != "" {
 					vulnerableVersions = append(vulnerableVersions, vulnerable)
 				}
+				if event.Introduced == "0" {
+					event.Introduced = "0.0.0-0"
+				}
 				vulnerable = fmt.Sprintf(">=%s", event.Introduced)
 			case event.Fixed != "":
 				// patched versions

--- a/pkg/vulnsrc/govulndb/govulndb_test.go
+++ b/pkg/vulnsrc/govulndb/govulndb_test.go
@@ -1,8 +1,9 @@
 package govulndb_test
 
 import (
-	"github.com/aquasecurity/trivy-db/pkg/vulnsrctest"
 	"testing"
+
+	"github.com/aquasecurity/trivy-db/pkg/vulnsrctest"
 
 	"github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/govulndb"
@@ -50,7 +51,7 @@ func TestVulnSrc_Update(t *testing.T) {
 					Key: []string{"advisory-detail", "CVE-2020-26160", "go::The Go Vulnerability Database", "github.com/dgrijalva/jwt-go/v4"},
 					Value: types.Advisory{
 						PatchedVersions:    []string{"4.0.0-preview1"},
-						VulnerableVersions: []string{">=0, <4.0.0-preview1"},
+						VulnerableVersions: []string{">=0.0.0-0, <4.0.0-preview1"},
 					},
 				},
 				{


### PR DESCRIPTION
comparion of zero (0) version is failing with 0.0.0-<timestamp>-<commit> type versions.