### PR TITLE
feat(db): sign db artifact with cosign

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -49,6 +49,11 @@ jobs:
           username: ${{ env.GH_USER }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@main
+        with:
+          cosign-release: 'v1.9.0'
+
       - name: Install oras
         run: |
           # oras was rollbacked to v0.12.0, because now v0.13.0 (the latest version) contains bugs: https://github.com/oras-project/oras/issues/447
@@ -64,3 +69,9 @@ jobs:
               --manifest-config /dev/null:application/vnd.aquasec.trivy.config.v1+json \
               db.tar.gz:application/vnd.aquasec.trivy.db.layer.v1.tar+gzip
           done
+
+      - name: Sign DB and push signature to GHCR
+        env:
+          COSIGN_REPOSITORY: "ghcr.io/${{ github.repository_owner }}/trivy-db-signatures"
+        run: |
+          echo -n "${{ secrets.COSIGN_PRIVATE_KEY_PASSWORD }}" | cosign sign --key <(echo -n "${{ secrets.COSIGN_PRIVATE_KEY }}") ghcr.io/${{ github.repository }}:latest


### PR DESCRIPTION
Closes #205 

Introduces cosign as a signing artifact tool to sign our DB on the GHCR. The signatures are pushed to a new repo, "trivy-db-signatures" to avoid populating the db CR with signatures.

**Before merging**, the following steps are needed to be performed by the maintainer:
1. Install `cosign` and generate a public-private key pair with the command
```sh
cosign generate-key-pair
```
2. Add the `cosign.pub` in our repo as cosign.pub in main dir (so that our users can fetch it to verify the builds)
3. The password used to generate the key pair shooul be stored as:
    GitHub Repo secret
      key: `COSIGN_PRIVATE_KEY_PASSWORD`
      value: <one used to generate the key-pair>

4. And the provate key generated should be stored as:
     GitHub Repo secret:
      key: `COSIGN_PRIVATE_KEY`
      value: <the cosign.key>
    make sure there's not an empty line at the end.

And after merging the PR and the signature being pushed, make the repo `trivy-db-signatures` public.