### PR TITLE
fix(redhat): add rejected vulnerability check for rhsa-xxx

### DIFF
--- a/pkg/vulndb/db.go
+++ b/pkg/vulndb/db.go
@@ -129,7 +129,7 @@ func (t TrivyDB) optimize() error {
 	// This bucket has only vulnerability IDs provided by vendors. They must be stored.
 	err := t.dbc.ForEachVulnerabilityID(func(tx *bolt.Tx, cveID string) error {
 		details := t.vulnClient.GetDetails(cveID)
-		if t.vulnClient.IsRejected(details) {
+		if vulnerability.IsRejected(details) {
 			return nil
 		}
 

--- a/pkg/vulnsrc/vulnerability/vulnerability.go
+++ b/pkg/vulnsrc/vulnerability/vulnerability.go
@@ -38,7 +38,7 @@ func (v Vulnerability) GetDetails(vulnID string) map[types.SourceID]types.Vulner
 	return details
 }
 
-func (Vulnerability) IsRejected(details map[types.SourceID]types.VulnerabilityDetail) bool {
+func IsRejected(details map[types.SourceID]types.VulnerabilityDetail) bool {
 	return getRejectedStatus(details)
 }
 

--- a/pkg/vulnsrc/vulnerability/vulnerability_test.go
+++ b/pkg/vulnsrc/vulnerability/vulnerability_test.go
@@ -126,7 +126,7 @@ func TestIsRejected(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := vulnerability.New(nil).IsRejected(tc.details)
+			got := vulnerability.IsRejected(tc.details)
 			assert.Equal(t, tc.want, got)
 		})
 	}


### PR DESCRIPTION
## Description
 `RHSA-xxx` advisories don't checks to `reject`  when do optimizing because `NVD` only contains `CVE-xxx`.
Added check for RHSAs

## Related issues
- Close aquasecurity/trivy/issues/2623