### PR TITLE
feat: add vendor status

### DIFF
--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -9,6 +9,10 @@ type Severity int
 
 type VendorSeverity map[SourceID]Severity
 
+type Status string
+
+type VendorStatus map[SourceID]Status
+
 type CVSS struct {
 	V2Vector string  `json:"V2Vector,omitempty"`
 	V3Vector string  `json:"V3Vector,omitempty"`
@@ -29,6 +33,12 @@ const (
 	SeverityMedium
 	SeverityHigh
 	SeverityCritical
+
+	StatusFixed      Status = "fixed"
+	StatusAffected   Status = "affected"
+	StatusWillNotFix Status = "will-not-fix"
+	StatusDeferred   Status = "deferred"
+	StatusRejected   Status = "rejected"
 )
 
 var (
@@ -77,6 +87,7 @@ type VulnerabilityDetail struct {
 	Description      string     `json:",omitempty"`
 	PublishedDate    *time.Time `json:",omitempty"` // Take from NVD
 	LastModifiedDate *time.Time `json:",omitempty"` // Take from NVD
+	Status           Status     `json:",omitempty"` // e.g. Fixed, Affected
 }
 
 type AdvisoryDetail struct {
@@ -135,6 +146,7 @@ type Vulnerability struct {
 	Severity         string         `json:",omitempty"` // Selected from VendorSeverity, depending on a scan target
 	CweIDs           []string       `json:",omitempty"` // e.g. CWE-78, CWE-89
 	VendorSeverity   VendorSeverity `json:",omitempty"`
+	VendorStatus     VendorStatus   `json:",omitempty"`
 	CVSS             VendorCVSS     `json:",omitempty"`
 	References       []string       `json:",omitempty"`
 	PublishedDate    *time.Time     `json:",omitempty"` // Take from NVD

--- a/pkg/vulndb/db.go
+++ b/pkg/vulndb/db.go
@@ -128,15 +128,11 @@ func (t TrivyDB) optimize() error {
 	// Trivy DB will not store them so that it could reduce the database size.
 	// This bucket has only vulnerability IDs provided by vendors. They must be stored.
 	err := t.dbc.ForEachVulnerabilityID(func(tx *bolt.Tx, cveID string) error {
-		details := t.vulnClient.GetDetails(cveID)
-		if t.vulnClient.IsRejected(details) {
-			return nil
-		}
-
 		if err := t.dbc.SaveAdvisoryDetails(tx, cveID); err != nil {
 			return xerrors.Errorf("failed to save advisories: %w", err)
 		}
 
+		details := t.vulnClient.GetDetails(cveID)
 		if len(details) == 0 {
 			return nil
 		}

--- a/pkg/vulndb/db_test.go
+++ b/pkg/vulndb/db_test.go
@@ -158,6 +158,10 @@ func TestTrivyDB_Build(t *testing.T) {
 							vulnerability.NVD:    types.SeverityHigh,
 							vulnerability.RedHat: types.SeverityCritical,
 						},
+						VendorStatus: types.VendorStatus{
+							vulnerability.NVD:    "",
+							vulnerability.RedHat: "",
+						},
 						PublishedDate:    &published,
 						LastModifiedDate: &modified,
 					},

--- a/pkg/vulnsrc/redhat/redhat.go
+++ b/pkg/vulnsrc/redhat/redhat.go
@@ -3,14 +3,15 @@ package redhat
 import (
 	"encoding/json"
 	"fmt"
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
 	"io"
 	"io/ioutil"
 	"log"
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 
 	bolt "go.etcd.io/bbolt"
 	"golang.org/x/xerrors"
@@ -164,4 +165,18 @@ func severityFromThreat(sev string) types.Severity {
 		return types.SeverityCritical
 	}
 	return types.SeverityUnknown
+}
+
+func normalizeStatus(status string) types.Status {
+	switch status {
+	case "Affected":
+		return types.StatusAffected
+	case "Fix deferred":
+		return types.StatusDeferred
+	case "Will not fix", "Out of support scope":
+		return types.StatusWillNotFix
+	case "Fixed":
+		return types.StatusFixed
+	}
+	return ""
 }

--- a/pkg/vulnsrc/vulnerability/vulnerability.go
+++ b/pkg/vulnsrc/vulnerability/vulnerability.go
@@ -38,17 +38,22 @@ func (v Vulnerability) GetDetails(vulnID string) map[types.SourceID]types.Vulner
 	return details
 }
 
-func (Vulnerability) IsRejected(details map[types.SourceID]types.VulnerabilityDetail) bool {
-	return getRejectedStatus(details)
-}
-
 func (Vulnerability) Normalize(details map[types.SourceID]types.VulnerabilityDetail) types.Vulnerability {
+	vendorStatus, rejected := getVendorStatus(details)
+	if rejected {
+		// If the vulnerability is rejected, other details will not be stored in the database,
+		// so that the database size can be kept small.
+		return types.Vulnerability{
+			VendorStatus: vendorStatus,
+		}
+	}
 	return types.Vulnerability{
 		Title:            getTitle(details),
 		Description:      getDescription(details),
 		Severity:         getSeverity(details).String(), // TODO: We have to keep this key until we deprecate
 		CweIDs:           getCweIDs(details),
 		VendorSeverity:   getVendorSeverity(details),
+		VendorStatus:     vendorStatus,
 		CVSS:             getCVSS(details),
 		References:       getReferences(details),
 		PublishedDate:    details[NVD].PublishedDate,
@@ -175,17 +180,22 @@ func getReferences(details map[types.SourceID]types.VulnerabilityDetail) []strin
 	return refs
 }
 
-func getRejectedStatus(details map[types.SourceID]types.VulnerabilityDetail) bool {
+func getVendorStatus(details map[types.SourceID]types.VulnerabilityDetail) (types.VendorStatus, bool) {
+	vs := make(types.VendorStatus)
+	var rejected bool
 	for _, source := range sources {
 		d, ok := details[source]
 		if !ok {
 			continue
 		}
 		if strings.Contains(d.Description, rejectVulnerability) {
-			return true
+			vs[source] = types.StatusRejected
+			rejected = true
+			continue
 		}
+		vs[source] = d.Status
 	}
-	return false
+	return vs, rejected
 }
 
 func scoreToSeverity(score float64) types.Severity {

--- a/pkg/vulnsrc/vulnerability/vulnerability_test.go
+++ b/pkg/vulnsrc/vulnerability/vulnerability_test.go
@@ -71,67 +71,6 @@ func TestGetDetails(t *testing.T) {
 	}
 }
 
-func TestIsRejected(t *testing.T) {
-	testCases := []struct {
-		name    string
-		details map[types.SourceID]types.VulnerabilityDetail
-		want    bool
-	}{
-		{
-			name: "happy path",
-			details: map[types.SourceID]types.VulnerabilityDetail{
-				vulnerability.NVD: {
-					ID:          "CVE-2020-1234",
-					CvssScore:   9.1,
-					Title:       "test vulnerability",
-					Description: "a test vulnerability where vendor rates it lower than NVD",
-				},
-				vulnerability.RedHat: {
-					ID:          "CVE-2020-1234",
-					CvssScoreV3: 5.6,
-					Title:       "test vulnerability",
-					Description: "a test vulnerability where vendor rates it lower than NVD",
-				},
-			},
-			want: false,
-		},
-		{
-			name: "happy path, when vulnerability from redhat and ubuntu is rejected by Nvd",
-			details: map[types.SourceID]types.VulnerabilityDetail{
-				vulnerability.RedHat: {
-					ID:          "CVE-2020-1234",
-					CvssScoreV3: 5.6,
-					Title:       "test vulnerability",
-					Description: "a test vulnerability where vendor rates it lower than NVD",
-				},
-				vulnerability.Ubuntu: {
-					ID:          "CVE-2020-1234",
-					CvssScore:   1.2,
-					CvssScoreV3: 3.4,
-					Severity:    types.SeverityLow,
-					SeverityV3:  types.SeverityMedium,
-					Title:       "test vulnerability",
-					Description: "a test vulnerability where vendor rates it lower than NVD",
-				},
-				vulnerability.NVD: {
-					ID:          "CVE-2020-1234",
-					CvssScore:   9.1,
-					Title:       "test vulnerability",
-					Description: "** REJECT ** a test vulnerability where vendor rates it lower than NVD",
-				},
-			},
-			want: true,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			got := vulnerability.New(nil).IsRejected(tc.details)
-			assert.Equal(t, tc.want, got)
-		})
-	}
-}
-
 func TestNormalize(t *testing.T) {
 	testCases := []struct {
 		name    string
@@ -158,6 +97,7 @@ func TestNormalize(t *testing.T) {
 					Title:        "test vulnerability",
 					Description:  "a test vulnerability where vendor rates it lower than NVD",
 					References:   []string{"http://foo-bar.com/baz"},
+					Status:       types.StatusFixed,
 				},
 			},
 			want: types.Vulnerability{
@@ -182,6 +122,10 @@ func TestNormalize(t *testing.T) {
 						V3Score:  6.7,
 					},
 				},
+				VendorStatus: types.VendorStatus{
+					vulnerability.NVD:    "",
+					vulnerability.RedHat: types.StatusFixed,
+				},
 				CweIDs:           []string{"CWE-125", "CWE-200"},
 				References:       []string{"http://foo-bar.com/baz"},
 				LastModifiedDate: utils.MustTimeParse("2020-01-01T01:02:03Z"),
@@ -201,6 +145,7 @@ func TestNormalize(t *testing.T) {
 					Title:        "test vulnerability",
 					Description:  "a test vulnerability where vendor rates it lower than NVD",
 					References:   []string{"http://foo-bar.com/baz"},
+					Status:       types.StatusWillNotFix,
 				},
 				vulnerability.Ubuntu: {
 					ID:           "CVE-2020-1234",
@@ -238,6 +183,11 @@ func TestNormalize(t *testing.T) {
 						V3Score:  3.4,
 					},
 				},
+				VendorStatus: types.VendorStatus{
+					vulnerability.RedHat:           types.StatusWillNotFix,
+					vulnerability.Ubuntu:           "",
+					vulnerability.NodejsSecurityWg: "",
+				},
 				References: []string{"http://foo-bar.com/baz"},
 			},
 		},
@@ -262,9 +212,36 @@ func TestNormalize(t *testing.T) {
 				VendorSeverity: types.VendorSeverity{
 					vulnerability.Ubuntu: types.SeverityMedium,
 				},
+				VendorStatus: types.VendorStatus{
+					vulnerability.Ubuntu:           "",
+					vulnerability.NodejsSecurityWg: "",
+				},
 				CVSS:        types.VendorCVSS{},
 				Title:       "test vulnerability",
 				Description: "a test vulnerability where vendor rates it lower than NVD",
+			},
+		},
+		{
+			name: "happy path. Rejected cve",
+			details: map[types.SourceID]types.VulnerabilityDetail{
+				vulnerability.NVD: {
+					Description: "** REJECT **",
+				},
+				vulnerability.RedHat: {
+					CvssScoreV3:  6.7,
+					CvssVectorV3: "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+					SeverityV3:   types.SeverityHigh,
+					Title:        "test vulnerability",
+					Description:  "a test vulnerability where vendor rates it lower than NVD",
+					References:   []string{"http://foo-bar.com/baz"},
+					Status:       types.StatusAffected,
+				},
+			},
+			want: types.Vulnerability{
+				VendorStatus: types.VendorStatus{
+					vulnerability.NVD:    types.StatusRejected,
+					vulnerability.RedHat: types.StatusAffected,
+				},
 			},
 		},
 	}


### PR DESCRIPTION
## Description
Added structure with cve statuses for different vendors.
e.g.:
```
  "VendorStatus": {
    "nvd": "rejected",
    "redhat": "fixed",
    "alpine": "will not fix",
  }
```
There are next statuses:
-  "fixed"
- "affected"
- "will-not-fix"
- "deferred"
- "rejected"