### PR TITLE
feat: add Rust ecosystem from GHSA and disable from OSV

### DIFF
--- a/pkg/vulnsrc/bucket/bucket.go
+++ b/pkg/vulnsrc/bucket/bucket.go
@@ -29,7 +29,7 @@ func Name(ecosystem, dataSource string) string {
 		prefix = vulnerability.NuGet
 	case "conan":
 		prefix = vulnerability.Conan
-	case "cargo":
+	case "cargo", "rust":
 		prefix = vulnerability.Cargo
 	default:
 		return ""

--- a/pkg/vulnsrc/ghsa/ghsa.go
+++ b/pkg/vulnsrc/ghsa/ghsa.go
@@ -31,6 +31,7 @@ var (
 		vulnerability.NuGet,
 		vulnerability.Pip,
 		vulnerability.RubyGems,
+		vulnerability.Rust,
 	}
 	platformFormat = "GitHub Security Advisory %s"
 )

--- a/pkg/vulnsrc/ghsa/ghsa_test.go
+++ b/pkg/vulnsrc/ghsa/ghsa_test.go
@@ -233,6 +233,44 @@ func TestVulnSrc_Update(t *testing.T) {
 					Key:   []string{"vulnerability-id", "CVE-2018-16477"},
 					Value: map[string]interface{}{},
 				},
+				{
+					Key: []string{"data-source", "cargo::GitHub Security Advisory Rust"},
+					Value: types.DataSource{
+						ID:   vulnerability.GHSA,
+						Name: "GitHub Security Advisory Rust",
+						URL:  "https://github.com/advisories?query=type%3Areviewed+ecosystem%3Arust",
+					},
+				},
+				{
+					Key: []string{"advisory-detail", "CVE-2020-26235", "cargo::GitHub Security Advisory Rust", "time"},
+					Value: types.Advisory{
+						PatchedVersions:    []string{"0.2.23"},
+						VulnerableVersions: []string{"\u003e= 0.2.7, \u003c 0.2.23"},
+					},
+				},
+				{
+					Key: []string{"vulnerability-detail", "CVE-2020-26235", ghsaDir},
+					Value: types.VulnerabilityDetail{
+						ID:          "CVE-2020-26235",
+						Title:       "Segmentation fault in time",
+						Description: "### Impact\n\nUnix-like operating systems may segfault due to dereferencing a dangling pointer in specific circumstances. This requires an environment variable to be set in a different thread than the affected functions. This may occur without the user's knowledge, notably in a third-party library.\n\nThe affected functions from time 0.2.7 through 0.2.22 are:\n\n- `time::UtcOffset::local_offset_at`\n- `time::UtcOffset::try_local_offset_at`\n- `time::UtcOffset::current_local_offset`\n- `time::UtcOffset::try_current_local_offset`\n- `time::OffsetDateTime::now_local`\n- `time::OffsetDateTime::try_now_local`\n\nThe affected functions in time 0.1 (all versions) are:\n\n- `at`\n- `at_utc`\n- `now`\n\nNon-Unix targets (including Windows and wasm) are unaffected.\n\n### Patches\n\nIn some versions of time`, the internal method that determines the local offset has been modified to always return `None` on the affected operating systems. This has the effect of returning an `Err` on the `try_*` methods and `UTC` on the non-`try_*` methods. In later versions, `time` will attempt to determine the number of threads running in the process. If the process is single-threaded, the call will proceed as its safety invariant is upheld.\n\nUsers and library authors with time in their dependency tree must perform `cargo update`, which will pull in the updated, unaffected code.\n\nUsers of time 0.1 do not have a patch and must upgrade to an unaffected version: time 0.2.23 or greater or the 0.3 series.\n\n### Workarounds\n\nLibrary authors must ensure that the program only has one running thread at the time of calling any affected method. Binary authors may do the same and/or ensure that no other thread is actively mutating the environment.\n\n### References\n\ntime-rs/time#293",
+						References: []string{
+							"https://github.com/time-rs/time/security/advisories/GHSA-wcg3-cvx6-7396",
+							"https://nvd.nist.gov/vuln/detail/CVE-2020-26235",
+							"https://github.com/time-rs/time/issues/293",
+							"https://rustsec.org/advisories/RUSTSEC-2020-0071.html",
+							"https://crates.io/crates/time/0.2.23",
+							"https://github.com/advisories/GHSA-wcg3-cvx6-7396",
+						},
+						Severity:     types.SeverityMedium,
+						CvssScoreV3:  6.2,
+						CvssVectorV3: "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+					},
+				},
+				{
+					Key:   []string{"vulnerability-id", "CVE-2020-26235"},
+					Value: map[string]interface{}{},
+				},
 			},
 		},
 		{

--- a/pkg/vulnsrc/ghsa/testdata/happy/vuln-list/ghsa/rust/time/GHSA-wcg3-cvx6-7396.json
+++ b/pkg/vulnsrc/ghsa/testdata/happy/vuln-list/ghsa/rust/time/GHSA-wcg3-cvx6-7396.json
@@ -1,0 +1,62 @@
+{
+  "Severity": "MODERATE",
+  "UpdatedAt": "2021-08-18T21:06:22Z",
+  "Package": {
+    "Ecosystem": "RUST",
+    "Name": "time"
+  },
+  "Advisory": {
+    "DatabaseId": 5095,
+    "Id": "MDE2OlNlY3VyaXR5QWR2aXNvcnlHSFNBLXdjZzMtY3Z4Ni03Mzk2",
+    "GhsaId": "GHSA-wcg3-cvx6-7396",
+    "References": [
+      {
+        "Url": "https://github.com/time-rs/time/security/advisories/GHSA-wcg3-cvx6-7396"
+      },
+      {
+        "Url": "https://nvd.nist.gov/vuln/detail/CVE-2020-26235"
+      },
+      {
+        "Url": "https://github.com/time-rs/time/issues/293"
+      },
+      {
+        "Url": "https://rustsec.org/advisories/RUSTSEC-2020-0071.html"
+      },
+      {
+        "Url": "https://crates.io/crates/time/0.2.23"
+      },
+      {
+        "Url": "https://github.com/advisories/GHSA-wcg3-cvx6-7396"
+      }
+    ],
+    "Identifiers": [
+      {
+        "Type": "GHSA",
+        "Value": "GHSA-wcg3-cvx6-7396"
+      },
+      {
+        "Type": "CVE",
+        "Value": "CVE-2020-26235"
+      }
+    ],
+    "Description": "### Impact\n\nUnix-like operating systems may segfault due to dereferencing a dangling pointer in specific circumstances. This requires an environment variable to be set in a different thread than the affected functions. This may occur without the user's knowledge, notably in a third-party library.\n\nThe affected functions from time 0.2.7 through 0.2.22 are:\n\n- `time::UtcOffset::local_offset_at`\n- `time::UtcOffset::try_local_offset_at`\n- `time::UtcOffset::current_local_offset`\n- `time::UtcOffset::try_current_local_offset`\n- `time::OffsetDateTime::now_local`\n- `time::OffsetDateTime::try_now_local`\n\nThe affected functions in time 0.1 (all versions) are:\n\n- `at`\n- `at_utc`\n- `now`\n\nNon-Unix targets (including Windows and wasm) are unaffected.\n\n### Patches\n\nIn some versions of time`, the internal method that determines the local offset has been modified to always return `None` on the affected operating systems. This has the effect of returning an `Err` on the `try_*` methods and `UTC` on the non-`try_*` methods. In later versions, `time` will attempt to determine the number of threads running in the process. If the process is single-threaded, the call will proceed as its safety invariant is upheld.\n\nUsers and library authors with time in their dependency tree must perform `cargo update`, which will pull in the updated, unaffected code.\n\nUsers of time 0.1 do not have a patch and must upgrade to an unaffected version: time 0.2.23 or greater or the 0.3 series.\n\n### Workarounds\n\nLibrary authors must ensure that the program only has one running thread at the time of calling any affected method. Binary authors may do the same and/or ensure that no other thread is actively mutating the environment.\n\n### References\n\ntime-rs/time#293",
+    "Origin": "UNSPECIFIED",
+    "PublishedAt": "2021-08-25T20:56:46Z",
+    "Severity": "MODERATE",
+    "Summary": "Segmentation fault in time",
+    "UpdatedAt": "2022-06-07T21:09:27Z",
+    "WithdrawnAt": "",
+    "CVSS": {
+      "Score": 6.2,
+      "VectorString": "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+    }
+  },
+  "Versions": [
+    {
+      "FirstPatchedVersion": {
+        "Identifier": "0.2.23"
+      },
+      "VulnerableVersionRange": "\u003e= 0.2.7, \u003c 0.2.23"
+    }
+  ]
+}

--- a/pkg/vulnsrc/osv/osv.go
+++ b/pkg/vulnsrc/osv/osv.go
@@ -35,15 +35,19 @@ var ecosystems = []ecosystem{
 			URL:  "https://github.com/pypa/advisory-db",
 		},
 	},
-	{
-		dir:  "rust",
-		name: vulnerability.Cargo,
-		dataSource: types.DataSource{
-			ID:   sourceID,
-			Name: "RustSec Advisory Database",
-			URL:  "https://github.com/RustSec/advisory-db",
+	// Cargo ecosystem advisories in OSV were disabled,
+	// because GitHub Advisory Database contains almost all information.
+	/*
+		{
+			dir:  "rust",
+			name: vulnerability.Cargo,
+			dataSource: types.DataSource{
+				ID:   sourceID,
+				Name: "RustSec Advisory Database",
+				URL:  "https://github.com/RustSec/advisory-db",
+			},
 		},
-	},
+	*/
 
 	// We cannot use OSV for golang scanning until module names are included.
 	// See https://github.com/golang/go/issues/50006 for the detail.

--- a/pkg/vulnsrc/osv/osv_test.go
+++ b/pkg/vulnsrc/osv/osv_test.go
@@ -29,14 +29,16 @@ func TestVulnSrc_Update(t *testing.T) {
 						URL:  "https://github.com/pypa/advisory-db",
 					},
 				},
-				{
-					Key: []string{"data-source", "cargo::Open Source Vulnerability"},
-					Value: types.DataSource{
-						ID:   vulnerability.OSV,
-						Name: "RustSec Advisory Database",
-						URL:  "https://github.com/RustSec/advisory-db",
+				/*
+					{
+						Key: []string{"data-source", "cargo::Open Source Vulnerability"},
+						Value: types.DataSource{
+							ID:   vulnerability.OSV,
+							Name: "RustSec Advisory Database",
+							URL:  "https://github.com/RustSec/advisory-db",
+						},
 					},
-				},
+				*/
 				{
 					Key: []string{"advisory-detail", "CVE-2018-10895", "pip::Open Source Vulnerability", "qutebrowser"},
 					Value: types.Advisory{
@@ -56,31 +58,33 @@ func TestVulnSrc_Update(t *testing.T) {
 						},
 					},
 				},
-				{
-					Key: []string{"advisory-detail", "CVE-2017-18587", "cargo::Open Source Vulnerability", "hyper"},
-					Value: types.Advisory{
-						VulnerableVersions: []string{">=0.0.0-0, <0.9.18", ">=0.10.0, <0.10.2"},
-						PatchedVersions:    []string{"0.9.18", "0.10.2"},
-					},
-				},
-				{
-					Key: []string{"vulnerability-detail", "CVE-2017-18587", string(vulnerability.OSV)},
-					Value: types.VulnerabilityDetail{
-						Title:       "headers containing newline characters can split messages",
-						Description: "Serializing of headers to the socket did not filter the values for newline bytes (`\\r` or `\\n`),\nwhich allowed for header values to split a request or response. People would not likely include\nnewlines in the headers in their own applications, so the way for most people to exploit this\nis if an application constructs headers based on unsanitized user input.\n\nThis issue was fixed by replacing all newline characters with a space during serialization of\na header value.",
-						References: []string{
-							"https://crates.io/crates/hyper",
-							"https://rustsec.org/advisories/RUSTSEC-2017-0002.html",
-							"https://github.com/hyperium/hyper/wiki/Security-001",
+				/*
+						{
+							Key: []string{"advisory-detail", "CVE-2017-18587", "cargo::Open Source Vulnerability", "hyper"},
+							Value: types.Advisory{
+								VulnerableVersions: []string{">=0.0.0-0, <0.9.18", ">=0.10.0, <0.10.2"},
+								PatchedVersions:    []string{"0.9.18", "0.10.2"},
+							},
+						},
+					{
+						Key: []string{"vulnerability-detail", "CVE-2017-18587", string(vulnerability.OSV)},
+						Value: types.VulnerabilityDetail{
+							Title:       "headers containing newline characters can split messages",
+							Description: "Serializing of headers to the socket did not filter the values for newline bytes (`\\r` or `\\n`),\nwhich allowed for header values to split a request or response. People would not likely include\nnewlines in the headers in their own applications, so the way for most people to exploit this\nis if an application constructs headers based on unsanitized user input.\n\nThis issue was fixed by replacing all newline characters with a space during serialization of\na header value.",
+							References: []string{
+								"https://crates.io/crates/hyper",
+								"https://rustsec.org/advisories/RUSTSEC-2017-0002.html",
+								"https://github.com/hyperium/hyper/wiki/Security-001",
+							},
 						},
 					},
-				},
+					{
+						Key:   []string{"vulnerability-id", "CVE-2017-18587"},
+						Value: map[string]interface{}{},
+					},
+				*/
 				{
 					Key:   []string{"vulnerability-id", "CVE-2018-10895"},
-					Value: map[string]interface{}{},
-				},
-				{
-					Key:   []string{"vulnerability-id", "CVE-2017-18587"},
 					Value: map[string]interface{}{},
 				},
 			},

--- a/pkg/vulnsrc/osv/osv_test.go
+++ b/pkg/vulnsrc/osv/osv_test.go
@@ -29,16 +29,6 @@ func TestVulnSrc_Update(t *testing.T) {
 						URL:  "https://github.com/pypa/advisory-db",
 					},
 				},
-				/*
-					{
-						Key: []string{"data-source", "cargo::Open Source Vulnerability"},
-						Value: types.DataSource{
-							ID:   vulnerability.OSV,
-							Name: "RustSec Advisory Database",
-							URL:  "https://github.com/RustSec/advisory-db",
-						},
-					},
-				*/
 				{
 					Key: []string{"advisory-detail", "CVE-2018-10895", "pip::Open Source Vulnerability", "qutebrowser"},
 					Value: types.Advisory{
@@ -58,31 +48,6 @@ func TestVulnSrc_Update(t *testing.T) {
 						},
 					},
 				},
-				/*
-						{
-							Key: []string{"advisory-detail", "CVE-2017-18587", "cargo::Open Source Vulnerability", "hyper"},
-							Value: types.Advisory{
-								VulnerableVersions: []string{">=0.0.0-0, <0.9.18", ">=0.10.0, <0.10.2"},
-								PatchedVersions:    []string{"0.9.18", "0.10.2"},
-							},
-						},
-					{
-						Key: []string{"vulnerability-detail", "CVE-2017-18587", string(vulnerability.OSV)},
-						Value: types.VulnerabilityDetail{
-							Title:       "headers containing newline characters can split messages",
-							Description: "Serializing of headers to the socket did not filter the values for newline bytes (`\\r` or `\\n`),\nwhich allowed for header values to split a request or response. People would not likely include\nnewlines in the headers in their own applications, so the way for most people to exploit this\nis if an application constructs headers based on unsanitized user input.\n\nThis issue was fixed by replacing all newline characters with a space during serialization of\na header value.",
-							References: []string{
-								"https://crates.io/crates/hyper",
-								"https://rustsec.org/advisories/RUSTSEC-2017-0002.html",
-								"https://github.com/hyperium/hyper/wiki/Security-001",
-							},
-						},
-					},
-					{
-						Key:   []string{"vulnerability-id", "CVE-2017-18587"},
-						Value: map[string]interface{}{},
-					},
-				*/
 				{
 					Key:   []string{"vulnerability-id", "CVE-2018-10895"},
 					Value: map[string]interface{}{},

--- a/pkg/vulnsrc/vulnerability/const.go
+++ b/pkg/vulnsrc/vulnerability/const.go
@@ -37,5 +37,6 @@ const (
 	NuGet    types.Ecosystem = "nuget"
 	Maven    types.Ecosystem = "maven"
 	Go       types.Ecosystem = "go"
+	Rust     types.Ecosystem = "rust"
 	Conan    types.Ecosystem = "conan"
 )


### PR DESCRIPTION
## Description
Trivy DB should contain data from GitHub Advisory Database for Rust ecosystem: https://github.com/advisories?query=type%3Areviewed+ecosystem%3Arust

## Related PRs
- [x] https://github.com/aquasecurity/vuln-list-update/pull/174
