### PR TITLE
feat: fetch vulnerability IDs from references

### DIFF
--- a/pkg/utils/ids.go
+++ b/pkg/utils/ids.go
@@ -1,0 +1,55 @@
+package utils
+
+import (
+	"net/url"
+	"strings"
+
+	strutil "github.com/aquasecurity/trivy-db/pkg/utils/strings"
+)
+
+const (
+	nvd     = "nvd.nist.gov"
+	rustsec = "rustsec.org"
+	ghsa    = "github.com"
+)
+
+func GetUniqueIDsFromReferences(refs []string, knownIDs []string) []string {
+	condidates := map[string]interface{}{}
+	for _, ref := range refs {
+		u, err := url.Parse(ref)
+		if err != nil {
+			continue
+		}
+		id := ""
+		switch u.Host {
+		// https://rustsec.org/advisories/RUSTSEC-2021-0120.html"
+		case rustsec:
+			if strings.HasPrefix(u.Path, "/advisories/") {
+				id = strings.TrimSuffix(strings.TrimPrefix(u.Path, "/advisories/"), ".html")
+			}
+			break
+			// https://nvd.nist.gov/vuln/detail/CVE-2021-45708
+		case nvd:
+			if strings.HasPrefix(u.Path, "/vuln/detail/") {
+				id = strings.TrimPrefix(u.Path, "/vuln/detail/")
+			}
+			break
+			// https://github.com/advisories/GHSA-4qrp-27r3-66fj
+		case ghsa:
+			if strings.HasPrefix(u.Path, "/advisories/") {
+				id = strings.TrimPrefix(u.Path, "/advisories/")
+			}
+			break
+		default:
+			continue
+		}
+		if id != "" && !strutil.InSlice(id, knownIDs) {
+			condidates[id] = struct{}{}
+		}
+	}
+	ids := []string{}
+	for k := range condidates {
+		ids = append(ids, k)
+	}
+	return ids
+}

--- a/pkg/utils/ids.go
+++ b/pkg/utils/ids.go
@@ -14,7 +14,7 @@ const (
 )
 
 func GetUniqueIDsFromReferences(refs []string, knownIDs []string) []string {
-	condidates := map[string]interface{}{}
+	candidates := map[string]interface{}{}
 	for _, ref := range refs {
 		u, err := url.Parse(ref)
 		if err != nil {
@@ -41,11 +41,11 @@ func GetUniqueIDsFromReferences(refs []string, knownIDs []string) []string {
 			continue
 		}
 		if id != "" && !strutil.InSlice(id, knownIDs) {
-			condidates[id] = struct{}{}
+			candidates[id] = struct{}{}
 		}
 	}
 	ids := []string{}
-	for k := range condidates {
+	for k := range candidates {
 		ids = append(ids, k)
 	}
 	return ids

--- a/pkg/utils/ids.go
+++ b/pkg/utils/ids.go
@@ -27,19 +27,16 @@ func GetUniqueIDsFromReferences(refs []string, knownIDs []string) []string {
 			if strings.HasPrefix(u.Path, "/advisories/") {
 				id = strings.TrimSuffix(strings.TrimPrefix(u.Path, "/advisories/"), ".html")
 			}
-			break
-			// https://nvd.nist.gov/vuln/detail/CVE-2021-45708
+		// https://nvd.nist.gov/vuln/detail/CVE-2021-45708
 		case nvd:
 			if strings.HasPrefix(u.Path, "/vuln/detail/") {
 				id = strings.TrimPrefix(u.Path, "/vuln/detail/")
 			}
-			break
-			// https://github.com/advisories/GHSA-4qrp-27r3-66fj
+		// https://github.com/advisories/GHSA-4qrp-27r3-66fj
 		case ghsa:
 			if strings.HasPrefix(u.Path, "/advisories/") {
 				id = strings.TrimPrefix(u.Path, "/advisories/")
 			}
-			break
 		default:
 			continue
 		}

--- a/pkg/utils/ids_test.go
+++ b/pkg/utils/ids_test.go
@@ -46,6 +46,14 @@ func TestGetUniqueIDsFromReferences(t *testing.T) {
 				"CVE-2022-24749",
 			},
 		},
+		{
+			title: "no references, but there is a known vuln",
+			known: []string{
+				"GHSA-4qrp-27r3-66fj",
+			},
+			references: []string{},
+			ids:        []string{},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/utils/ids_test.go
+++ b/pkg/utils/ids_test.go
@@ -1,0 +1,57 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetUniqueIDsFromReferences(t *testing.T) {
+	tests := []struct {
+		title      string
+		known      []string
+		references []string
+		ids        []string
+	}{
+		{
+			title: "happy path",
+			known: []string{},
+			references: []string{
+				"https://github.com/Sylius/Sylius/security/advisories/GHSA-4qrp-27r3-66fj",
+				"https://github.com/Sylius/Sylius/releases/tag/v1.10.11",
+				"https://github.com/Sylius/Sylius/releases/tag/v1.11.2",
+				"https://github.com/Sylius/Sylius/releases/tag/v1.9.10",
+				"https://nvd.nist.gov/vuln/detail/CVE-2022-24749",
+				"https://github.com/advisories/GHSA-4qrp-27r3-66fj",
+			},
+			ids: []string{
+				"CVE-2022-24749",
+				"GHSA-4qrp-27r3-66fj",
+			},
+		},
+		{
+			title: "there is a known ID",
+			known: []string{
+				"GHSA-4qrp-27r3-66fj",
+			},
+			references: []string{
+				"https://github.com/Sylius/Sylius/security/advisories/GHSA-4qrp-27r3-66fj",
+				"https://github.com/Sylius/Sylius/releases/tag/v1.10.11",
+				"https://github.com/Sylius/Sylius/releases/tag/v1.11.2",
+				"https://github.com/Sylius/Sylius/releases/tag/v1.9.10",
+				"https://nvd.nist.gov/vuln/detail/CVE-2022-24749",
+				"https://github.com/advisories/GHSA-4qrp-27r3-66fj",
+			},
+			ids: []string{
+				"CVE-2022-24749",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.title, func(t *testing.T) {
+			got := GetUniqueIDsFromReferences(tt.references, tt.known)
+			assert.Equal(t, tt.ids, got)
+		})
+	}
+}

--- a/pkg/vulnsrc/ghsa/ghsa.go
+++ b/pkg/vulnsrc/ghsa/ghsa.go
@@ -122,16 +122,28 @@ func (vs VulnSrc) commit(tx *bolt.Tx, ecosystem types.Ecosystem, entries []Entry
 		}
 
 		vulnID := entry.Advisory.GhsaId
+		vendorIDs := []string{}
+
 		for _, identifier := range entry.Advisory.Identifiers {
+			if identifier.Value != "" {
+				vendorIDs = append(vendorIDs, identifier.Value)
+			}
 			if identifier.Type == "CVE" && identifier.Value != "" {
 				vulnID = identifier.Value
 			}
 		}
+		refs := []string{}
+		for _, ref := range entry.Advisory.References {
+			refs = append(refs, ref.Url)
+		}
+		vendorIDs = append(vendorIDs, utils.GetUniqueIDsFromReferences(refs, vendorIDs)...)
+
 		vulnID = strings.TrimSpace(vulnID)
 
 		a := types.Advisory{
 			PatchedVersions:    pvs,
 			VulnerableVersions: avs,
+			VendorIDs:          vendorIDs,
 		}
 
 		pkgName := vulnerability.NormalizePkgName(ecosystem, entry.Package.Name)

--- a/pkg/vulnsrc/ghsa/ghsa_test.go
+++ b/pkg/vulnsrc/ghsa/ghsa_test.go
@@ -33,6 +33,7 @@ func TestVulnSrc_Update(t *testing.T) {
 					Value: types.Advisory{
 						PatchedVersions:    []string{"4.8.6", "4.4.46"},
 						VulnerableVersions: []string{"\u003e= 4.5.0, \u003c 4.8.6", "\u003e= 4.0.0, \u003c 4.4.46"},
+						VendorIDs:          []string{"GHSA-wjx8-cgrm-hh8p", "CVE-2019-19745"},
 					},
 				},
 				{
@@ -71,6 +72,7 @@ func TestVulnSrc_Update(t *testing.T) {
 					Value: types.Advisory{
 						PatchedVersions:    []string{"1.5.10"},
 						VulnerableVersions: []string{"\u003e= 1.5.0, \u003c 1.5.10"},
+						VendorIDs:          []string{"GHSA-xx65-cc7g-9pfp", "CVE-2018-1196"},
 					},
 				},
 				{
@@ -106,6 +108,7 @@ func TestVulnSrc_Update(t *testing.T) {
 					Value: types.Advisory{
 						PatchedVersions:    []string{"2.1.0"},
 						VulnerableVersions: []string{"\u003c 2.1.0"},
+						VendorIDs:          []string{"GHSA-8w4h-3cm3-2pm2", "CVE-2018-3745"},
 					},
 				},
 				{
@@ -139,6 +142,7 @@ func TestVulnSrc_Update(t *testing.T) {
 					Key: []string{"advisory-detail", "CVE-2019-1010113", "nuget::GitHub Security Advisory Nuget", "CLEditor"},
 					Value: types.Advisory{
 						VulnerableVersions: []string{"\u003c= 1.4.5"},
+						VendorIDs:          []string{"GHSA-hh56-x62g-gvhc", "CVE-2019-1010113"},
 					},
 				},
 				{
@@ -170,6 +174,7 @@ func TestVulnSrc_Update(t *testing.T) {
 					Value: types.Advisory{
 						PatchedVersions:    []string{"2.0.8", "1.11.15"},
 						VulnerableVersions: []string{"\u003e= 2.0, \u003c 2.0.8", "\u003e= 1.11.0, \u003c 1.11.15"},
+						VendorIDs:          []string{"GHSA-5hg3-6c2f-f3wr", "CVE-2018-14574"},
 					},
 				},
 				{
@@ -210,6 +215,7 @@ func TestVulnSrc_Update(t *testing.T) {
 					Value: types.Advisory{
 						PatchedVersions:    []string{"5.2.1.1"},
 						VulnerableVersions: []string{"\u003e= 5.2.0, \u003c= 5.2.1.0"},
+						VendorIDs:          []string{"GHSA-7rr7-rcjw-56vj", "CVE-2018-16477"},
 					},
 				},
 				{


### PR DESCRIPTION
there are some advisories without aliases, but have references to it.

 ex: https://github.com/advisories/GHSA-5vwc-r48g-wj6c
this advisory doesn't have `RUSTSEC-2021-0120` as alias.

we can parse references and get IDs from it.