### PR TITLE
Publish tag containing the build date to locate old DB

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Upload assets to GHCR
         run: |
           ./oras version
-          tags=(latest ${{ env.VERSION }})
+          tags=(latest ${{ env.VERSION }} $(date +"%Y%m%d%H"))
           for tag in ${tags[@]}; do
             ./oras push ghcr.io/${{ github.repository }}:${tag} \
               --manifest-config /dev/null:application/vnd.aquasec.trivy.config.v1+json \


### PR DESCRIPTION
There does not currently appear to be any way to run Trivy using an older version of the DB.

Example use case: check how many vulnerabilities would have been detected by Trivy in a given image 30 days ago.

There is additional work to do in the CLI to change the tag to something other that "2" (for example `--db-tag=2022091512`). However, until these tags start to be published, there is no reliable way to obtain this data other than by scrubbing through the GitHub Actions logs, locating the digest published by oras, and following the air-gap instructions.