### PR TITLE
fix(debian): don't create advisories not contained in cve-xxx/dsa-xxx/dla-xxx

### DIFF
--- a/pkg/vulnsrc/debian/debian.go
+++ b/pkg/vulnsrc/debian/debian.go
@@ -42,7 +42,7 @@ const (
 var (
 	// NOTE: "removed" should not be marked as "not-affected".
 	// ref. https://security-team.debian.org/security_tracker.html#removed-packages
-	skipStatuses = []string{"not-affected", "undetermined"}
+	skipStatuses = []string{"not-affected", "undetermined", "ignored"}
 
 	source = types.DataSource{
 		ID:   vulnerability.Debian,

--- a/pkg/vulnsrc/debian/debian.go
+++ b/pkg/vulnsrc/debian/debian.go
@@ -42,7 +42,7 @@ const (
 var (
 	// NOTE: "removed" should not be marked as "not-affected".
 	// ref. https://security-team.debian.org/security_tracker.html#removed-packages
-	skipStatuses = []string{"not-affected", "undetermined", "ignored"}
+	skipStatuses = []string{"not-affected", "undetermined"}
 
 	source = types.DataSource{
 		ID:   vulnerability.Debian,

--- a/pkg/vulnsrc/debian/debian_test.go
+++ b/pkg/vulnsrc/debian/debian_test.go
@@ -45,12 +45,6 @@ func TestVulnSrc_Update(t *testing.T) {
 					},
 				},
 				{
-					Key: []string{"advisory-detail", "CVE-2021-33560", "debian 11", "libgcrypt20"},
-					Value: types.Advisory{
-						FixedVersion: "1.8.7-6",
-					},
-				},
-				{
 					Key: []string{"advisory-detail", "CVE-2021-29629", "debian 10", "dacs"},
 					Value: types.Advisory{
 						State:    "ignored",


### PR DESCRIPTION
## Description
If i understand correctly - Debian doesn't add old(EOL) releases to CVES.
e.g. [CVE-2022-3358](https://github.com/aquasecurity/vuln-list/blob/main/debian/CVE/CVE-2022-3358.json) doens't contain debian 8.
We are currently adding similar CVEs to the DB without a fixed version.
![Screenshot from 2022-11-21 15-56-56](https://user-images.githubusercontent.com/91113035/203020886-af234eb7-f14b-4c68-998c-ceb7d386a64a.png).

Fixed: Only found versions were used.

## Related issues:
- Close aquasecurity/trivy/issues/3194
- Close aquasecurity/trivy/issues/3147
