### PR TITLE
feat:  add support for Wolfi OS advisories

### DIFF
--- a/pkg/vulnsrc/vulnerability/const.go
+++ b/pkg/vulnsrc/vulnerability/const.go
@@ -16,6 +16,7 @@ const (
 	OracleOVAL            types.SourceID = "oracle-oval"
 	SuseCVRF              types.SourceID = "suse-cvrf"
 	Alpine                types.SourceID = "alpine"
+	Wolfi                 types.SourceID = "wolfi"
 	ArchLinux             types.SourceID = "arch-linux"
 	Alma                  types.SourceID = "alma"
 	CBLMariner            types.SourceID = "cbl-mariner"

--- a/pkg/vulnsrc/vulnsrc.go
+++ b/pkg/vulnsrc/vulnsrc.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/rocky"
 	susecvrf "github.com/aquasecurity/trivy-db/pkg/vulnsrc/suse-cvrf"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/ubuntu"
+	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/wolfi"
 )
 
 type VulnSrc interface {
@@ -39,6 +40,7 @@ var (
 		// OS packages
 		alma.NewVulnSrc(),
 		alpine.NewVulnSrc(),
+		wolfi.NewVulnSrc(),
 		archlinux.NewVulnSrc(),
 		redhat.NewVulnSrc(),
 		redhatoval.NewVulnSrc(),

--- a/pkg/vulnsrc/wolfi/wolfi.go
+++ b/pkg/vulnsrc/wolfi/wolfi.go
@@ -1,0 +1,27 @@
+package wolfi
+
+import (
+	"github.com/aquasecurity/trivy-db/pkg/types"
+	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/alpine"
+	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/vulnerability"
+)
+
+const (
+	wolfiDir       = "wolfi"
+	platformFormat = "wolfi%s"
+)
+
+var (
+	source = types.DataSource{
+		ID:   vulnerability.Wolfi,
+		Name: "Wolfi security databases",
+		URL:  "https://packages.wolfi.dev/os/security.json",
+	}
+)
+
+func NewVulnSrc() alpine.VulnSrc {
+	return alpine.NewVulnSrc(
+		alpine.WithDir(wolfiDir),
+		alpine.WithSource(source),
+		alpine.WithPlatformFormat(platformFormat))
+}

--- a/pkg/vulnsrc/wolfi/wolfi.go
+++ b/pkg/vulnsrc/wolfi/wolfi.go
@@ -14,7 +14,7 @@ const (
 var (
 	source = types.DataSource{
 		ID:   vulnerability.Wolfi,
-		Name: "Wolfi security databases",
+		Name: "Wolfi security database",
 		URL:  "https://packages.wolfi.dev/os/security.json",
 	}
 )


### PR DESCRIPTION
Wolfi is based on Alpine, but they have their own advisories.

Wolfi security databases are based on Alpine's security database format, presenting a serialized JSON graph.

## References
* https://packages.wolfi.dev/os/security.json
* https://www.chainguard.dev/unchained/introducing-wolfi-the-first-linux-un-distro
* https://github.com/wolfi-dev/secdb

## Related PRs
* https://github.com/aquasecurity/vuln-list-update/pull/181
