### PR TITLE
feat(wolfi): add support for Wolfi Linux

### DIFF
--- a/pkg/vulnsrc/vulnerability/const.go
+++ b/pkg/vulnsrc/vulnerability/const.go
@@ -27,6 +27,7 @@ const (
 	GLAD                  types.SourceID = "glad"
 	GoVulnDB              types.SourceID = "go-vulndb"
 	OSV                   types.SourceID = "osv"
+	Wolfi                 types.SourceID = "wolfi"
 
 	// Ecosystem
 	Npm      types.Ecosystem = "npm"

--- a/pkg/vulnsrc/vulnsrc.go
+++ b/pkg/vulnsrc/vulnsrc.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/rocky"
 	susecvrf "github.com/aquasecurity/trivy-db/pkg/vulnsrc/suse-cvrf"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/ubuntu"
+	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/wolfi"
 )
 
 type VulnSrc interface {
@@ -51,6 +52,7 @@ var (
 		susecvrf.NewVulnSrc(susecvrf.OpenSUSE),
 		photon.NewVulnSrc(),
 		mariner.NewVulnSrc(),
+		wolfi.NewVulnSrc(),
 
 		// Language-specific packages
 		bundler.NewVulnSrc(),

--- a/pkg/vulnsrc/wolfi/testdata/happy/vuln-list/wolfi/binutils.json
+++ b/pkg/vulnsrc/wolfi/testdata/happy/vuln-list/wolfi/binutils.json
@@ -1,0 +1,17 @@
+{
+  "name": "binutils",
+  "secfixes": {
+    "2.39-r1": [
+      "CVE-2022-38126"
+    ],
+    "2.39-r2": [
+      "CVE-2022-38533"
+    ]
+  },
+  "apkurl": "{{urlprefix}}/{{reponame}}/{{arch}}/{{pkg.name}}-{{pkg.ver}}.apk",
+  "archs": [
+    "x86_64"
+  ],
+  "urlprefix": "https://packages.wolfi.dev",
+  "reponame": "os"
+}

--- a/pkg/vulnsrc/wolfi/testdata/sad/vuln-list/wolfi/binutils.json
+++ b/pkg/vulnsrc/wolfi/testdata/sad/vuln-list/wolfi/binutils.json
@@ -1,0 +1,12 @@
+{
+  "name": "binutils",
+  "secfixes": {
+    "2.39-r1": {},
+  },
+  "apkurl": "{{urlprefix}}/{{reponame}}/{{arch}}/{{pkg.name}}-{{pkg.ver}}.apk",
+  "archs": [
+    "x86_64"
+  ],
+  "urlprefix": "https://packages.wolfi.dev",
+  "reponame": "os"
+}

--- a/pkg/vulnsrc/wolfi/types.go
+++ b/pkg/vulnsrc/wolfi/types.go
@@ -1,0 +1,11 @@
+package wolfi
+
+type advisory struct {
+	PkgName       string              `json:"name"`
+	Secfixes      map[string][]string `json:"secfixes"`
+	Apkurl        string              `json:"apkurl"`
+	Archs         []string            `json:"archs"`
+	Urlprefix     string              `json:"urlprefix"`
+	Reponame      string              `json:"reponame"`
+	Distroversion string              `json:"distroversion"`
+}

--- a/pkg/vulnsrc/wolfi/wolfi.go
+++ b/pkg/vulnsrc/wolfi/wolfi.go
@@ -1,0 +1,121 @@
+package wolfi
+
+import (
+	"encoding/json"
+	"io"
+	"path/filepath"
+	"strings"
+
+	bolt "go.etcd.io/bbolt"
+	"golang.org/x/xerrors"
+
+	"github.com/aquasecurity/trivy-db/pkg/db"
+	"github.com/aquasecurity/trivy-db/pkg/types"
+	"github.com/aquasecurity/trivy-db/pkg/utils"
+	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/vulnerability"
+)
+
+const (
+	wolfiDir   = "wolfi"
+	distroName = "wolfi"
+)
+
+var (
+	source = types.DataSource{
+		ID:   vulnerability.Wolfi,
+		Name: "Wolfi Secdb",
+		URL:  "https://packages.wolfi.dev/os/security.json",
+	}
+)
+
+type VulnSrc struct {
+	dbc db.Operation
+}
+
+func NewVulnSrc() VulnSrc {
+	return VulnSrc{
+		dbc: db.Config{},
+	}
+}
+
+func (vs VulnSrc) Name() types.SourceID {
+	return source.ID
+}
+
+func (vs VulnSrc) Update(dir string) error {
+	rootDir := filepath.Join(dir, "vuln-list", wolfiDir)
+	var advisories []advisory
+	err := utils.FileWalk(rootDir, func(r io.Reader, path string) error {
+		var advisory advisory
+		if err := json.NewDecoder(r).Decode(&advisory); err != nil {
+			return xerrors.Errorf("failed to decode Wolfi advisory: %w", err)
+		}
+		advisories = append(advisories, advisory)
+		return nil
+	})
+	if err != nil {
+		return xerrors.Errorf("error in Wolfi walk: %w", err)
+	}
+
+	if err = vs.save(advisories); err != nil {
+		return xerrors.Errorf("error in Wolfi save: %w", err)
+	}
+
+	return nil
+}
+
+func (vs VulnSrc) save(advisories []advisory) error {
+	err := vs.dbc.BatchUpdate(func(tx *bolt.Tx) error {
+		for _, adv := range advisories {
+			bucket := distroName
+			if err := vs.dbc.PutDataSource(tx, bucket, source); err != nil {
+				return xerrors.Errorf("failed to put data source: %w", err)
+			}
+			if err := vs.saveSecFixes(tx, distroName, adv.PkgName, adv.Secfixes); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return xerrors.Errorf("error in db batch update: %w", err)
+	}
+	return nil
+}
+
+func (vs VulnSrc) saveSecFixes(tx *bolt.Tx, platform, pkgName string, secfixes map[string][]string) error {
+	for fixedVersion, vulnIDs := range secfixes {
+		advisory := types.Advisory{
+			FixedVersion: fixedVersion,
+		}
+		for _, vulnID := range vulnIDs {
+			// See https://gitlab.alpinelinux.org/alpine/infra/docker/secdb/-/issues/3
+			// e.g. CVE-2017-2616 (+ regression fix)
+			ids := strings.Fields(vulnID)
+			for _, cveID := range ids {
+				cveID = strings.ReplaceAll(cveID, "CVE_", "CVE-")
+				if !strings.HasPrefix(cveID, "CVE-") {
+					continue
+				}
+				if err := vs.dbc.PutAdvisoryDetail(tx, cveID, pkgName, []string{platform}, advisory); err != nil {
+					return xerrors.Errorf("failed to save Wolfi advisory: %w", err)
+				}
+
+				// for optimization
+				if err := vs.dbc.PutVulnerabilityID(tx, cveID); err != nil {
+					return xerrors.Errorf("failed to save the vulnerability ID: %w", err)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (vs VulnSrc) Get(_, pkgName string) ([]types.Advisory, error) {
+	bucket := distroName
+	advisories, err := vs.dbc.GetAdvisories(bucket, pkgName)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to get Wolfi advisories: %w", err)
+	}
+	return advisories, nil
+}

--- a/pkg/vulnsrc/wolfi/wolfi_test.go
+++ b/pkg/vulnsrc/wolfi/wolfi_test.go
@@ -1,0 +1,63 @@
+package wolfi_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/wolfi"
+	"github.com/aquasecurity/trivy-db/pkg/vulnsrctest"
+
+	"github.com/aquasecurity/trivy-db/pkg/types"
+	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/vulnerability"
+)
+
+func TestVulnSrc_Update(t *testing.T) {
+	tests := []struct {
+		name       string
+		dir        string
+		wantValues []vulnsrctest.WantValues
+		wantErr    string
+	}{
+		{
+			name: "happy path",
+			dir:  filepath.Join("testdata", "happy"),
+			wantValues: []vulnsrctest.WantValues{
+				{
+					Key: []string{"data-source", "wolfi"},
+					Value: types.DataSource{
+						ID:   vulnerability.Wolfi,
+						Name: "Wolfi Secdb",
+						URL:  "https://packages.wolfi.dev/os/security.json",
+					},
+				},
+				{
+					Key: []string{"advisory-detail", "CVE-2022-38126", "wolfi", "binutils"},
+					Value: types.Advisory{
+						FixedVersion: "2.39-r1",
+					},
+				},
+				{
+					Key: []string{"advisory-detail", "CVE-2022-38533", "wolfi", "binutils"},
+					Value: types.Advisory{
+						FixedVersion: "2.39-r2",
+					},
+				},
+			},
+		},
+		{
+			name:    "sad path",
+			dir:     filepath.Join("testdata", "sad"),
+			wantErr: "failed to decode Wolfi advisory",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vs := wolfi.NewVulnSrc()
+			vulnsrctest.TestUpdate(t, vs, vulnsrctest.TestUpdateArgs{
+				Dir:        tt.dir,
+				WantValues: tt.wantValues,
+				WantErr:    tt.wantErr,
+			})
+		})
+	}
+}


### PR DESCRIPTION
This PR follows up https://github.com/aquasecurity/vuln-list-update/pull/183 and adds support for the Wolfi secdb data to be included in Trivy's vulnerability database file.

Related to https://github.com/aquasecurity/trivy/issues/3205