### PR TITLE
feat(ghsa): add pub ecosystem

### DIFF
--- a/pkg/vulnsrc/bucket/bucket.go
+++ b/pkg/vulnsrc/bucket/bucket.go
@@ -31,6 +31,8 @@ func Name(ecosystem, dataSource string) string {
 		prefix = vulnerability.Conan
 	case "cargo", "rust":
 		prefix = vulnerability.Cargo
+	case "pub":
+		prefix = vulnerability.Pub
 	default:
 		return ""
 	}

--- a/pkg/vulnsrc/ghsa/ghsa.go
+++ b/pkg/vulnsrc/ghsa/ghsa.go
@@ -33,6 +33,7 @@ var (
 		vulnerability.Pip,
 		vulnerability.RubyGems,
 		vulnerability.Rust,
+		vulnerability.Pub,
 	}
 	platformFormat = "GitHub Security Advisory %s"
 )

--- a/pkg/vulnsrc/ghsa/ghsa_test.go
+++ b/pkg/vulnsrc/ghsa/ghsa_test.go
@@ -297,6 +297,45 @@ func TestVulnSrc_Update(t *testing.T) {
 					Key:   []string{"vulnerability-id", "CVE-2020-8911"},
 					Value: map[string]interface{}{},
 				},
+				{
+					Key: []string{"data-source", "pub::GitHub Security Advisory Pub"},
+					Value: types.DataSource{
+						ID:   vulnerability.GHSA,
+						Name: "GitHub Security Advisory Pub",
+						URL:  "https://github.com/advisories?query=type%3Areviewed+ecosystem%3Apub",
+					},
+				},
+				{
+					Key: []string{"advisory-detail", "CVE-2020-35669", "pub::GitHub Security Advisory Pub", "http"},
+					Value: types.Advisory{
+						PatchedVersions:    []string{"0.13.3"},
+						VulnerableVersions: []string{"\u003c 0.13.3"},
+					},
+				},
+				{
+					Key: []string{"vulnerability-detail", "CVE-2020-35669", ghsaDir},
+					Value: types.VulnerabilityDetail{
+						ID:          "CVE-2020-35669",
+						Title:       "http before 0.13.3 vulnerable to header injection",
+						Description: `An issue was discovered in the http package before 0.13.3 for Dart. If the attacker controls the HTTP method and the app is using Request directly, it's possible to achieve CRLF injection in an HTTP request via HTTP header injection. This issue has been addressed in commit abb2bb182 by validating request methods.`,
+						References: []string{
+							"https://nvd.nist.gov/vuln/detail/CVE-2020-35669",
+							"https://github.com/dart-lang/http/issues/511",
+							"https://github.com/dart-lang/http/blob/master/CHANGELOG.md#0133",
+							"https://github.com/dart-lang/http/pull/512",
+							"https://github.com/dart-lang/http/commit/abb2bb182fbd7f03aafd1f889b902d7b3bdb8769",
+							"https://pub.dev/packages/http/changelog#0133",
+							"https://github.com/advisories/GHSA-4rgh-jx4f-qfcq",
+						},
+						Severity:     types.SeverityMedium,
+						CvssScoreV3:  6.1,
+						CvssVectorV3: "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+					},
+				},
+				{
+					Key:   []string{"vulnerability-id", "CVE-2020-35669"},
+					Value: map[string]interface{}{},
+				},
 			},
 		},
 		{

--- a/pkg/vulnsrc/ghsa/testdata/happy/vuln-list/ghsa/pub/http/GHSA-4rgh-jx4f-qfcq.json
+++ b/pkg/vulnsrc/ghsa/testdata/happy/vuln-list/ghsa/pub/http/GHSA-4rgh-jx4f-qfcq.json
@@ -1,0 +1,65 @@
+{
+  "Severity": "MODERATE",
+  "UpdatedAt": "2022-08-04T21:05:04Z",
+  "Package": {
+    "Ecosystem": "PUB",
+    "Name": "http"
+  },
+  "Advisory": {
+    "DatabaseId": 159707,
+    "Id": "GSA_kwCzR0hTQS00cmdoLWp4NGYtcWZjcc4AAm_b",
+    "GhsaId": "GHSA-4rgh-jx4f-qfcq",
+    "References": [
+      {
+        "Url": "https://nvd.nist.gov/vuln/detail/CVE-2020-35669"
+      },
+      {
+        "Url": "https://github.com/dart-lang/http/issues/511"
+      },
+      {
+        "Url": "https://github.com/dart-lang/http/blob/master/CHANGELOG.md#0133"
+      },
+      {
+        "Url": "https://github.com/dart-lang/http/pull/512"
+      },
+      {
+        "Url": "https://github.com/dart-lang/http/commit/abb2bb182fbd7f03aafd1f889b902d7b3bdb8769"
+      },
+      {
+        "Url": "https://pub.dev/packages/http/changelog#0133"
+      },
+      {
+        "Url": "https://github.com/advisories/GHSA-4rgh-jx4f-qfcq"
+      }
+    ],
+    "Identifiers": [
+      {
+        "Type": "GHSA",
+        "Value": "GHSA-4rgh-jx4f-qfcq"
+      },
+      {
+        "Type": "CVE",
+        "Value": "CVE-2020-35669"
+      }
+    ],
+    "Description": "An issue was discovered in the http package before 0.13.3 for Dart. If the attacker controls the HTTP method and the app is using Request directly, it's possible to achieve CRLF injection in an HTTP request via HTTP header injection. This issue has been addressed in commit abb2bb182 by validating request methods.",
+    "Origin": "UNSPECIFIED",
+    "PublishedAt": "2022-05-24T17:37:16Z",
+    "Severity": "MODERATE",
+    "Summary": "http before 0.13.3 vulnerable to header injection",
+    "UpdatedAt": "2022-10-06T20:26:08Z",
+    "WithdrawnAt": "",
+    "CVSS": {
+      "Score": 6.1,
+      "VectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N"
+    }
+  },
+  "Versions": [
+    {
+      "FirstPatchedVersion": {
+        "Identifier": "0.13.3"
+      },
+      "VulnerableVersionRange": "\u003c 0.13.3"
+    }
+  ]
+}

--- a/pkg/vulnsrc/vulnerability/const.go
+++ b/pkg/vulnsrc/vulnerability/const.go
@@ -40,4 +40,5 @@ const (
 	Go       types.Ecosystem = "go"
 	Rust     types.Ecosystem = "rust"
 	Conan    types.Ecosystem = "conan"
+	Pub      types.Ecosystem = "pub"
 )


### PR DESCRIPTION
## Description
Add `pub` ecosystem for `Dart`

Required to merge [#186](https://github.com/aquasecurity/vuln-list-update/pull/186) first.