### PR TITLE
ci: update deprecated GitHub Actions with Node 12 and `save-state` command

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.17
         id: go
@@ -22,7 +22,7 @@ jobs:
         run: go install go.etcd.io/bbolt/cmd/bbolt@v1.3.5
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Download vuln-list and advisories
         run: make db-fetch-langs db-fetch-vuln-list
@@ -43,7 +43,7 @@ jobs:
         run: mv assets/db.tar.gz .
 
       - name: Login to GitHub Packages Container registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ env.GH_USER }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.17
         id: go

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3
       - name: yaml-lint
-        uses: ibiqlik/action-yamllint@v3
+        uses: ibiqlik/action-yamllint@v3.1.1
       - name: Lint
         uses: golangci/golangci-lint-action@v3.1.0
         with:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@ jobs:
         id: go
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2.5.0
+        uses: actions/checkout@v3
       - name: yaml-lint
         uses: ibiqlik/action-yamllint@v3.1.1
       - name: Lint

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@ jobs:
         id: go
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2.5.0
       - name: yaml-lint
         uses: ibiqlik/action-yamllint@v3.1.1
       - name: Lint

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@ jobs:
         id: go
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
       - name: yaml-lint
         uses: ibiqlik/action-yamllint@v3
       - name: Lint

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,9 +16,9 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3
       - name: yaml-lint
-        uses: ibiqlik/action-yamllint@v3.1.1
+        uses: ibiqlik/action-yamllint@v3
       - name: Lint
-        uses: golangci/golangci-lint-action@v3.1.0
+        uses: golangci/golangci-lint-action@v3.4.0
         with:
           version: v1.45.2
           args: -D errcheck


### PR DESCRIPTION
Node 12 has been out of support since April 2022, so Node.js 12 actions are deprecated.
we should update the actions (actions/setup-go@v2, actions/checkout@v2, docker/login-action@v1) to use Node.js 16.

Also `save-state` and `set-output` commands are deprecated now, so all actions should be updated for using `@actions/core` package v1.10.0 or greater.

Before:
![image](https://user-images.githubusercontent.com/19297627/223060652-d48362f5-2807-4d3f-bf4d-dd7f03c8c8ca.png)

After:
![image](https://user-images.githubusercontent.com/19297627/223060193-5d47b9dc-dd8c-40fa-acfe-da94e5b1cbf6.png)
