### PR TITLE
feat(amazon): add amazon linux 2023 support

### DIFF
--- a/pkg/vulnsrc/amazon/amazon.go
+++ b/pkg/vulnsrc/amazon/amazon.go
@@ -24,7 +24,7 @@ const (
 )
 
 var (
-	targetVersions = []string{"1", "2", "2022"}
+	targetVersions = []string{"1", "2", "2022", "2023"}
 
 	source = types.DataSource{
 		ID:   vulnerability.Amazon,


### PR DESCRIPTION
## Description
Add `Amazon Linux 2023` support.

## Related PRs
- [x] aquasecurity/vuln-list-update/pull/199
merge this PR first!