### PR TITLE
upgrade to oras 1.0.0 and fix issue with 0 length config

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -51,16 +51,16 @@ jobs:
 
       - name: Install oras
         run: |
-          # oras was rollbacked to v0.12.0, because now v0.13.0 (the latest version) contains bugs: https://github.com/oras-project/oras/issues/447
-          curl -LO https://github.com/oras-project/oras/releases/download/v0.12.0/oras_0.12.0_linux_amd64.tar.gz
-          tar -xvf ./oras_0.12.0_linux_amd64.tar.gz
+          # upgrade to ORAS 1.0.0
+          curl -LO https://github.com/oras-project/oras/releases/download/v1.0.0/oras_1.0.0_linux_amd64.tar.gz
+          tar -xvf ./oras_1.0.0_linux_amd64.tar.gz
 
       - name: Upload assets to GHCR
         run: |
           ./oras version
           tags=(latest ${{ env.VERSION }})
           for tag in ${tags[@]}; do
-            ./oras push ghcr.io/${{ github.repository }}:${tag} \
-              --manifest-config /dev/null:application/vnd.aquasec.trivy.config.v1+json \
+            ./oras push --artifact-type application/vnd.aquasec.trivy.config.v1+json \
+              ghcr.io/${{ github.repository }}:${tag} \
               db.tar.gz:application/vnd.aquasec.trivy.db.layer.v1.tar+gzip
           done


### PR DESCRIPTION
This pull request updates the github workflow to use oras version 1.0.0, I believe the bugs that were preventing an upgrade have now been resolved.  see [oras issue #447](https://github.com/oras-project/oras/issues/447).

This pull request also updates the syntax used to push the OCI artifact. Using /dev/null as the source for the config results in a zero (0) length blob, this causes an error when using `oras copy` to  copy the artifact to another v2 API registry. Using the new `--artifact-type` parameter creates a config of the given type, containing an empty json object `{}`, and allows for the artifact to be copied successfully.

These changes are necessary to allow the trivy db OCI artifact to be copied to a registry hosted on an air-gapped network.