### PR TITLE
Fix panics caused by keeping unsafe byte arrays returned by Bolt

### DIFF
--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -157,7 +157,12 @@ func (dbc Config) get(bktNames []string, key string) (value []byte, err error) {
 				return nil
 			}
 		}
-		value = bkt.Get([]byte(key))
+		dbValue := bkt.Get([]byte(key))
+
+		// Copy the byte slice so it can be used outside of the current transaction
+		value = make([]byte, len(dbValue))
+		copy(value, dbValue)
+
 		return nil
 	})
 	if err != nil {
@@ -216,9 +221,13 @@ func (dbc Config) forEach(bktNames []string) (map[string]Value, error) {
 			}
 
 			err = bkt.ForEach(func(k, v []byte) error {
+				// Copy the byte slice so it can be used outside of the current transaction
+				copiedContent := make([]byte, len(v))
+				copy(copiedContent, v)
+
 				values[string(k)] = Value{
 					Source:  source,
-					Content: v,
+					Content: copiedContent,
 				}
 				return nil
 			})


### PR DESCRIPTION
Slices returned by Bolt's Get and ForEach are only valid while the transaction is open (this is documented for example at https://github.com/etcd-io/bbolt#foreach). The return values of `get` and `forEach` in `db.go` were thus unsafe; using them for example json unmarshalling in `GetAdvisories` lead to panics (segmentation violations).

This is unlikely to happen when used as part of a one-time CLI, but happened regularly when used as part of a long-running service.

Note: we fixed this issue internally a few weeks ago (no occurence of panics since then), and haven't kept the stack traces around to create an issue unfortunately (not that they were particularly helpful, as the code at the root of the issue wasn't part of the trace).