### PR TITLE
feat(ubuntu): support Ubuntu 23.04

### DIFF
--- a/pkg/vulnsrc/ubuntu/ubuntu.go
+++ b/pkg/vulnsrc/ubuntu/ubuntu.go
@@ -47,6 +47,7 @@ var (
 		"impish":  "21.10",
 		"jammy":   "22.04",
 		"kinetic": "22.10",
+		"lunar":   "23.04",
 		// ESM versions:
 		"precise/esm":      "12.04-ESM",
 		"trusty/esm":       "14.04-ESM",


### PR DESCRIPTION
Ubuntu 23.04's code name is Lunar Lobster - see https://wiki.ubuntu.com/Releases.