### PR TITLE
feat(redhat-oval): fill DataSource field in Advisories from Get function

### DIFF
--- a/pkg/vulnsrc/redhat-oval/redhat-oval.go
+++ b/pkg/vulnsrc/redhat-oval/redhat-oval.go
@@ -275,6 +275,7 @@ func (vs VulnSrc) Get(pkgName string, repositories, nvrs []string) ([]types.Advi
 					FixedVersion: entry.FixedVersion,
 					Arches:       entry.Arches,
 					State:        entry.State,
+					DataSource:   &v.Source,
 				}
 
 				if strings.HasPrefix(vulnID, "CVE-") {

--- a/pkg/vulnsrc/redhat-oval/redhat-oval_test.go
+++ b/pkg/vulnsrc/redhat-oval/redhat-oval_test.go
@@ -544,37 +544,6 @@ func TestVulnSrc_Get(t *testing.T) {
 			},
 		},
 		{
-			name: "nvr",
-			args: args{
-				pkgName: "bind",
-				nvrs:    []string{"ubi8-init-container-8.0-7-x86_64"},
-			},
-			fixtures: []string{"testdata/fixtures/happy.yaml", "testdata/fixtures/cpe.yaml", "testdata/fixtures/data-source.yaml"},
-			want: []types.Advisory{
-				{
-					VulnerabilityID: "CVE-2017-3145",
-					VendorIDs:       []string{"RHSA-2018:0488"},
-					Severity:        types.SeverityHigh,
-					FixedVersion:    "32:9.9.4-29.el7_2.8",
-					Arches:          []string{"i386", "ppc64", "x86_64"},
-					DataSource: &types.DataSource{
-						ID:   vulnerability.RedHatOVAL,
-						Name: "Red Hat OVAL v2",
-						URL:  "https://www.redhat.com/security/data/oval/v2/",
-					},
-				},
-				{
-					VulnerabilityID: "CVE-2020-8625",
-					Severity:        types.SeverityLow,
-					DataSource: &types.DataSource{
-						ID:   vulnerability.RedHatOVAL,
-						Name: "Red Hat OVAL v2",
-						URL:  "https://www.redhat.com/security/data/oval/v2/",
-					},
-				},
-			},
-		},
-		{
 			name: "no CPE match",
 			args: args{
 				pkgName:      "bind",

--- a/pkg/vulnsrc/redhat-oval/redhat-oval_test.go
+++ b/pkg/vulnsrc/redhat-oval/redhat-oval_test.go
@@ -487,7 +487,7 @@ func TestVulnSrc_Get(t *testing.T) {
 				pkgName:      "bind",
 				repositories: []string{"rhel-8-for-x86_64-baseos-rpms"},
 			},
-			fixtures: []string{"testdata/fixtures/happy.yaml", "testdata/fixtures/cpe.yaml"},
+			fixtures: []string{"testdata/fixtures/happy.yaml", "testdata/fixtures/cpe.yaml", "testdata/fixtures/data-source.yaml"},
 			want: []types.Advisory{
 				{
 					VulnerabilityID: "CVE-2017-3145",
@@ -495,10 +495,20 @@ func TestVulnSrc_Get(t *testing.T) {
 					Severity:        types.SeverityHigh,
 					FixedVersion:    "32:9.9.4-29.el7_2.8",
 					Arches:          []string{"i386", "ppc64", "x86_64"},
+					DataSource: &types.DataSource{
+						ID:   vulnerability.RedHatOVAL,
+						Name: "Red Hat OVAL v2",
+						URL:  "https://www.redhat.com/security/data/oval/v2/",
+					},
 				},
 				{
 					VulnerabilityID: "CVE-2020-8625",
 					Severity:        types.SeverityLow,
+					DataSource: &types.DataSource{
+						ID:   vulnerability.RedHatOVAL,
+						Name: "Red Hat OVAL v2",
+						URL:  "https://www.redhat.com/security/data/oval/v2/",
+					},
 				},
 			},
 		},
@@ -508,7 +518,7 @@ func TestVulnSrc_Get(t *testing.T) {
 				pkgName: "bind",
 				nvrs:    []string{"ubi8-init-container-8.0-7-x86_64"},
 			},
-			fixtures: []string{"testdata/fixtures/happy.yaml", "testdata/fixtures/cpe.yaml"},
+			fixtures: []string{"testdata/fixtures/happy.yaml", "testdata/fixtures/cpe.yaml", "testdata/fixtures/data-source.yaml"},
 			want: []types.Advisory{
 				{
 					VulnerabilityID: "CVE-2017-3145",
@@ -516,10 +526,20 @@ func TestVulnSrc_Get(t *testing.T) {
 					Severity:        types.SeverityHigh,
 					FixedVersion:    "32:9.9.4-29.el7_2.8",
 					Arches:          []string{"i386", "ppc64", "x86_64"},
+					DataSource: &types.DataSource{
+						ID:   vulnerability.RedHatOVAL,
+						Name: "Red Hat OVAL v2",
+						URL:  "https://www.redhat.com/security/data/oval/v2/",
+					},
 				},
 				{
 					VulnerabilityID: "CVE-2020-8625",
 					Severity:        types.SeverityLow,
+					DataSource: &types.DataSource{
+						ID:   vulnerability.RedHatOVAL,
+						Name: "Red Hat OVAL v2",
+						URL:  "https://www.redhat.com/security/data/oval/v2/",
+					},
 				},
 			},
 		},
@@ -529,7 +549,7 @@ func TestVulnSrc_Get(t *testing.T) {
 				pkgName: "bind",
 				nvrs:    []string{"ubi8-init-container-8.0-7-x86_64"},
 			},
-			fixtures: []string{"testdata/fixtures/happy.yaml", "testdata/fixtures/cpe.yaml"},
+			fixtures: []string{"testdata/fixtures/happy.yaml", "testdata/fixtures/cpe.yaml", "testdata/fixtures/data-source.yaml"},
 			want: []types.Advisory{
 				{
 					VulnerabilityID: "CVE-2017-3145",
@@ -537,10 +557,20 @@ func TestVulnSrc_Get(t *testing.T) {
 					Severity:        types.SeverityHigh,
 					FixedVersion:    "32:9.9.4-29.el7_2.8",
 					Arches:          []string{"i386", "ppc64", "x86_64"},
+					DataSource: &types.DataSource{
+						ID:   vulnerability.RedHatOVAL,
+						Name: "Red Hat OVAL v2",
+						URL:  "https://www.redhat.com/security/data/oval/v2/",
+					},
 				},
 				{
 					VulnerabilityID: "CVE-2020-8625",
 					Severity:        types.SeverityLow,
+					DataSource: &types.DataSource{
+						ID:   vulnerability.RedHatOVAL,
+						Name: "Red Hat OVAL v2",
+						URL:  "https://www.redhat.com/security/data/oval/v2/",
+					},
 				},
 			},
 		},

--- a/pkg/vulnsrc/redhat-oval/testdata/fixtures/data-source.yaml
+++ b/pkg/vulnsrc/redhat-oval/testdata/fixtures/data-source.yaml
@@ -1,0 +1,7 @@
+- bucket: data-source
+  pairs:
+    - key: Red Hat
+      value:
+        ID: "redhat-oval"
+        Name: "Red Hat OVAL v2"
+        URL: "https://www.redhat.com/security/data/oval/v2/"


### PR DESCRIPTION
## Description
Fill `DataSource` field in advisories from [Get](https://github.com/aquasecurity/trivy-db/blob/6e8ee5a37ad994f13ef21d69cbe1d0ec7a8b0539/pkg/vulnsrc/redhat-oval/redhat-oval.go#L245) function.