### PR TITLE
chore: fall back into vuln-list-reserve

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ db-clean:
 .PHONY: db-fetch-vuln-list
 db-fetch-vuln-list:
 	mkdir -p cache/vuln-list
-	wget -qO - https://github.com/$(REPO_OWNER)/vuln-list/archive/main.tar.gz | tar xz -C cache/vuln-list --strip-components=1
+	wget -qO - https://github.com/$(REPO_OWNER)/vuln-list-reserve/archive/main.tar.gz | tar xz -C cache/vuln-list --strip-components=1
 	mkdir -p cache/vuln-list-redhat
 	wget -qO - https://github.com/$(REPO_OWNER)/vuln-list-redhat/archive/main.tar.gz | tar xz -C cache/vuln-list-redhat --strip-components=1
 	mkdir -p cache/vuln-list-debian

--- a/pkg/vulnsrc/vulnsrc.go
+++ b/pkg/vulnsrc/vulnsrc.go
@@ -5,7 +5,6 @@ import (
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/alma"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/alpine"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/amazon"
-	archlinux "github.com/aquasecurity/trivy-db/pkg/vulnsrc/arch-linux"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/bundler"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/chainguard"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/composer"
@@ -40,7 +39,6 @@ var (
 		// OS packages
 		alma.NewVulnSrc(),
 		alpine.NewVulnSrc(),
-		archlinux.NewVulnSrc(),
 		redhat.NewVulnSrc(),
 		redhatoval.NewVulnSrc(),
 		debian.NewVulnSrc(),


### PR DESCRIPTION
See https://github.com/aquasecurity/vuln-list-update/pull/229

Also, this PR drops Arch Linux since Trivy doesn't support it.