### PR TITLE
BugFix|Assigned erratum to custom put input

### DIFF
--- a/pkg/vulnsrc/rocky/rocky.go
+++ b/pkg/vulnsrc/rocky/rocky.go
@@ -222,6 +222,7 @@ func (vs *VulnSrc) commit(tx *bolt.Tx, platformName string, errata []RLSA) error
 			input.PlatformName = platformName
 			input.CveID = cveID
 			input.Vuln = vuln
+			input.Erratum = erratum
 
 			savedInputs[cveID] = input
 		}


### PR DESCRIPTION
erratum value is not being sent to custom "Put" input anymore which is resulting in tracker failure. This started happening post the recent changes in rocky tracker. 

Added back the erratum assignment to custom Put input