### PR TITLE
fix(ci): move `CocoaPods Specs` load into `db-fetch-langs` command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,20 +53,23 @@ $(GOBIN)/bbolt:
 trivy-db:
 	make build
 
+## db-all is not used in GitHub Actions
 .PHONY: db-all
 db-all:
-	make build db-fetch-langs db-fetch-vuln-list db-fetch-cocoapods
+	make build db-fetch-langs db-fetch-vuln-list
 	make db-build
 	make db-compact
 	make db-compress
 
 .PHONY: db-fetch-langs
 db-fetch-langs:
-	mkdir -p cache/ruby-advisory-db cache/php-security-advisories cache/nodejs-security-wg cache/ghsa
+	mkdir -p cache/ruby-advisory-db cache/php-security-advisories cache/nodejs-security-wg cache/ghsa cache/cocoapods-specs
 	wget -qO - https://github.com/rubysec/ruby-advisory-db/archive/master.tar.gz | tar xz -C cache/ruby-advisory-db --strip-components=1
 	wget -qO - https://github.com/FriendsOfPHP/security-advisories/archive/master.tar.gz | tar xz -C cache/php-security-advisories --strip-components=1
 	wget -qO - https://github.com/nodejs/security-wg/archive/main.tar.gz | tar xz -C cache/nodejs-security-wg --strip-components=1
 	wget -qO - https://github.com/github/advisory-database/archive/refs/heads/main.tar.gz | tar xz -C cache/ghsa --strip-components=1
+	## required to convert GHSA Swift repo links to Cocoapods package names
+	wget -qO - https://github.com/CocoaPods/Specs/archive/master.zip | tar xz -C cache/cocoapods-specs --strip-components=1
 
 .PHONY: db-build
 db-build: trivy-db
@@ -97,9 +100,3 @@ db-fetch-vuln-list:
 	wget -qO - https://github.com/$(REPO_OWNER)/vuln-list-debian/archive/main.tar.gz | tar xz -C cache/vuln-list-debian --strip-components=1
 	mkdir -p cache/vuln-list-nvd
 	wget -qO - https://github.com/$(REPO_OWNER)/vuln-list-nvd/archive/main.tar.gz | tar xz -C cache/vuln-list-nvd --strip-components=1
-
-## required to convert GHSA Swift repo links to Cocoapods package names
-.PHONY: db-fetch-cocoapods
-db-fetch-cocoapods:
-	mkdir -p cache/cocoapods-specs
-	wget -qO - https://github.com/CocoaPods/Specs/archive/master.zip | tar xz -C cache/cocoapods-specs --strip-components=1


### PR DESCRIPTION
## Description
Github Action doesn't use `db-all` command.
Add comment about this and move `CocoaPods Specs` load into `db-fetch-langs` command.