### PR TITLE
fix(ghsa): return Rust advisories 

### DIFF
--- a/pkg/vulnsrc/ghsa/ghsa.go
+++ b/pkg/vulnsrc/ghsa/ghsa.go
@@ -58,6 +58,10 @@ func (GHSA) Update(root string) error {
 			Name: fmt.Sprintf(platformFormat, cases.Title(language.English).String(string(ecosystem))),
 			URL:  fmt.Sprintf("https://github.com/advisories?query=type%%3Areviewed+ecosystem%%3A%s", ecosystem),
 		}
+		// Trivy uses Cargo for Rust
+		if ecosystem == vulnerability.Rust {
+			ecosystem = vulnerability.Cargo
+		}
 		dataSources[ecosystem] = src
 
 		// CocoaPods' vulnerability detection uses the Swift advisories.

--- a/pkg/vulnsrc/ghsa/ghsa_test.go
+++ b/pkg/vulnsrc/ghsa/ghsa_test.go
@@ -76,6 +76,59 @@ func TestVulnSrc_Update(t *testing.T) {
 				{
 					Key: []string{
 						"data-source",
+						"cargo::GitHub Security Advisory Rust",
+					},
+					Value: types.DataSource{
+						ID:   vulnerability.GHSA,
+						Name: "GitHub Security Advisory Rust",
+						URL:  "https://github.com/advisories?query=type%3Areviewed+ecosystem%3Arust",
+					},
+				},
+				{
+					Key: []string{
+						"advisory-detail",
+						"CVE-2020-25792",
+						"cargo::GitHub Security Advisory Rust",
+						"sized-chunks",
+					},
+					Value: types.Advisory{
+						VendorIDs: []string{
+							"GHSA-mp6f-p9gp-vpj9",
+						},
+						PatchedVersions:    []string{"0.6.3"},
+						VulnerableVersions: []string{"<0.6.3"},
+					},
+				},
+				{
+					Key: []string{
+						"vulnerability-detail",
+						"CVE-2020-25792",
+						"ghsa",
+					},
+					Value: types.VulnerabilityDetail{
+						Title:       "Array size is not checked in sized-chunks",
+						Description: "An issue was discovered in the sized-chunks crate through 0.6.2 for Rust. In the Chunk implementation, the array size is not checked when constructed with pair().",
+						References: []string{
+							"https://nvd.nist.gov/vuln/detail/CVE-2020-25792",
+							"https://github.com/bodil/sized-chunks/issues/11",
+							"https://github.com/bodil/sized-chunks",
+							"https://rustsec.org/advisories/RUSTSEC-2020-0041.html",
+						},
+						Severity:     types.SeverityHigh,
+						CvssVectorV3: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+						CvssScoreV3:  7.5,
+					},
+				},
+				{
+					Key: []string{
+						"vulnerability-id",
+						"CVE-2020-25792",
+					},
+					Value: map[string]interface{}{},
+				},
+				{
+					Key: []string{
+						"data-source",
 						"go::GitHub Security Advisory Go",
 					},
 					Value: types.DataSource{

--- a/pkg/vulnsrc/ghsa/testdata/happy/ghsa/advisories/github-reviewed/2021/08/GHSA-mp6f-p9gp-vpj9/GHSA-mp6f-p9gp-vpj9.json
+++ b/pkg/vulnsrc/ghsa/testdata/happy/ghsa/advisories/github-reviewed/2021/08/GHSA-mp6f-p9gp-vpj9/GHSA-mp6f-p9gp-vpj9.json
@@ -1,0 +1,65 @@
+{
+  "schema_version": "1.4.0",
+  "id": "GHSA-mp6f-p9gp-vpj9",
+  "modified": "2022-06-14T20:54:51Z",
+  "published": "2021-08-25T20:46:06Z",
+  "aliases": [
+    "CVE-2020-25792"
+  ],
+  "summary": "Array size is not checked in sized-chunks",
+  "details": "An issue was discovered in the sized-chunks crate through 0.6.2 for Rust. In the Chunk implementation, the array size is not checked when constructed with pair().",
+  "severity": [
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+    }
+  ],
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "crates.io",
+        "name": "sized-chunks"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0.6.3"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ADVISORY",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-25792"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/bodil/sized-chunks/issues/11"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/bodil/sized-chunks"
+    },
+    {
+      "type": "WEB",
+      "url": "https://rustsec.org/advisories/RUSTSEC-2020-0041.html"
+    }
+  ],
+  "database_specific": {
+    "cwe_ids": [
+      "CWE-129"
+    ],
+    "severity": "HIGH",
+    "github_reviewed": true,
+    "github_reviewed_at": "2021-08-19T21:20:31Z",
+    "nvd_published_at": null
+  }
+}

--- a/pkg/vulnsrc/vulnerability/const.go
+++ b/pkg/vulnsrc/vulnerability/const.go
@@ -40,7 +40,6 @@ const (
 	NuGet     types.Ecosystem = "nuget"
 	Maven     types.Ecosystem = "maven"
 	Go        types.Ecosystem = "go"
-	Rust      types.Ecosystem = "rust"
 	Conan     types.Ecosystem = "conan"
 	Erlang    types.Ecosystem = "erlang"
 	Pub       types.Ecosystem = "pub"


### PR DESCRIPTION
## Description
After #345 changes we addув check of ecosystems for OSV - https://github.com/aquasecurity/trivy-db/blob/d5388c99ca492bf0c8822b27a2e5190794543bb5/pkg/vulnsrc/osv/osv.go#L143-L146 
GHSA uses `Rust`ecosystem -https://github.com/aquasecurity/trivy-db/blob/d5388c99ca492bf0c8822b27a2e5190794543bb5/pkg/vulnsrc/ghsa/ghsa.go#L32
OSV uses `Cargo` ecosystem - https://github.com/aquasecurity/trivy-db/blob/d5388c99ca492bf0c8822b27a2e5190794543bb5/pkg/vulnsrc/osv/osv.go#L345-L346

That is why we don't save Rust advisories.

Result DB:
<img width="566" alt="изображение" src="https://github.com/aquasecurity/trivy-db/assets/91113035/19ea6b6f-22d3-42e9-945d-4553f21c9733">

<img width="516" alt="изображение" src="https://github.com/aquasecurity/trivy-db/assets/91113035/1b0ce9e2-5be8-4a90-b080-66a5137c809d">
