### PR TITLE
refactor: use types.Ecosystem in bucket.Name()

### DIFF
--- a/pkg/vulnsrc/bitnami/bitnami_test.go
+++ b/pkg/vulnsrc/bitnami/bitnami_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrctest"
 )
 
-var bucketName = bucket.Name(string(vulnerability.Bitnami), "Bitnami Vulnerability Database")
+var bucketName = bucket.Name(vulnerability.Bitnami, "Bitnami Vulnerability Database")
 
 func TestVulnSrc_Update(t *testing.T) {
 	tests := []struct {

--- a/pkg/vulnsrc/bucket/bucket.go
+++ b/pkg/vulnsrc/bucket/bucket.go
@@ -2,47 +2,12 @@ package bucket
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/aquasecurity/trivy-db/pkg/types"
-	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/vulnerability"
 )
 
 const separator = "::"
 
-func Name(ecosystem, dataSource string) string {
-	var prefix types.Ecosystem
-	switch strings.ToLower(ecosystem) {
-	case "go", "golang":
-		prefix = vulnerability.Go
-	case "maven", "gradle":
-		prefix = vulnerability.Maven
-	case "npm", "yarn":
-		prefix = vulnerability.Npm
-	case "packagist", "composer":
-		prefix = vulnerability.Composer
-	case "pypi", "pip", "pipenv", "poetry":
-		prefix = vulnerability.Pip
-	case "gem", "bundler", "rubygems":
-		prefix = vulnerability.RubyGems
-	case "nuget":
-		prefix = vulnerability.NuGet
-	case "conan":
-		prefix = vulnerability.Conan
-	case "cargo", "rust":
-		prefix = vulnerability.Cargo
-	case "erlang":
-		prefix = vulnerability.Erlang
-	case "pub":
-		prefix = vulnerability.Pub
-	case "swift":
-		prefix = vulnerability.Swift
-	case "cocoapods":
-		prefix = vulnerability.Cocoapods
-	case "bitnami":
-		prefix = vulnerability.Bitnami
-	default:
-		return ""
-	}
-	return fmt.Sprintf("%s%s%s", prefix, separator, dataSource)
+func Name(ecosystem types.Ecosystem, dataSource string) string {
+	return fmt.Sprintf("%s%s%s", ecosystem, separator, dataSource)
 }

--- a/pkg/vulnsrc/bucket/bucket_test.go
+++ b/pkg/vulnsrc/bucket/bucket_test.go
@@ -5,40 +5,30 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/bucket"
+	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/vulnerability"
 )
 
 func TestBucketName(t *testing.T) {
 	testCases := []struct {
 		name       string
-		ecosystem  string
+		ecosystem  types.Ecosystem
 		dataSource string
 		want       string
 		wantErr    string
 	}{
 		{
-			name:       "happy path go",
-			ecosystem:  "go",
+			name:       "go",
+			ecosystem:  vulnerability.Go,
 			dataSource: "GitLab Advisory Database",
 			want:       "go::GitLab Advisory Database",
 		},
 		{
-			name:       "happy path golang",
-			ecosystem:  "golang",
-			dataSource: "GitLab Advisory Database",
-			want:       "go::GitLab Advisory Database",
-		},
-		{
-			name:       "happy path maven",
-			ecosystem:  "maven",
-			dataSource: "GitLab Advisory Database",
-			want:       "maven::GitLab Advisory Database",
-		},
-		{
-			name:       "sad path unknown",
-			ecosystem:  "unknown",
-			dataSource: "GitLab Advisory Database",
-			wantErr:    "unknown ecosystem",
+			name:       "rubygems",
+			ecosystem:  vulnerability.RubyGems,
+			dataSource: "GitHub Advisory Database",
+			want:       "rubygems::GitHub Advisory Database",
 		},
 	}
 

--- a/pkg/vulnsrc/bundler/bundler.go
+++ b/pkg/vulnsrc/bundler/bundler.go
@@ -25,7 +25,7 @@ var (
 		URL:  "https://github.com/rubysec/ruby-advisory-db",
 	}
 
-	bucketName = bucket.Name(string(vulnerability.RubyGems), source.Name)
+	bucketName = bucket.Name(vulnerability.RubyGems, source.Name)
 )
 
 type RawAdvisory struct {

--- a/pkg/vulnsrc/composer/composer.go
+++ b/pkg/vulnsrc/composer/composer.go
@@ -24,7 +24,7 @@ var (
 		URL:  "https://github.com/FriendsOfPHP/security-advisories",
 	}
 
-	bucketName = bucket.Name(string(vulnerability.Composer), source.Name)
+	bucketName = bucket.Name(vulnerability.Composer, source.Name)
 )
 
 type RawAdvisory struct {

--- a/pkg/vulnsrc/node/node.go
+++ b/pkg/vulnsrc/node/node.go
@@ -28,7 +28,7 @@ var (
 		URL:  "https://github.com/nodejs/security-wg",
 	}
 
-	bucketName = bucket.Name(string(vulnerability.Npm), source.Name)
+	bucketName = bucket.Name(vulnerability.Npm, source.Name)
 )
 
 type Number struct {

--- a/pkg/vulnsrc/osv/osv.go
+++ b/pkg/vulnsrc/osv/osv.go
@@ -144,7 +144,7 @@ func (o OSV) commit(tx *bolt.Tx, entry Entry) error {
 		if !ok {
 			continue
 		}
-		bktName := bucket.Name(string(adv.Ecosystem), dataSource.Name)
+		bktName := bucket.Name(adv.Ecosystem, dataSource.Name)
 
 		if err = o.dbc.PutDataSource(tx, bktName, dataSource); err != nil {
 			return xerrors.Errorf("failed to put data source: %w", err)


### PR DESCRIPTION
Using `types.Ecosystem` prevents misuse of the first argument of bucket.Name.