### PR TITLE
feat(ubuntu): support Ubuntu 23.10

### DIFF
--- a/pkg/vulnsrc/ubuntu/ubuntu.go
+++ b/pkg/vulnsrc/ubuntu/ubuntu.go
@@ -48,6 +48,7 @@ var (
 		"jammy":   "22.04",
 		"kinetic": "22.10",
 		"lunar":   "23.04",
+		"mantic":  "23.10",
 		// ESM versions:
 		"precise/esm":      "12.04-ESM",
 		"trusty/esm":       "14.04-ESM",


### PR DESCRIPTION
Ubuntu 23.10's code name is Mantic Minotaur - see https://wiki.ubuntu.com/Releases.