### PR TITLE
fix rocky: multi-arch support broke backward compatibility

### DIFF
--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -165,6 +165,8 @@ func (a *Advisory) UnmarshalJSON(data []byte) error {
 type Advisories struct {
 	FixedVersion string     `json:",omitempty"` // For backward compatibility
 	Entries      []Advisory `json:",omitempty"`
+	// Custom is basically for extensibility and is not supposed to be used in OSS
+	Custom interface{} `json:",omitempty"` // For backward compatibility
 }
 
 type Vulnerability struct {

--- a/pkg/vulnsrc/rocky/rocky.go
+++ b/pkg/vulnsrc/rocky/rocky.go
@@ -222,6 +222,7 @@ func (vs *VulnSrc) commit(tx *bolt.Tx, platformName string, errata []RLSA) error
 			input.PlatformName = platformName
 			input.CveID = cveID
 			input.Vuln = vuln
+			input.Erratum = erratum // For Trivy Premium
 
 			savedInputs[cveID] = input
 		}
@@ -272,12 +273,13 @@ func (r *Rocky) Get(release, pkgName, arch string) ([]types.Advisory, error) {
 		}
 
 		// For backward compatibility
-		// The old trivy-db has no entries, but has fixed versions only.
+		// The old trivy-db has no entries, but has fixed versions and custom fields.
 		if len(adv.Entries) == 0 {
 			advisories = append(advisories, types.Advisory{
 				VulnerabilityID: vulnID,
 				FixedVersion:    adv.FixedVersion,
 				DataSource:      &v.Source,
+				Custom:          adv.Custom,
 			})
 			continue
 		}


### PR DESCRIPTION
Added handling for Custom and Erratum fields

Resolves: #369