### PR TITLE
fix(amazon): compare severity in lower case

### DIFF
--- a/pkg/vulnsrc/amazon/amazon.go
+++ b/pkg/vulnsrc/amazon/amazon.go
@@ -173,7 +173,7 @@ func (vs VulnSrc) Get(version string, pkgName string) ([]types.Advisory, error) 
 }
 
 func severityFromPriority(priority string) types.Severity {
-	switch priority {
+	switch strings.ToLower(priority) {
 	case "low":
 		return types.SeverityLow
 	case "medium":

--- a/pkg/vulnsrc/amazon/testdata/happy/vuln-list/amazon/1/ALAS-2018-1093.json
+++ b/pkg/vulnsrc/amazon/testdata/happy/vuln-list/amazon/1/ALAS-2018-1093.json
@@ -7,7 +7,7 @@
   "updated": {
     "date": "2018-10-18 22:23"
   },
-  "severity": "important",
+  "severity": "Important",
   "description": "Package updates are available for Amazon Linux AMI that fix the following vulnerabilities:\nCVE-2018-17456:\n\tGit before 2.14.5, 2.15.x before 2.15.3, 2.16.x before 2.16.5, 2.17.x before 2.17.2, 2.18.x before 2.18.1, and 2.19.x before 2.19.1 allows remote code execution during processing of a recursive \u0026quot;git clone\u0026quot; of a superproject if a .gitmodules file has a URL field beginning with a \u0026#039;-\u0026#039; character.\n1636619: \nCVE-2018-17456 git: arbitrary code execution via .gitmodules\n",
   "packages": [
     {


### PR DESCRIPTION
## Description
Severity for `amazon` advisories is not always in lower case:
[Important](https://github.com/aquasecurity/vuln-list/blob/71ec42935249865020c560fb8e2cbe4606b00280/amazon/2023/ALAS2023-2023-297.json#L10)
[important](https://github.com/aquasecurity/vuln-list/blob/71ec42935249865020c560fb8e2cbe4606b00280/amazon/2/ALAS2-2023-2224.json#L10)

## Related Issues
- Close aquasecurity/trivy/issues/5762