### PR TITLE
ci: use maximize-build-space

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Maximize build space
         uses: easimon/maximize-build-space@v10
         with:
-          root-reserve-mb: 32768 # vuln-list dirs + language repositores use more that 12GB of storage
+          root-reserve-mb: 32768 # vuln-list dirs + language repositories use more than 12GB of storage
           remove-android: "true"
           remove-docker-images: "true"
           remove-dotnet: "true"

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -13,6 +13,15 @@ jobs:
     name: Build DB
     runs-on: ubuntu-latest
     steps:
+      - name: Maximize build space
+        uses: easimon/maximize-build-space@v10
+        with:
+          root-reserve-mb: 32768 # vuln-list dirs + language repositores use more that 12GB of storage
+          remove-android: "true"
+          remove-docker-images: "true"
+          remove-dotnet: "true"
+          remove-haskell: "true"
+
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
 


### PR DESCRIPTION
## Description
cache dir size is 12GB:
```
➜ du -sh ./cache 
12G    ./cache
➜ make db-build
...
➜ du -sh ./cache/db 
2.7G	./cache/db
➜ du -sh ./cache   
16G	./cache
```
So we need move space to build, compact and compress db.
Add `maximize-build-space`.

## Related Issues
- [ ] Close #383  