### PR TITLE
fix(ghsa): add support of `last_known_affected_version_range` field

### DIFF
--- a/pkg/vulnsrc/ghsa/ghsa_test.go
+++ b/pkg/vulnsrc/ghsa/ghsa_test.go
@@ -100,6 +100,21 @@ func TestVulnSrc_Update(t *testing.T) {
 				},
 				{
 					Key: []string{
+						"advisory-detail",
+						"CVE-2023-25330",
+						"maven::GitHub Security Advisory Maven",
+						"com.baomidou:mybatis-plus-copy",
+					},
+					Value: types.Advisory{
+						VendorIDs: []string{
+							"GHSA-32qq-m9fh-f74w",
+						},
+						PatchedVersions:    []string{"3.5.0"},
+						VulnerableVersions: []string{"<3.5.0"},
+					},
+				},
+				{
+					Key: []string{
 						"vulnerability-detail",
 						"CVE-2023-25330",
 						"ghsa",

--- a/pkg/vulnsrc/ghsa/ghsa_test.go
+++ b/pkg/vulnsrc/ghsa/ghsa_test.go
@@ -76,6 +76,57 @@ func TestVulnSrc_Update(t *testing.T) {
 				{
 					Key: []string{
 						"data-source",
+						"maven::GitHub Security Advisory Maven",
+					},
+					Value: types.DataSource{
+						ID:   vulnerability.GHSA,
+						Name: "GitHub Security Advisory Maven",
+						URL:  "https://github.com/advisories?query=type%3Areviewed+ecosystem%3Amaven",
+					},
+				},
+				{
+					Key: []string{
+						"advisory-detail",
+						"CVE-2023-25330",
+						"maven::GitHub Security Advisory Maven",
+						"com.baomidou:mybatis-plus",
+					},
+					Value: types.Advisory{
+						VendorIDs: []string{
+							"GHSA-32qq-m9fh-f74w",
+						},
+						VulnerableVersions: []string{">=0, <3.5.3.1"},
+					},
+				},
+				{
+					Key: []string{
+						"vulnerability-detail",
+						"CVE-2023-25330",
+						"ghsa",
+					},
+					Value: types.VulnerabilityDetail{
+						Title:       "MyBatis-Plus vulnerable to SQL injection via TenantPlugin",
+						Description: "MyBatis-Plus below 3.5.3.1 is vulnerable to SQL injection via the tenant ID value. This may allow remote attackers to execute arbitrary SQL commands.",
+						References: []string{
+							"https://nvd.nist.gov/vuln/detail/CVE-2023-25330",
+							"https://github.com/FCncdn/MybatisPlusTenantPluginSQLInjection-POC/blob/master/Readme.en.md",
+							"https://github.com/baomidou/mybatis-plus",
+						},
+						Severity:     types.SeverityCritical,
+						CvssVectorV3: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+						CvssScoreV3:  9.8,
+					},
+				},
+				{
+					Key: []string{
+						"vulnerability-id",
+						"CVE-2023-25330",
+					},
+					Value: map[string]interface{}{},
+				},
+				{
+					Key: []string{
+						"data-source",
 						"cargo::GitHub Security Advisory Rust",
 					},
 					Value: types.DataSource{

--- a/pkg/vulnsrc/ghsa/testdata/happy/ghsa/advisories/github-reviewed/2023/04/GHSA-32qq-m9fh-f74w/GHSA-32qq-m9fh-f74w.json
+++ b/pkg/vulnsrc/ghsa/testdata/happy/ghsa/advisories/github-reviewed/2023/04/GHSA-32qq-m9fh-f74w/GHSA-32qq-m9fh-f74w.json
@@ -1,0 +1,61 @@
+{
+  "schema_version": "1.4.0",
+  "id": "GHSA-32qq-m9fh-f74w",
+  "modified": "2023-04-14T20:31:15Z",
+  "published": "2023-04-05T15:30:24Z",
+  "aliases": [
+    "CVE-2023-25330"
+  ],
+  "summary": "MyBatis-Plus vulnerable to SQL injection via TenantPlugin",
+  "details": "MyBatis-Plus below 3.5.3.1 is vulnerable to SQL injection via the tenant ID value. This may allow remote attackers to execute arbitrary SQL commands.",
+  "severity": [
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+    }
+  ],
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "com.baomidou:mybatis-plus"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 3.5.3.1"
+      }
+    }
+  ],
+  "references": [
+    {
+      "type": "ADVISORY",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-25330"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/FCncdn/MybatisPlusTenantPluginSQLInjection-POC/blob/master/Readme.en.md"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/baomidou/mybatis-plus"
+    }
+  ],
+  "database_specific": {
+    "cwe_ids": [
+      "CWE-89"
+    ],
+    "severity": "CRITICAL",
+    "github_reviewed": true,
+    "github_reviewed_at": "2023-04-05T21:13:04Z",
+    "nvd_published_at": "2023-04-05T14:15:00Z"
+  }
+}

--- a/pkg/vulnsrc/ghsa/testdata/happy/ghsa/advisories/github-reviewed/2023/04/GHSA-32qq-m9fh-f74w/GHSA-32qq-m9fh-f74w.json
+++ b/pkg/vulnsrc/ghsa/testdata/happy/ghsa/advisories/github-reviewed/2023/04/GHSA-32qq-m9fh-f74w/GHSA-32qq-m9fh-f74w.json
@@ -33,6 +33,28 @@
       "database_specific": {
         "last_known_affected_version_range": "< 3.5.3.1"
       }
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "com.baomidou:mybatis-plus-copy"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "3.5.0"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 3.5.3.1"
+      }
     }
   ],
   "references": [

--- a/pkg/vulnsrc/osv/osv.go
+++ b/pkg/vulnsrc/osv/osv.go
@@ -212,7 +212,7 @@ func parseAffected(entry Entry, vulnIDs, aliases, references []string) ([]Adviso
 
 	uniqAdvisories := map[string]Advisory{}
 	for _, affected := range entry.Affected {
-		ecosystem := convertEcosystem(affected.Package.Ecosystem)
+		ecosystem := ConvertEcosystem(affected.Package.Ecosystem)
 		if ecosystem == vulnerability.Unknown {
 			continue
 		}
@@ -334,7 +334,7 @@ func parseSeverity(severities []Severity) (string, float64, error) {
 	return "", 0, nil
 }
 
-func convertEcosystem(eco Ecosystem) types.Ecosystem {
+func ConvertEcosystem(eco Ecosystem) types.Ecosystem {
 	// cf. https://ossf.github.io/osv-schema/#affectedpackage-field
 	switch strings.ToLower(string(eco)) {
 	case "go":

--- a/pkg/vulnsrc/osv/osv.go
+++ b/pkg/vulnsrc/osv/osv.go
@@ -40,6 +40,9 @@ type Advisory struct {
 	References   []string
 	CVSSScoreV3  float64
 	CVSSVectorV3 string
+
+	// From affected[].database_specific
+	DatabaseSpecific json.RawMessage
 }
 
 type OSV struct {
@@ -212,7 +215,7 @@ func parseAffected(entry Entry, vulnIDs, aliases, references []string) ([]Adviso
 
 	uniqAdvisories := map[string]Advisory{}
 	for _, affected := range entry.Affected {
-		ecosystem := ConvertEcosystem(affected.Package.Ecosystem)
+		ecosystem := convertEcosystem(affected.Package.Ecosystem)
 		if ecosystem == vulnerability.Unknown {
 			continue
 		}
@@ -252,6 +255,7 @@ func parseAffected(entry Entry, vulnIDs, aliases, references []string) ([]Adviso
 					References:         references,
 					CVSSVectorV3:       cvssVectorV3,
 					CVSSScoreV3:        cvssScoreV3,
+					DatabaseSpecific:   affected.DatabaseSpecific,
 				}
 			}
 		}
@@ -334,7 +338,7 @@ func parseSeverity(severities []Severity) (string, float64, error) {
 	return "", 0, nil
 }
 
-func ConvertEcosystem(eco Ecosystem) types.Ecosystem {
+func convertEcosystem(eco Ecosystem) types.Ecosystem {
 	// cf. https://ossf.github.io/osv-schema/#affectedpackage-field
 	switch strings.ToLower(string(eco)) {
 	case "go":

--- a/pkg/vulnsrc/osv/types.go
+++ b/pkg/vulnsrc/osv/types.go
@@ -55,6 +55,7 @@ type Affected struct {
 	Ranges            []Range           `json:"ranges,omitempty"`
 	Versions          []string          `json:"versions,omitempty"`
 	EcosystemSpecific EcosystemSpecific `json:"ecosystem_specific"`
+	DatabaseSpecific  json.RawMessage   `json:"database_specific,omitempty"`
 }
 
 type Import struct {


### PR DESCRIPTION
## Description 
There two cases when `GHSA` uses `last_known_affected_version_range` field - https://github.com/github/advisory-database/issues/470#issuecomment-1998604377.
We need to add version for case when `last_known_affected_version_range field` is exist and `fixed`/`last_affected` field doesn't exist.

## Related Issues
- Close #391 