### PR TITLE
added openSUSE Tumbleweed version detection

### DIFF
--- a/pkg/vulnsrc/suse-cvrf/suse-cvrf.go
+++ b/pkg/vulnsrc/suse-cvrf/suse-cvrf.go
@@ -26,9 +26,9 @@ const (
 	OpenSUSE
 	OpenSUSETumbleweed
 
-	platformOpenSUSETumbleweedFormat  = "openSUSE Tumbleweed"
-	platformOpenSUSELeapFormat  = "openSUSE Leap %s"
-	platformSUSELinuxFormat = "SUSE Linux Enterprise %s"
+	platformOpenSUSELeapFormat       = "openSUSE Leap %s"
+	platformOpenSUSETumbleweedFormat = "openSUSE Tumbleweed"
+	platformSUSELinuxFormat          = "SUSE Linux Enterprise %s"
 )
 
 var (

--- a/pkg/vulnsrc/suse-cvrf/suse-cvrf.go
+++ b/pkg/vulnsrc/suse-cvrf/suse-cvrf.go
@@ -24,8 +24,10 @@ type Distribution int
 const (
 	SUSEEnterpriseLinux Distribution = iota
 	OpenSUSE
+	OpenSUSETumbleweed
 
-	platformOpenSUSEFormat  = "openSUSE Leap %s"
+	platformOpenSUSETumbleweedFormat  = "openSUSE Tumbleweed"
+	platformOpenSUSELeapFormat  = "openSUSE Leap %s"
 	platformSUSELinuxFormat = "SUSE Linux Enterprise %s"
 )
 
@@ -55,6 +57,9 @@ func (vs VulnSrc) Name() types.SourceID {
 	if vs.dist == OpenSUSE {
 		return "opensuse-cvrf"
 	}
+	if vs.dist == OpenSUSETumbleweed {
+		return "opensuse-tumbleweed-cvrf"
+	}
 	return source.ID
 }
 
@@ -66,6 +71,7 @@ func (vs VulnSrc) Update(dir string) error {
 	case SUSEEnterpriseLinux:
 		rootDir = filepath.Join(rootDir, "suse")
 	case OpenSUSE:
+	case OpenSUSETumbleweed:
 		rootDir = filepath.Join(rootDir, "opensuse")
 	default:
 		return xerrors.New("unknown distribution")
@@ -185,6 +191,10 @@ func getOSVersion(platformName string) string {
 		// SUSE Linux Enterprise Module for SUSE Manager Server 4.0
 		return ""
 	}
+	if strings.HasPrefix(platformName, "openSUSE Tumbleweed") {
+		// Tumbleweed has no version, it is a rolling release
+		return platformOpenSUSETumbleweedFormat
+	}
 	if strings.HasPrefix(platformName, "openSUSE Leap") {
 		// openSUSE Leap 15.0
 		ss := strings.Split(platformName, " ")
@@ -196,7 +206,7 @@ func getOSVersion(platformName string) string {
 			log.Printf("invalid version: %s, err: %s", platformName, err)
 			return ""
 		}
-		return fmt.Sprintf(platformOpenSUSEFormat, ss[2])
+		return fmt.Sprintf(platformOpenSUSELeapFormat, ss[2])
 	}
 	if strings.Contains(platformName, "SUSE Linux Enterprise") {
 		// e.g. SUSE Linux Enterprise Storage 7, SUSE Linux Enterprise Micro 5.1
@@ -276,7 +286,9 @@ func (vs VulnSrc) Get(version string, pkgName string) ([]types.Advisory, error) 
 	case SUSEEnterpriseLinux:
 		bucket = fmt.Sprintf(platformSUSELinuxFormat, version)
 	case OpenSUSE:
-		bucket = fmt.Sprintf(platformOpenSUSEFormat, version)
+		bucket = fmt.Sprintf(platformOpenSUSELeapFormat, version)
+	case OpenSUSETumbleweed:
+		bucket = platformOpenSUSETumbleweedFormat
 	default:
 		return nil, xerrors.New("unknown distribution")
 	}

--- a/pkg/vulnsrc/suse-cvrf/suse-cvrf.go
+++ b/pkg/vulnsrc/suse-cvrf/suse-cvrf.go
@@ -70,8 +70,7 @@ func (vs VulnSrc) Update(dir string) error {
 	switch vs.dist {
 	case SUSEEnterpriseLinux:
 		rootDir = filepath.Join(rootDir, "suse")
-	case OpenSUSE:
-	case OpenSUSETumbleweed:
+	case OpenSUSE, OpenSUSETumbleweed:
 		rootDir = filepath.Join(rootDir, "opensuse")
 	default:
 		return xerrors.New("unknown distribution")

--- a/pkg/vulnsrc/suse-cvrf/suse-cvrf_test.go
+++ b/pkg/vulnsrc/suse-cvrf/suse-cvrf_test.go
@@ -102,7 +102,7 @@ func TestVulnSrc_Update(t *testing.T) {
 							"https://www.suse.com/security/cve/CVE-2014-1838/",
 							"https://www.suse.com/support/security/rating/",
 						},
-						Severity: types.SeverityModerate,
+						Severity: types.SeverityMedium,
 					},
 				},
 				{

--- a/pkg/vulnsrc/suse-cvrf/suse-cvrf_test.go
+++ b/pkg/vulnsrc/suse-cvrf/suse-cvrf_test.go
@@ -69,6 +69,49 @@ func TestVulnSrc_Update(t *testing.T) {
 			},
 		},
 		{
+			name: "happy path with openSUSE Tumbleweed",
+			dir:  filepath.Join("testdata", "happy", "openSUSE Tumbleweed"),
+			dist: OpenSUSE,
+			wantValues: []vulnsrctest.WantValues{
+				{
+					Key: []string{"data-source", "openSUSE Tumbleweed"},
+					Value: types.DataSource{
+						ID:   vulnerability.SuseCVRF,
+						Name: "SUSE CVRF",
+						URL:  "https://ftp.suse.com/pub/projects/security/cvrf/",
+					},
+				},
+				{
+					Key: []string{"advisory-detail", "openSUSE-SU-2024:10400-1", "openSUSE Tumbleweed", "python3-logilab-common"},
+					Value: types.Advisory{
+						FixedVersion: "1.2.2-1.2",
+					},
+				},
+				{
+					Key: []string{"advisory-detail", "openSUSE-SU-2024:10400-1", "openSUSE Tumbleweed", "python-logilab-common"},
+					Value: types.Advisory{
+						FixedVersion: "1.0.2-1.4",
+					},
+				},
+				{
+					Key: []string{"vulnerability-detail", "openSUSE-SU-2024:10400-1", "suse-cvrf"},
+					Value: types.VulnerabilityDetail{
+						Title:       "python-logilab-common-1.0.2-1.4 on GA media",
+						Description: "These are all security issues fixed in the python-logilab-common-1.0.2-1.4 package on the GA media of openSUSE Tumbleweed.",
+						References: []string{
+							"https://www.suse.com/security/cve/CVE-2014-1838/",
+							"https://www.suse.com/support/security/rating/",
+						},
+						Severity: types.SeverityModerate,
+					},
+				},
+				{
+					Key:   []string{"vulnerability-id", "openSUSE-SU-2024:10400-1"},
+					Value: map[string]interface{}{},
+				},
+			},
+		},
+		{
 			name: "happy path with SUSE Enterprise Linux",
 			dir:  filepath.Join("testdata", "happy", "SUSE Enterprise Linux"),
 			dist: SUSEEnterpriseLinux,

--- a/pkg/vulnsrc/suse-cvrf/suse-cvrf_test.go
+++ b/pkg/vulnsrc/suse-cvrf/suse-cvrf_test.go
@@ -467,6 +467,10 @@ func TestGetOSVersion(t *testing.T) {
 			inputPlatformName:    "openSUSE Leap 15.1 NonFree",
 			expectedPlatformName: "openSUSE Leap 15.1",
 		},
+		{
+			inputPlatformName:    "openSUSE Tumbleweed",
+			expectedPlatformName: "openSUSE Tumbleweed",
+		},
 		// Below tests exclude platformNames
 		{
 			inputPlatformName:    "openSUSE Leap NonFree 15.1",

--- a/pkg/vulnsrc/suse-cvrf/suse-cvrf_test.go
+++ b/pkg/vulnsrc/suse-cvrf/suse-cvrf_test.go
@@ -71,7 +71,7 @@ func TestVulnSrc_Update(t *testing.T) {
 		{
 			name: "happy path with openSUSE Tumbleweed",
 			dir:  filepath.Join("testdata", "happy", "openSUSE Tumbleweed"),
-			dist: OpenSUSE,
+			dist: OpenSUSETumbleweed,
 			wantValues: []vulnsrctest.WantValues{
 				{
 					Key: []string{"data-source", "openSUSE Tumbleweed"},
@@ -99,8 +99,9 @@ func TestVulnSrc_Update(t *testing.T) {
 						Title:       "python-logilab-common-1.0.2-1.4 on GA media",
 						Description: "These are all security issues fixed in the python-logilab-common-1.0.2-1.4 package on the GA media of openSUSE Tumbleweed.",
 						References: []string{
-							"https://www.suse.com/security/cve/CVE-2014-1838/",
 							"https://www.suse.com/support/security/rating/",
+							"https://www.suse.com/security/cve/CVE-2014-1838/",
+							"https://www.suse.com/security/cve/CVE-2014-1839/",
 						},
 						Severity: types.SeverityMedium,
 					},

--- a/pkg/vulnsrc/suse-cvrf/testdata/happy/openSUSE Tumbleweed/vuln-list/cvrf/suse/opensuse/openSUSE-SU-2024-10400-1.json
+++ b/pkg/vulnsrc/suse-cvrf/testdata/happy/openSUSE Tumbleweed/vuln-list/cvrf/suse/opensuse/openSUSE-SU-2024-10400-1.json
@@ -1,0 +1,129 @@
+{
+  "Title": "python-logilab-common-1.0.2-1.4 on GA media",
+  "Tracking": {
+    "ID": "openSUSE-SU-2024:10400-1",
+    "Status": "Final",
+    "Version": "1",
+    "InitialReleaseDate": "2024-06-20T21:44:22Z",
+    "CurrentReleaseDate": "2024-06-20T21:44:22Z",
+    "RevisionHistory": [
+      {
+        "Number": "1",
+        "Date": "2024-06-20T21:44:22Z",
+        "Description": "current"
+      }
+    ]
+  },
+  "Notes": [
+    {
+      "Text": "python-logilab-common-1.0.2-1.4 on GA media",
+      "Title": "Topic",
+      "Type": "Summary"
+    },
+    {
+      "Text": "These are all security issues fixed in the python-logilab-common-1.0.2-1.4 package on the GA media of openSUSE Tumbleweed.",
+      "Title": "Details",
+      "Type": "General"
+    },
+    {
+      "Text": "The CVRF data is provided by SUSE under the Creative Commons License 4.0 with Attribution (CC-BY-4.0).",
+      "Title": "Terms of Use",
+      "Type": "Legal Disclaimer"
+    },
+    {
+      "Text": "openSUSE-Tumbleweed-2024-10400",
+      "Title": "Patchnames",
+      "Type": "Details"
+    }
+  ],
+  "ProductTree": {
+    "Relationships": [
+      {
+        "ProductReference": "python-logilab-common-1.0.2-1.4",
+        "RelatesToProductReference": "openSUSE Tumbleweed",
+        "RelationType": "Default Component Of"
+      },
+      {
+        "ProductReference": "python3-logilab-common-1.2.2-1.2",
+        "RelatesToProductReference": "openSUSE Tumbleweed",
+        "RelationType": "Default Component Of"
+      }
+    ]
+  },
+  "References": [
+    {
+      "URL": "https://www.suse.com/support/security/rating/",
+      "Description": "SUSE Security Ratings"
+    },
+    {
+      "URL": "https://www.suse.com/security/cve/CVE-2014-1838/",
+      "Description": "SUSE CVE CVE-2014-1838 page"
+    },
+    {
+      "URL": "https://www.suse.com/security/cve/CVE-2014-1839/",
+      "Description": "SUSE CVE CVE-2014-1839 page"
+    }
+  ],
+  "Vulnerabilities": [
+    {
+      "CVE": "CVE-2014-1838",
+      "Description": "The (1) extract_keys_from_pdf and (2) fill_pdf functions in pdf_ext.py in logilab-commons before 0.61.0 allows local users to overwrite arbitrary files and possibly have other unspecified impact via a symlink attack on /tmp/toto.fdf.",
+      "Threats": [
+        {
+          "Type": "Impact",
+          "Severity": "moderate"
+        }
+      ],
+      "References": [
+        {
+          "URL": "https://www.suse.com/security/cve/CVE-2014-1838.html",
+          "Description": "CVE-2014-1838"
+        },
+        {
+          "URL": "https://bugzilla.suse.com/861822",
+          "Description": "SUSE Bug 861822"
+        }
+      ],
+      "ProductStatuses": [
+        {
+          "Type": "Fixed",
+          "ProductID": [
+            "openSUSE Tumbleweed:python-logilab-common-1.0.2-1.4",
+            "openSUSE Tumbleweed:python3-logilab-common-1.2.2-1.2"
+          ]
+        }
+      ],
+      "CVSSScoreSets": {}
+    },
+    {
+      "CVE": "CVE-2014-1839",
+      "Description": "The Execute class in shellutils in logilab-commons before 0.61.0 uses tempfile.mktemp, which allows local users to have an unspecified impact by pre-creating the temporary file.",
+      "Threats": [
+        {
+          "Type": "Impact",
+          "Severity": "moderate"
+        }
+      ],
+      "References": [
+        {
+          "URL": "https://www.suse.com/security/cve/CVE-2014-1839.html",
+          "Description": "CVE-2014-1839"
+        },
+        {
+          "URL": "https://bugzilla.suse.com/861822",
+          "Description": "SUSE Bug 861822"
+        }
+      ],
+      "ProductStatuses": [
+        {
+          "Type": "Fixed",
+          "ProductID": [
+            "openSUSE Tumbleweed:python-logilab-common-1.0.2-1.4",
+            "openSUSE Tumbleweed:python3-logilab-common-1.2.2-1.2"
+          ]
+        }
+      ],
+      "CVSSScoreSets": {}
+    }
+  ]
+}


### PR DESCRIPTION
(Tumbleweed has no version as it is rolling)

https://github.com/aquasecurity/trivy-db/issues/410