### PR TITLE
pkg: replace `utils/strings/InSlice` func with `slices.Contains`

### DIFF
--- a/pkg/utils/strings/strings.go
+++ b/pkg/utils/strings/strings.go
@@ -25,15 +25,6 @@ func IsInt(s string) bool {
 	return err == nil
 }
 
-func InSlice(a string, list []string) bool {
-	for _, b := range list {
-		if b == a {
-			return true
-		}
-	}
-	return false
-}
-
 func Merge(a, b []string) []string {
 	uniq := map[string]struct{}{}
 	for _, v := range append(a, b...) {

--- a/pkg/vulnsrc/amazon/amazon.go
+++ b/pkg/vulnsrc/amazon/amazon.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	bolt "go.etcd.io/bbolt"
@@ -14,7 +15,6 @@ import (
 	"github.com/aquasecurity/trivy-db/pkg/db"
 	"github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy-db/pkg/utils"
-	ustrings "github.com/aquasecurity/trivy-db/pkg/utils/strings"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/vulnerability"
 )
 
@@ -95,7 +95,7 @@ func (vs *VulnSrc) walkFunc(r io.Reader, path string) error {
 		return nil
 	}
 	version := paths[len(paths)-2]
-	if !ustrings.InSlice(version, targetVersions) {
+	if !slices.Contains(targetVersions, version) {
 		log.Printf("unsupported Amazon version: %s\n", version)
 		return nil
 	}

--- a/pkg/vulnsrc/debian/debian.go
+++ b/pkg/vulnsrc/debian/debian.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	debver "github.com/knqyf263/go-deb-version"
@@ -16,7 +17,6 @@ import (
 	"github.com/aquasecurity/trivy-db/pkg/db"
 	"github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy-db/pkg/utils"
-	ustrings "github.com/aquasecurity/trivy-db/pkg/utils/strings"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/vulnerability"
 )
 
@@ -204,7 +204,7 @@ func (vs VulnSrc) parseCVE(dir string) error {
 			}
 
 			// Skip not-affected, removed or undetermined advisories
-			if ustrings.InSlice(ann.Kind, skipStatuses) {
+			if slices.Contains(skipStatuses, ann.Kind) {
 				vs.notAffected[bkt] = struct{}{}
 				continue
 			}
@@ -310,7 +310,7 @@ func (vs VulnSrc) parseAdvisory(dir string) error {
 				}
 
 				// Skip not-affected, removed or undetermined advisories
-				if ustrings.InSlice(ann.Kind, skipStatuses) {
+				if slices.Contains(skipStatuses, ann.Kind) {
 					vs.notAffected[bkt] = struct{}{}
 					continue
 				}

--- a/pkg/vulnsrc/oracle-oval/oracle-oval.go
+++ b/pkg/vulnsrc/oracle-oval/oracle-oval.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	version "github.com/knqyf263/go-rpm-version"
@@ -129,7 +130,7 @@ func (vs *VulnSrc) commit(tx *bolt.Tx, ovals []OracleOVAL) error {
 			}
 
 			platformName := affectedPkg.PlatformName()
-			if !ustrings.InSlice(platformName, targetPlatforms) {
+			if !slices.Contains(targetPlatforms, platformName) {
 				continue
 			}
 

--- a/pkg/vulnsrc/rocky/rocky.go
+++ b/pkg/vulnsrc/rocky/rocky.go
@@ -17,7 +17,6 @@ import (
 	"github.com/aquasecurity/trivy-db/pkg/db"
 	"github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy-db/pkg/utils"
-	ustrings "github.com/aquasecurity/trivy-db/pkg/utils/strings"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/vulnerability"
 )
 
@@ -110,12 +109,12 @@ func (vs *VulnSrc) parse(rootDir string) (map[string][]RLSA, error) {
 			majorVer = dirs[0][:strings.Index(dirs[0], ".")]
 		}
 		repo, arch := dirs[1], dirs[2]
-		if !ustrings.InSlice(repo, targetRepos) {
+		if !slices.Contains(targetRepos, repo) {
 			log.Printf("Unsupported Rocky repo: %s", repo)
 			return nil
 		}
 
-		if !ustrings.InSlice(arch, targetArches) {
+		if !slices.Contains(targetArches, arch) {
 			log.Printf("Unsupported Rocky arch: %s", arch)
 			return nil
 		}

--- a/pkg/vulnsrc/ubuntu/ubuntu.go
+++ b/pkg/vulnsrc/ubuntu/ubuntu.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log"
 	"path/filepath"
+	"slices"
 
 	bolt "go.etcd.io/bbolt"
 	"golang.org/x/xerrors"
@@ -13,7 +14,6 @@ import (
 	"github.com/aquasecurity/trivy-db/pkg/db"
 	"github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy-db/pkg/utils"
-	"github.com/aquasecurity/trivy-db/pkg/utils/strings"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/vulnerability"
 )
 
@@ -157,7 +157,7 @@ func defaultPut(dbc db.Operation, tx *bolt.Tx, advisory interface{}) error {
 	for packageName, patch := range cve.Patches {
 		pkgName := string(packageName)
 		for release, status := range patch {
-			if !strings.InSlice(status.Status, targetStatuses) {
+			if !slices.Contains(targetStatuses, status.Status) {
 				continue
 			}
 			osVersion, ok := UbuntuReleasesMapping[string(release)]


### PR DESCRIPTION
## Description

In this commit, we replace `utils/strings/InSlice` function with the built-in `slices.Contains` function which is supported in go 1.18+ and it would work with the current project go version `1.19` as appears in the `go.mod` file.

Closes #245

## How has this been tested?

I've run the test cases using `make test` and all of them passed.