### PR TITLE
feat(vulnsrc/nvd): add CVSS v4.0

### DIFF
--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -11,10 +11,12 @@ type Severity int
 type VendorSeverity map[SourceID]Severity
 
 type CVSS struct {
-	V2Vector string  `json:"V2Vector,omitempty"`
-	V3Vector string  `json:"V3Vector,omitempty"`
-	V2Score  float64 `json:"V2Score,omitempty"`
-	V3Score  float64 `json:"V3Score,omitempty"`
+	V2Vector  string  `json:"V2Vector,omitempty"`
+	V3Vector  string  `json:"V3Vector,omitempty"`
+	V40Vector string  `json:"V40Vector,omitempty"`
+	V2Score   float64 `json:"V2Score,omitempty"`
+	V3Score   float64 `json:"V3Score,omitempty"`
+	V40Score  float64 `json:"V40Score,omitempty"`
 }
 
 type CVSSVector struct {
@@ -70,8 +72,11 @@ type VulnerabilityDetail struct {
 	CvssVector       string     `json:",omitempty"`
 	CvssScoreV3      float64    `json:",omitempty"`
 	CvssVectorV3     string     `json:",omitempty"`
+	CvssScoreV40     float64    `json:",omitempty"`
+	CvssVectorV40    string     `json:",omitempty"`
 	Severity         Severity   `json:",omitempty"`
 	SeverityV3       Severity   `json:",omitempty"`
+	SeverityV40      Severity   `json:",omitempty"`
 	CweIDs           []string   `json:",omitempty"` // e.g. CWE-78, CWE-89
 	References       []string   `json:",omitempty"`
 	Title            string     `json:",omitempty"`

--- a/pkg/vulnsrc/nvd/nvd.go
+++ b/pkg/vulnsrc/nvd/nvd.go
@@ -73,6 +73,7 @@ func (vs VulnSrc) commit(tx *bolt.Tx, cves []Cve) error {
 
 		cvssScore, cvssVector, severity := getCvssV2(cve.Metrics.CvssMetricV2)
 		cvssScoreV3, cvssVectorV3, severityV3 := getCvssV3(cve.Metrics.CvssMetricV31, cve.Metrics.CvssMetricV30)
+		cvssScoreV40, cvssVectorV40, severityV40 := getCvssV40(cve.Metrics.CvssMetricV40)
 
 		var references []string
 		for _, ref := range cve.References {
@@ -104,8 +105,11 @@ func (vs VulnSrc) commit(tx *bolt.Tx, cves []Cve) error {
 			CvssVector:       cvssVector,
 			CvssScoreV3:      cvssScoreV3,
 			CvssVectorV3:     cvssVectorV3,
+			CvssScoreV40:     cvssScoreV40,
+			CvssVectorV40:    cvssVectorV40,
 			Severity:         severity,
 			SeverityV3:       severityV3,
+			SeverityV40:      severityV40,
 			CweIDs:           lo.Uniq(cweIDs),
 			References:       references,
 			Title:            "",
@@ -155,6 +159,20 @@ func getCvssV3(metricsV31, metricsV30 []CvssMetricV3) (score float64, vector str
 			score = metricV3.CvssData.BaseScore
 			vector = metricV3.CvssData.VectorString
 			severity, _ = types.NewSeverity(metricV3.CvssData.BaseSeverity)
+			return
+		}
+	}
+	return
+}
+
+// getCvssV40 selects vector, score and severity from V40 metrics
+func getCvssV40(metricsV40 []CvssMetricV40) (score float64, vector string, severity types.Severity) {
+	for _, metricV40 := range metricsV40 {
+		// save only NVD metric
+		if metricV40.Source == nvdSource {
+			score = metricV40.CvssData.BaseScore
+			vector = metricV40.CvssData.VectorString
+			severity, _ = types.NewSeverity(metricV40.CvssData.BaseSeverity)
 			return
 		}
 	}

--- a/pkg/vulnsrc/nvd/nvd_test.go
+++ b/pkg/vulnsrc/nvd/nvd_test.go
@@ -56,6 +56,22 @@ func TestVulnSrc_Update(t *testing.T) {
 						PublishedDate:    utils.MustTimeParse("2023-11-28T00:15:07.140Z"),
 					},
 				},
+				{
+					Key: []string{"vulnerability-detail", "CVE-2024-5732", "nvd"},
+					Value: types.VulnerabilityDetail{
+						Description:      "A vulnerability was found in Clash up to 0.20.1 on Windows. It has been declared as critical. This vulnerability affects unknown code of the component Proxy Port. The manipulation leads to improper authentication. The attack can be initiated remotely. The exploit has been disclosed to the public and may be used. It is recommended to change the configuration settings. VDB-267406 is the identifier assigned to this vulnerability.",
+						CvssScoreV3:      9.8,
+						CvssVectorV3:     "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+						CvssScoreV40:     6.9,
+						CvssVectorV40:    "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:L/VI:L/VA:L/SC:N/SI:N/SA:N/E:X/CR:X/IR:X/AR:X/MAV:X/MAC:X/MAT:X/MPR:X/MUI:X/MVC:X/MVI:X/MVA:X/MSC:X/MSI:X/MSA:X/S:X/AU:X/R:X/V:X/RE:X/U:X",
+						SeverityV3:       types.SeverityCritical,
+						SeverityV40:      types.SeverityMedium,
+						CweIDs:           []string{"CWE-287"},
+						References:       []string{"https://github.com/GTA12138/vul/blob/main/clash%20for%20windows.md", "https://vuldb.com/?ctiid.267406", "https://vuldb.com/?id.267406", "https://vuldb.com/?submit.345469"},
+						LastModifiedDate: utils.MustTimeParse("2024-06-11T17:57:13.767Z"),
+						PublishedDate:    utils.MustTimeParse("2024-06-07T10:15:12.293Z"),
+					},
+				},
 			},
 		},
 		{

--- a/pkg/vulnsrc/nvd/testdata/happy/vuln-list-nvd/api/2024/CVE-2024-5732.json
+++ b/pkg/vulnsrc/nvd/testdata/happy/vuln-list-nvd/api/2024/CVE-2024-5732.json
@@ -1,0 +1,196 @@
+{
+  "id": "CVE-2024-5732",
+  "sourceIdentifier": "cna@vuldb.com",
+  "published": "2024-06-07T10:15:12.293",
+  "lastModified": "2024-06-11T17:57:13.767",
+  "vulnStatus": "Analyzed",
+  "descriptions": [
+    {
+      "lang": "en",
+      "value": "A vulnerability was found in Clash up to 0.20.1 on Windows. It has been declared as critical. This vulnerability affects unknown code of the component Proxy Port. The manipulation leads to improper authentication. The attack can be initiated remotely. The exploit has been disclosed to the public and may be used. It is recommended to change the configuration settings. VDB-267406 is the identifier assigned to this vulnerability."
+    },
+    {
+      "lang": "es",
+      "value": "Se encontró una vulnerabilidad en Clash hasta 0.20.1 en Windows. Ha sido declarada crítica. Esta vulnerabilidad afecta a un código desconocido del componente Proxy Port. La manipulación conduce a una autenticación incorrecta. El ataque se puede iniciar de forma remota. El exploit ha sido divulgado al público y puede utilizarse. Se recomienda cambiar los ajustes de configuración. VDB-267406 es el identificador asignado a esta vulnerabilidad."
+    }
+  ],
+  "metrics": {
+    "cvssMetricV40": [
+      {
+        "source": "nvd@nist.gov",
+        "type": "Primary",
+        "cvssData": {
+          "version": "4.0",
+          "vectorString": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:L/VI:L/VA:L/SC:N/SI:N/SA:N/E:X/CR:X/IR:X/AR:X/MAV:X/MAC:X/MAT:X/MPR:X/MUI:X/MVC:X/MVI:X/MVA:X/MSC:X/MSI:X/MSA:X/S:X/AU:X/R:X/V:X/RE:X/U:X",
+          "baseScore": 6.9,
+          "baseSeverity": "MEDIUM",
+          "attackVector": "NETWORK",
+          "attackComplexity": "LOW",
+          "attackRequirements": "NONE",
+          "privilegesRequired": "NONE",
+          "userInteraction": "NONE",
+          "vulnerableSystemConfidentiality": "LOW",
+          "vulnerableSystemIntegrity": "LOW",
+          "vulnerableSystemAvailability": "LOW",
+          "subsequentSystemConfidentiality": "NONE",
+          "subsequentSystemIntegrity": "NONE",
+          "subsequentSystemAvailability": "NONE",
+          "exploitMaturity": "NOT_DEFINED",
+          "confidentialityRequirements": "NOT_DEFINED",
+          "integrityRequirements": "NOT_DEFINED",
+          "availabilityRequirements": "NOT_DEFINED",
+          "modifiedAttackVector": "NOT_DEFINED",
+          "modifiedAttackComplexity": "NOT_DEFINED",
+          "modifiedAttackRequirements": "NOT_DEFINED",
+          "modifiedPrivilegesRequired": "NOT_DEFINED",
+          "modifiedUserInteraction": "NOT_DEFINED",
+          "modifiedVulnerableSystemConfidentiality": "NOT_DEFINED",
+          "modifiedVulnerableSystemIntegrity": "NOT_DEFINED",
+          "modifiedVulnerableSystemAvailability": "NOT_DEFINED",
+          "modifiedSubsequentSystemConfidentiality": "NOT_DEFINED",
+          "modifiedSubsequentSystemIntegrity": "NOT_DEFINED",
+          "modifiedSubsequentSystemAvailability": "NOT_DEFINED",
+          "safety": "NOT_DEFINED",
+          "automatable": "NOT_DEFINED",
+          "providerUrgency": "NOT_DEFINED",
+          "recovery": "NOT_DEFINED",
+          "valueDensity": "NOT_DEFINED",
+          "vulnerabilityResponseEffort": "NOT_DEFINED"
+        }
+      }
+    ],
+    "cvssMetricV31": [
+      {
+        "source": "nvd@nist.gov",
+        "type": "Primary",
+        "cvssData": {
+          "version": "3.1",
+          "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+          "attackVector": "NETWORK",
+          "attackComplexity": "LOW",
+          "privilegesRequired": "NONE",
+          "userInteraction": "NONE",
+          "scope": "UNCHANGED",
+          "confidentialityImpact": "HIGH",
+          "integrityImpact": "HIGH",
+          "availabilityImpact": "HIGH",
+          "baseScore": 9.8,
+          "baseSeverity": "CRITICAL"
+        },
+        "exploitabilityScore": 3.9,
+        "impactScore": 5.9
+      },
+      {
+        "source": "cna@vuldb.com",
+        "type": "Secondary",
+        "cvssData": {
+          "version": "3.1",
+          "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
+          "attackVector": "NETWORK",
+          "attackComplexity": "LOW",
+          "privilegesRequired": "NONE",
+          "userInteraction": "NONE",
+          "scope": "UNCHANGED",
+          "confidentialityImpact": "LOW",
+          "integrityImpact": "LOW",
+          "availabilityImpact": "LOW",
+          "baseScore": 7.3,
+          "baseSeverity": "HIGH"
+        },
+        "exploitabilityScore": 3.9,
+        "impactScore": 3.4
+      }
+    ],
+    "cvssMetricV2": [
+      {
+        "source": "cna@vuldb.com",
+        "type": "Secondary",
+        "cvssData": {
+          "version": "2.0",
+          "vectorString": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
+          "accessVector": "NETWORK",
+          "accessComplexity": "LOW",
+          "authentication": "NONE",
+          "confidentialityImpact": "PARTIAL",
+          "integrityImpact": "PARTIAL",
+          "availabilityImpact": "PARTIAL",
+          "baseScore": 7.5
+        },
+        "baseSeverity": "HIGH",
+        "exploitabilityScore": 10,
+        "impactScore": 6.4,
+        "acInsufInfo": false,
+        "obtainAllPrivilege": false,
+        "obtainUserPrivilege": false,
+        "obtainOtherPrivilege": false,
+        "userInteractionRequired": false
+      }
+    ]
+  },
+  "weaknesses": [
+    {
+      "source": "cna@vuldb.com",
+      "type": "Primary",
+      "description": [
+        {
+          "lang": "en",
+          "value": "CWE-287"
+        }
+      ]
+    }
+  ],
+  "configurations": [
+    {
+      "nodes": [
+        {
+          "operator": "OR",
+          "negate": false,
+          "cpeMatch": [
+            {
+              "vulnerable": true,
+              "criteria": "cpe:2.3:a:clashforwindows:clash:*:*:*:*:*:windows:*:*",
+              "matchCriteriaId": "329C7DB6-FE20-4BA7-ADFF-383019916ACC",
+              "versionStartIncluding": "0.1.0",
+              "versionEndIncluding": "0.20.1"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "references": [
+    {
+      "url": "https://github.com/GTA12138/vul/blob/main/clash%20for%20windows.md",
+      "source": "cna@vuldb.com",
+      "tags": [
+        "Exploit",
+        "Third Party Advisory"
+      ]
+    },
+    {
+      "url": "https://vuldb.com/?ctiid.267406",
+      "source": "cna@vuldb.com",
+      "tags": [
+        "Permissions Required",
+        "VDB Entry"
+      ]
+    },
+    {
+      "url": "https://vuldb.com/?id.267406",
+      "source": "cna@vuldb.com",
+      "tags": [
+        "Permissions Required",
+        "Third Party Advisory",
+        "VDB Entry"
+      ]
+    },
+    {
+      "url": "https://vuldb.com/?submit.345469",
+      "source": "cna@vuldb.com",
+      "tags": [
+        "Third Party Advisory",
+        "VDB Entry"
+      ]
+    }
+  ]
+}

--- a/pkg/vulnsrc/nvd/types.go
+++ b/pkg/vulnsrc/nvd/types.go
@@ -23,9 +23,25 @@ type Reference struct {
 }
 
 type Metrics struct {
-	CvssMetricV31 []CvssMetricV3 `json:"cvssMetricV31,omitempty"`
-	CvssMetricV30 []CvssMetricV3 `json:"cvssMetricV30,omitempty"`
-	CvssMetricV2  []CvssMetricV2 `json:"cvssMetricV2,omitempty"`
+	CvssMetricV40 []CvssMetricV40 `json:"cvssMetricV40,omitempty"`
+	CvssMetricV31 []CvssMetricV3  `json:"cvssMetricV31,omitempty"`
+	CvssMetricV30 []CvssMetricV3  `json:"cvssMetricV30,omitempty"`
+	CvssMetricV2  []CvssMetricV2  `json:"cvssMetricV2,omitempty"`
+}
+
+// CvssMetricV40 is based on https://csrc.nist.gov/schema/nvd/api/2.0/cve_api_json_2.0.schema.
+type CvssMetricV40 struct {
+	Source   string      `json:"source"`
+	Type     string      `json:"type"`
+	CvssData CvssDataV40 `json:"cvssData"`
+}
+
+// CvssDataV40 is based on https://csrc.nist.gov/schema/nvd/api/2.0/external/cvss-v4.0.json
+type CvssDataV40 struct {
+	Version      string  `json:"version"`
+	VectorString string  `json:"vectorString"`
+	BaseScore    float64 `json:"baseScore"`
+	BaseSeverity string  `json:"baseSeverity"`
 }
 
 // CvssMetricV3 is based on https://csrc.nist.gov/schema/nvd/api/2.0/cve_api_json_2.0.schema.

--- a/pkg/vulnsrc/vulnerability/vulnerability.go
+++ b/pkg/vulnsrc/vulnerability/vulnerability.go
@@ -59,14 +59,16 @@ func (Vulnerability) Normalize(details map[types.SourceID]types.VulnerabilityDet
 func getCVSS(details map[types.SourceID]types.VulnerabilityDetail) types.VendorCVSS {
 	vc := make(types.VendorCVSS)
 	for vendor, detail := range details {
-		if (detail.CvssVector == "" || detail.CvssScore == 0) && (detail.CvssVectorV3 == "" || detail.CvssScoreV3 == 0) {
+		if (detail.CvssVector == "" || detail.CvssScore == 0) && (detail.CvssVectorV3 == "" || detail.CvssScoreV3 == 0) && (detail.CvssVectorV40 == "" || detail.CvssScoreV40 == 0) {
 			continue
 		}
 		vc[vendor] = types.CVSS{
-			V2Vector: detail.CvssVector,
-			V3Vector: detail.CvssVectorV3,
-			V2Score:  detail.CvssScore,
-			V3Score:  detail.CvssScoreV3,
+			V2Vector:  detail.CvssVector,
+			V3Vector:  detail.CvssVectorV3,
+			V40Vector: detail.CvssVectorV40,
+			V2Score:   detail.CvssScore,
+			V3Score:   detail.CvssScoreV3,
+			V40Score:  detail.CvssScoreV40,
 		}
 	}
 	return vc
@@ -76,10 +78,14 @@ func getVendorSeverity(details map[types.SourceID]types.VulnerabilityDetail) typ
 	vs := make(types.VendorSeverity)
 	for vendor, detail := range details {
 		switch {
+		case detail.SeverityV40 != types.SeverityUnknown:
+			vs[vendor] = detail.SeverityV40
 		case detail.SeverityV3 != types.SeverityUnknown:
 			vs[vendor] = detail.SeverityV3
 		case detail.Severity != types.SeverityUnknown:
 			vs[vendor] = detail.Severity
+		case detail.CvssScoreV40 > 0:
+			vs[vendor] = scoreToSeverity(detail.CvssScoreV40)
 		case detail.CvssScoreV3 > 0:
 			vs[vendor] = scoreToSeverity(detail.CvssScoreV3)
 		case detail.CvssScore > 0:
@@ -94,10 +100,14 @@ func getSeverity(details map[types.SourceID]types.VulnerabilityDetail) types.Sev
 		switch d, ok := details[source]; {
 		case !ok:
 			continue
+		case d.CvssScoreV40 > 0:
+			return scoreToSeverity(d.CvssScoreV40)
 		case d.CvssScoreV3 > 0:
 			return scoreToSeverity(d.CvssScoreV3)
 		case d.CvssScore > 0:
 			return scoreToSeverity(d.CvssScore)
+		case d.SeverityV40 != 0:
+			return d.SeverityV40
 		case d.SeverityV3 != 0:
 			return d.SeverityV3
 		case d.Severity != 0:

--- a/pkg/vulnsrc/vulnerability/vulnerability_test.go
+++ b/pkg/vulnsrc/vulnerability/vulnerability_test.go
@@ -267,6 +267,43 @@ func TestNormalize(t *testing.T) {
 				Description: "a test vulnerability where vendor rates it lower than NVD",
 			},
 		},
+		{
+			name: "happy path, nvd CVSS v4.0",
+			details: map[types.SourceID]types.VulnerabilityDetail{
+				vulnerability.NVD: {
+					Description:      "a test vulnerability for NVD CVSS v4.0",
+					CvssScoreV3:      9.8,
+					CvssVectorV3:     "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+					CvssScoreV40:     6.9,
+					CvssVectorV40:    "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:L/VI:L/VA:L/SC:N/SI:N/SA:N/E:X/CR:X/IR:X/AR:X/MAV:X/MAC:X/MAT:X/MPR:X/MUI:X/MVC:X/MVI:X/MVA:X/MSC:X/MSI:X/MSA:X/S:X/AU:X/R:X/V:X/RE:X/U:X",
+					SeverityV3:       types.SeverityCritical,
+					SeverityV40:      types.SeverityMedium,
+					CweIDs:           []string{"CWE-287"},
+					References:       []string{"https://github.com/GTA12138/vul/blob/main/clash%20for%20windows.md", "https://vuldb.com/?ctiid.267406", "https://vuldb.com/?id.267406", "https://vuldb.com/?submit.345469"},
+					LastModifiedDate: utils.MustTimeParse("2024-06-11T17:57:13.767Z"),
+					PublishedDate:    utils.MustTimeParse("2024-06-07T10:15:12.293Z"),
+				},
+			},
+			want: types.Vulnerability{
+				Description: "a test vulnerability for NVD CVSS v4.0",
+				Severity:    types.SeverityMedium.String(),
+				VendorSeverity: types.VendorSeverity{
+					vulnerability.NVD: types.SeverityMedium,
+				},
+				CVSS: types.VendorCVSS{
+					vulnerability.NVD: types.CVSS{
+						V3Vector:  "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+						V40Vector: "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:L/VI:L/VA:L/SC:N/SI:N/SA:N/E:X/CR:X/IR:X/AR:X/MAV:X/MAC:X/MAT:X/MPR:X/MUI:X/MVC:X/MVI:X/MVA:X/MSC:X/MSI:X/MSA:X/S:X/AU:X/R:X/V:X/RE:X/U:X",
+						V3Score:   9.8,
+						V40Score:  6.9,
+					},
+				},
+				CweIDs:           []string{"CWE-287"},
+				References:       []string{"https://github.com/GTA12138/vul/blob/main/clash%20for%20windows.md", "https://vuldb.com/?ctiid.267406", "https://vuldb.com/?id.267406", "https://vuldb.com/?submit.345469"},
+				LastModifiedDate: utils.MustTimeParse("2024-06-11T17:57:13.767Z"),
+				PublishedDate:    utils.MustTimeParse("2024-06-07T10:15:12.293Z"),
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
## Description
Supports NVD CVSS V4.0 Schema with Trivy DB.
https://github.com/aquasecurity/vuln-list-update/pull/297

## How has this been tested?

I've run the test cases using make test and all of them passed.