### PR TITLE
chore: configure directories in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
 SHELL=/bin/bash
 LDFLAGS=-ldflags "-s -w"
-CACHE_DIR=cache
-OUT_DIR=out
-ASSET_DIR=assets
+
+CACHE_DIR ?= cache
+OUT_DIR ?= out
+ASSET_DIR ?= assets
 
 GOPATH=$(shell go env GOPATH)
 GOBIN=$(GOPATH)/bin


### PR DESCRIPTION
The directories can be passed now.

```
$ make db-fetch-vuln-list CACHE_DIR=/path/to/cache
```