### PR TITLE
refactor(redhat-oval): return an error if the CPE is not found

### DIFF
--- a/pkg/vulnsrc/redhat-oval/redhat-oval.go
+++ b/pkg/vulnsrc/redhat-oval/redhat-oval.go
@@ -248,6 +248,10 @@ func (vs VulnSrc) Get(pkgName string, repositories, nvrs []string) ([]types.Advi
 		return nil, xerrors.Errorf("CPE convert error: %w", err)
 	}
 
+	if len(cpeIndices) == 0 {
+		return nil, xerrors.Errorf("No CPE indices found")
+	}
+
 	rawAdvisories, err := vs.dbc.ForEachAdvisory([]string{rootBucket}, pkgName)
 	if err != nil {
 		return nil, xerrors.Errorf("unable to iterate advisories: %w", err)

--- a/pkg/vulnsrc/redhat-oval/redhat-oval.go
+++ b/pkg/vulnsrc/redhat-oval/redhat-oval.go
@@ -249,7 +249,7 @@ func (vs VulnSrc) Get(pkgName string, repositories, nvrs []string) ([]types.Advi
 	}
 
 	if len(cpeIndices) == 0 {
-		return nil, xerrors.Errorf("No CPE indices found")
+		return nil, xerrors.Errorf("unable to find CPE indices. See https://github.com/aquasecurity/trivy-db/issues/435 for details")
 	}
 
 	rawAdvisories, err := vs.dbc.ForEachAdvisory([]string{rootBucket}, pkgName)

--- a/pkg/vulnsrc/redhat-oval/redhat-oval_test.go
+++ b/pkg/vulnsrc/redhat-oval/redhat-oval_test.go
@@ -918,7 +918,7 @@ func TestVulnSrc_Get(t *testing.T) {
 				"testdata/fixtures/happy.yaml",
 				"testdata/fixtures/cpe.yaml",
 			},
-			want: []types.Advisory(nil),
+			wantErr: "No CPE indices found",
 		},
 		{
 			name: "no advisory bucket",
@@ -936,7 +936,7 @@ func TestVulnSrc_Get(t *testing.T) {
 				repositories: []string{"rhel-8-for-x86_64-baseos-rpms"},
 			},
 			fixtures: []string{"testdata/fixtures/happy.yaml"},
-			want:     []types.Advisory(nil),
+			wantErr:  "No CPE indices found",
 		},
 		{
 			name: "broken JSON",

--- a/pkg/vulnsrc/redhat-oval/redhat-oval_test.go
+++ b/pkg/vulnsrc/redhat-oval/redhat-oval_test.go
@@ -918,7 +918,7 @@ func TestVulnSrc_Get(t *testing.T) {
 				"testdata/fixtures/happy.yaml",
 				"testdata/fixtures/cpe.yaml",
 			},
-			wantErr: "No CPE indices found",
+			wantErr: "unable to find CPE indices.",
 		},
 		{
 			name: "no advisory bucket",
@@ -936,7 +936,7 @@ func TestVulnSrc_Get(t *testing.T) {
 				repositories: []string{"rhel-8-for-x86_64-baseos-rpms"},
 			},
 			fixtures: []string{"testdata/fixtures/happy.yaml"},
-			wantErr:  "No CPE indices found",
+			wantErr:  "unable to find CPE indices.",
 		},
 		{
 			name: "broken JSON",


### PR DESCRIPTION
## Description
`Get()` function returns an error if the CPE is not found