### PR TITLE
fix: do not use a pointer receiver for Status.MarshalJSON

### DIFF
--- a/pkg/types/status.go
+++ b/pkg/types/status.go
@@ -58,7 +58,7 @@ func (s *Status) Index() int {
 	return int(*s)
 }
 
-func (s *Status) MarshalJSON() ([]byte, error) {
+func (s Status) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s.String())
 }
 


### PR DESCRIPTION
## Description
In MarshalJSON, using a pointer receiver was not supposed to be marshalled correctly, but in Trivy, the output was correct (I did not investigate the reason in detail), and furthermore, to suppress the following warning, I used a pointer.

>Struct Status has methods on both value and pointer receivers. Such usage is not recommended by the Go Documentation. 

However, it seems that `Status` was only correctly marshalled by chance because [DetectedVulnerability](https://github.com/aquasecurity/trivy/blob/7aea79dd93cfb61453766dbbb2e3fc0fbd317852/pkg/types/report.go#L114) was a slice. We actually found a case where `DetectedVulnerability` was [not correctly marshalled](https://github.com/aquasecurity/trivy/pull/7463) when `DetectedVulnerability` was not a slice, so this PR will correct this.


Translated with DeepL.com (free version)
