### PR TITLE
ci: set to download DB daily

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ db-fetch-langs:
 
 .PHONY: db-build
 db-build: trivy-db
-	./trivy-db build --cache-dir ./$(CACHE_DIR) --output-dir ./$(OUT_DIR) --update-interval 6h
+	./trivy-db build --cache-dir ./$(CACHE_DIR) --output-dir ./$(OUT_DIR) --update-interval 24h
 
 .PHONY: db-compact
 db-compact: $(GOBIN)/bbolt out/trivy.db


### PR DESCRIPTION
This PR changes to have clients download the DB once a day as we are facing [GHCR rate limits](https://github.com/aquasecurity/trivy/discussions/7538). However, the DB will be built [once every 6 hours](https://github.com/aquasecurity/trivy-db/blob/cfa337a1088bbcee598ab93656c83fe6b9acb946/.github/workflows/cron.yml#L5).

