### PR TITLE
fix(cron): pin `ubuntu-24.04` runner and use installed (bump to v1.2.0) `oras` version

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -106,7 +106,7 @@ jobs:
             for tag in "${tags[@]}"; do
               echo "Pushing artifact with tag: ${tag}"
           
-              if oras push --artifact-type application/vnd.aquasec.trivy.config.v1+json \
+              if ./oras push --artifact-type application/vnd.aquasec.trivy.config.v1+json \
                 "${full_registry_url}:${tag}" \
                 db.tar.gz:application/vnd.aquasec.trivy.db.layer.v1.tar+gzip; then
                 echo "Successfully pushed to ${full_registry_url}:${tag}"

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -11,7 +11,7 @@ env:
 jobs:
   build:
     name: Build DB
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Maximize build space
         uses: easimon/maximize-build-space@v10

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -74,9 +74,8 @@ jobs:
 
       - name: Install oras
         run: |
-          # upgrade to ORAS 1.0.0
-          curl -LO https://github.com/oras-project/oras/releases/download/v1.0.0/oras_1.0.0_linux_amd64.tar.gz
-          tar -xvf ./oras_1.0.0_linux_amd64.tar.gz
+          curl -LO https://github.com/oras-project/oras/releases/download/v1.2.0/oras_1.2.0_linux_amd64.tar.gz
+          tar -xvf ./oras_1.2.0_linux_amd64.tar.gz
 
 
       - name: Upload assets to registries


### PR DESCRIPTION
## Description
`ubuntu-24.04` runner is now `latest` runner.

But `ubuntu-24.04` runner doesn't have preinstalled `oras` - https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md#cli-tools

Before using `ubuntu-24.04` - we used `ubuntu-22.04`.
`ubuntu-22.04` contains [oras v1.2.0](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md#cli-tools).

Changes of this PR:
- pin `ubuntu-24.04` runner (to avoid problem with next update `latest` runner).
- bump installed `oras` version to `v1.2.0` (as in `ubuntu-22.04` runner)
- use installed `oras`.

test run - https://github.com/DmitriyLewen/trivy-db/actions/runs/11339374413/job/31534396989