### PR TITLE
fix(oracle): split version flavors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/briandowns/spinner v1.23.0
 	github.com/fatih/color v1.10.0 // indirect
 	github.com/knqyf263/go-deb-version v0.0.0-20190517075300-09fca494f03d
-	github.com/knqyf263/go-rpm-version v0.0.0-20170716094938-74609b86c936
+	github.com/knqyf263/go-rpm-version v0.0.0-20240918084003-2afd7dc6a38f
 	github.com/masahiro331/go-mvn-version v0.0.0-20210429150710-d3157d602a08
 	github.com/pandatix/go-cvss v0.6.2
 	github.com/samber/lo v1.47.0

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/knqyf263/go-deb-version v0.0.0-20190517075300-09fca494f03d h1:X4cedH4
 github.com/knqyf263/go-deb-version v0.0.0-20190517075300-09fca494f03d/go.mod h1:o8sgWoz3JADecfc/cTYD92/Et1yMqMy0utV1z+VaZao=
 github.com/knqyf263/go-rpm-version v0.0.0-20170716094938-74609b86c936 h1:HDjRqotkViMNcGMGicb7cgxklx8OwnjtCBmyWEqrRvM=
 github.com/knqyf263/go-rpm-version v0.0.0-20170716094938-74609b86c936/go.mod h1:i4sF0l1fFnY1aiw08QQSwVAFxHEm311Me3WsU/X7nL0=
+github.com/knqyf263/go-rpm-version v0.0.0-20240918084003-2afd7dc6a38f h1:xt29M2T6STgldg+WEP51gGePQCsQvklmP2eIhPIBK3g=
+github.com/knqyf263/go-rpm-version v0.0.0-20240918084003-2afd7dc6a38f/go.mod h1:i4sF0l1fFnY1aiw08QQSwVAFxHEm311Me3WsU/X7nL0=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=

--- a/pkg/vulnsrc/oracle-oval/oracle-oval.go
+++ b/pkg/vulnsrc/oracle-oval/oracle-oval.go
@@ -140,7 +140,8 @@ func (vs *VulnSrc) commit(tx *bolt.Tx, ovals []OracleOVAL) error {
 				return xerrors.Errorf("failed to put data source: %w", err)
 			}
 
-			// TODO can we refactor that?
+			// Clean affectedPkg.Package.FixedVersion to find same packages,
+			// when we merge fixed versions from multiple ELSA files
 			fixedVersion := affectedPkg.Package.FixedVersion
 			affectedPkg.Package.FixedVersion = ""
 

--- a/pkg/vulnsrc/oracle-oval/oracle-oval.go
+++ b/pkg/vulnsrc/oracle-oval/oracle-oval.go
@@ -172,15 +172,15 @@ func (vs *VulnSrc) commit(tx *bolt.Tx, ovals []OracleOVAL) error {
 			if savedInput, ok := putInputs[input.VulnID]; ok {
 				input.OVALs = append(input.OVALs, savedInput.OVALs...)
 
-				// Merge advisories
-				for savedPkg, savedAdvisory := range savedInput.Advisories {
-					if adv, advFound := input.Advisories[savedPkg]; advFound {
+				for newPkg, newAdv := range input.Advisories {
+					if savedPkgAdv, pkgFound := savedInput.Advisories[newPkg]; pkgFound {
 						// Merge patchedVersions.
 						// We will remove duplicates later.
-						adv.PatchedVersions = append(adv.PatchedVersions, savedAdvisory.PatchedVersions...)
-						input.Advisories[savedPkg] = adv
+						newAdv.PatchedVersions = append(savedPkgAdv.PatchedVersions, newAdv.PatchedVersions...)
 					}
+					savedInput.Advisories[newPkg] = newAdv
 				}
+				input.Advisories = savedInput.Advisories
 			}
 			putInputs[input.VulnID] = input
 		}

--- a/pkg/vulnsrc/oracle-oval/oracle-oval.go
+++ b/pkg/vulnsrc/oracle-oval/oracle-oval.go
@@ -191,11 +191,11 @@ func (vs *VulnSrc) commit(tx *bolt.Tx, ovals []OracleOVAL) error {
 			// Keep only the normal version in adv.FixedVersion for backward compatibility.
 			adv.FixedVersion, adv.PatchedVersions = patchedVersions(adv.PatchedVersions)
 			input.Advisories[pkg] = adv
+		}
 
-			err := vs.Put(tx, input)
-			if err != nil {
-				return xerrors.Errorf("db put error: %w", err)
-			}
+		err := vs.Put(tx, input)
+		if err != nil {
+			return xerrors.Errorf("db put error: %w", err)
 		}
 	}
 
@@ -226,7 +226,11 @@ func patchedVersions(vers []string) (string, []string) {
 		}
 		patchedVers[flavor] = ver
 	}
-	return patchedVers[NormalPackageFlavor], lo.Values(patchedVers)
+
+	versions := lo.Values(patchedVers)
+	slices.Sort(versions)
+
+	return patchedVers[NormalPackageFlavor], versions
 }
 
 // PackageFlavor determinants the package "flavor" based on its version string
@@ -311,7 +315,11 @@ func referencesFromContains(sources []string, matches []string) []string {
 			}
 		}
 	}
-	return lo.Uniq(references)
+
+	references = lo.Uniq(references)
+	slices.Sort(references)
+
+	return references
 }
 
 func severityFromThreat(sev string) types.Severity {

--- a/pkg/vulnsrc/oracle-oval/oracle-oval_test.go
+++ b/pkg/vulnsrc/oracle-oval/oracle-oval_test.go
@@ -421,6 +421,9 @@ func TestVulnSrc_Get(t *testing.T) {
 				{
 					VulnerabilityID: "ELSA-2019-1145",
 					FixedVersion:    "32:9.11.4-17.P2.el8_0",
+					PatchedVersions: []string{
+						"32:9.11.4-17.P2.el8_0",
+					},
 				},
 			},
 		},

--- a/pkg/vulnsrc/oracle-oval/oracle-oval_test.go
+++ b/pkg/vulnsrc/oracle-oval/oracle-oval_test.go
@@ -39,24 +39,36 @@ func TestVulnSrc_Update(t *testing.T) {
 					Key: []string{"advisory-detail", "CVE-2007-0493", "Oracle Linux 5", "bind-devel"},
 					Value: types.Advisory{
 						FixedVersion: "30:9.3.3-8.el5",
+						PatchedVersions: []string{
+							"30:9.3.3-8.el5",
+						},
 					},
 				},
 				{
 					Key: []string{"advisory-detail", "CVE-2007-0494", "Oracle Linux 5", "bind-devel"},
 					Value: types.Advisory{
 						FixedVersion: "30:9.3.3-8.el5",
+						PatchedVersions: []string{
+							"30:9.3.3-8.el5",
+						},
 					},
 				},
 				{
 					Key: []string{"advisory-detail", "CVE-2007-0493", "Oracle Linux 5", "bind-sdb"},
 					Value: types.Advisory{
 						FixedVersion: "30:9.3.3-8.el5",
+						PatchedVersions: []string{
+							"30:9.3.3-8.el5",
+						},
 					},
 				},
 				{
 					Key: []string{"advisory-detail", "CVE-2007-0494", "Oracle Linux 5", "bind-sdb"},
 					Value: types.Advisory{
 						FixedVersion: "30:9.3.3-8.el5",
+						PatchedVersions: []string{
+							"30:9.3.3-8.el5",
+						},
 					},
 				},
 				{
@@ -117,48 +129,72 @@ func TestVulnSrc_Update(t *testing.T) {
 					Key: []string{"advisory-detail", "CVE-2018-1094", "Oracle Linux 6", "kernel-uek-doc"},
 					Value: types.Advisory{
 						FixedVersion: "4.1.12-124.24.3.el6uek",
+						PatchedVersions: []string{
+							"4.1.12-124.24.3.el6uek",
+						},
 					},
 				},
 				{
 					Key: []string{"advisory-detail", "CVE-2018-19824", "Oracle Linux 6", "kernel-uek-doc"},
 					Value: types.Advisory{
 						FixedVersion: "4.1.12-124.24.3.el6uek",
+						PatchedVersions: []string{
+							"4.1.12-124.24.3.el6uek",
+						},
 					},
 				},
 				{
 					Key: []string{"advisory-detail", "CVE-2018-1094", "Oracle Linux 6", "kernel-uek-firmware"},
 					Value: types.Advisory{
 						FixedVersion: "4.1.12-124.24.3.el6uek",
+						PatchedVersions: []string{
+							"4.1.12-124.24.3.el6uek",
+						},
 					},
 				},
 				{
 					Key: []string{"advisory-detail", "CVE-2018-19824", "Oracle Linux 6", "kernel-uek-firmware"},
 					Value: types.Advisory{
 						FixedVersion: "4.1.12-124.24.3.el6uek",
+						PatchedVersions: []string{
+							"4.1.12-124.24.3.el6uek",
+						},
 					},
 				},
 				{
 					Key: []string{"advisory-detail", "CVE-2018-1094", "Oracle Linux 7", "kernel-uek-doc"},
 					Value: types.Advisory{
 						FixedVersion: "4.1.12-124.24.3.el7uek",
+						PatchedVersions: []string{
+							"4.1.12-124.24.3.el7uek",
+						},
 					},
 				},
 				{
 					Key: []string{"advisory-detail", "CVE-2018-19824", "Oracle Linux 7", "kernel-uek-doc"},
 					Value: types.Advisory{
 						FixedVersion: "4.1.12-124.24.3.el7uek",
+						PatchedVersions: []string{
+							"4.1.12-124.24.3.el7uek",
+						},
 					},
 				},
 				{
 					Key: []string{"advisory-detail", "CVE-2018-1094", "Oracle Linux 7", "kernel-uek-firmware"},
 					Value: types.Advisory{
 						FixedVersion: "4.1.12-124.24.3.el7uek",
+						PatchedVersions: []string{
+							"4.1.12-124.24.3.el7uek",
+						},
 					},
 				},
 				{
 					Key: []string{"advisory-detail", "CVE-2018-19824", "Oracle Linux 7", "kernel-uek-firmware"},
 					Value: types.Advisory{
 						FixedVersion: "4.1.12-124.24.3.el7uek",
+						PatchedVersions: []string{
+							"4.1.12-124.24.3.el7uek",
+						},
 					},
 				},
 				{
@@ -196,6 +232,95 @@ func TestVulnSrc_Update(t *testing.T) {
 			},
 		},
 		{
+			name: "happy path multi flavors",
+			dir:  filepath.Join("testdata", "multi-flavor"),
+			wantValues: []vulnsrctest.WantValues{
+				{
+					Key: []string{"data-source", "Oracle Linux 8"},
+					Value: types.DataSource{
+						ID:   vulnerability.OracleOVAL,
+						Name: "Oracle Linux OVAL definitions",
+						URL:  "https://linux.oracle.com/security/oval/",
+					},
+				},
+				{
+					Key: []string{"advisory-detail", "CVE-2021-20232", "Oracle Linux 8", "gnutls"},
+					Value: types.Advisory{
+						FixedVersion: "3.6.16-4.el8",
+						PatchedVersions: []string{
+							"10:3.6.16-4.0.1.el8_fips",
+							"3.6.16-4.el8",
+						},
+					},
+				},
+				{
+					Key: []string{"advisory-detail", "CVE-2021-3580", "Oracle Linux 8", "gnutls"},
+					Value: types.Advisory{
+						PatchedVersions: []string{
+							"10:3.6.16-4.0.1.el8_fips",
+						},
+					},
+				},
+				{
+					Key: []string{"advisory-detail", "CVE-2021-20231", "Oracle Linux 8", "gnutls"},
+					Value: types.Advisory{
+						FixedVersion: "3.6.16-4.el8",
+						PatchedVersions: []string{
+							"3.6.16-4.el8",
+						},
+					},
+				},
+				{
+					Key: []string{"vulnerability-detail", "CVE-2021-3580", "oracle-oval"},
+					Value: types.VulnerabilityDetail{
+						Title:       "ELSA-2022-9221:  gnutls security update (MODERATE)",
+						Description: "[3.6.16-4.0.1_fips]\n- Allow RSA keygen with modulus sizes bigger than 3072 bits and validate the seed length\n  as defined in FIPS 186-4 section B.3.2 [Orabug: 33200526]\n- Allow bigger known RSA modulus sizes when calling\n  rsa_generate_fips186_4_keypair directly [Orabug: 33200526]\n- Change Epoch from 1 to 10\n\n[3.6.16-4]\n- p11tool: Document ID reuse behavior when importing certs (#1776250)\n\n[3.6.16-3]\n- Treat SHA-1 signed CA in the trusted set differently (#1965445)\n\n[3.6.16-2]\n- Filter certificate_types in TLS 1.2 CR based on signature algorithms (#1942216)\n\n[3.6.16-1]\n- Update to upstream 3.6.16 release (#1956783)\n- Fix potential use-after-free in key_share handling (#1927597)\n- Fix potential use-after-free in pre_shared_key handling (#1927593)\n- Stop gnutls-serv relying on AI_ADDRCONFIG to decide listening address (#1908334)\n- Fix cert expiration issue in tests (#1908110)\n\n[3.6.14-10]\n- Port fixes for potential miscalculation in ecdsa_verify (#1942931)\n\n[3.6.14-9]\n- Revert the previous change",
+						References: []string{
+							"https://linux.oracle.com/cve/CVE-2021-3580.html",
+							"https://linux.oracle.com/errata/ELSA-2022-9221.html",
+						},
+						Severity: types.SeverityMedium,
+					},
+				},
+				{
+					Key: []string{"vulnerability-detail", "CVE-2021-3580", "oracle-oval"},
+					Value: types.VulnerabilityDetail{
+						Title:       "ELSA-2022-9221:  gnutls security update (MODERATE)",
+						Description: "[3.6.16-4.0.1_fips]\n- Allow RSA keygen with modulus sizes bigger than 3072 bits and validate the seed length\n  as defined in FIPS 186-4 section B.3.2 [Orabug: 33200526]\n- Allow bigger known RSA modulus sizes when calling\n  rsa_generate_fips186_4_keypair directly [Orabug: 33200526]\n- Change Epoch from 1 to 10\n\n[3.6.16-4]\n- p11tool: Document ID reuse behavior when importing certs (#1776250)\n\n[3.6.16-3]\n- Treat SHA-1 signed CA in the trusted set differently (#1965445)\n\n[3.6.16-2]\n- Filter certificate_types in TLS 1.2 CR based on signature algorithms (#1942216)\n\n[3.6.16-1]\n- Update to upstream 3.6.16 release (#1956783)\n- Fix potential use-after-free in key_share handling (#1927597)\n- Fix potential use-after-free in pre_shared_key handling (#1927593)\n- Stop gnutls-serv relying on AI_ADDRCONFIG to decide listening address (#1908334)\n- Fix cert expiration issue in tests (#1908110)\n\n[3.6.14-10]\n- Port fixes for potential miscalculation in ecdsa_verify (#1942931)\n\n[3.6.14-9]\n- Revert the previous change",
+						References: []string{
+							"https://linux.oracle.com/cve/CVE-2021-3580.html",
+							"https://linux.oracle.com/errata/ELSA-2022-9221.html",
+						},
+						Severity: types.SeverityMedium,
+					},
+				},
+				{
+					Key: []string{"vulnerability-detail", "CVE-2021-20231", "oracle-oval"},
+					Value: types.VulnerabilityDetail{
+						Title:       "ELSA-2021-4451:  gnutls and nettle security, bug fix, and enhancement update (MODERATE)",
+						Description: "gnutls\n[3.6.16-4]\n- p11tool: Document ID reuse behavior when importing certs (#1776250)\n\n[3.6.16-3]\n- Treat SHA-1 signed CA in the trusted set differently (#1965445)\n\n[3.6.16-2]\n- Filter certificate_types in TLS 1.2 CR based on signature algorithms (#1942216)\n\n[3.6.16-1]\n- Update to upstream 3.6.16 release (#1956783)\n- Fix potential use-after-free in key_share handling (#1927597)\n- Fix potential use-after-free in pre_shared_key handling (#1927593)\n- Stop gnutls-serv relying on AI_ADDRCONFIG to decide listening address (#1908334)\n- Fix cert expiration issue in tests (#1908110)\n\n[3.6.14-10]\n- Port fixes for potential miscalculation in ecdsa_verify (#1942931)\n\n[3.6.14-9]\n- Revert the previous change\n\nnettle\n[3.4.1-7]\n- Backport CVE-2021-3580 from upstream 3.7.3 release (#1967990)\n\n[3.4.1-6]\n- Enable CTR mode optimization when the block size is 16\n\n[3.4.1-5]\n- Backport powerpc64 optimization patches from upstream (#1855228)\n  Patch from Christopher M. Riedl.",
+						References: []string{
+							"https://linux.oracle.com/cve/CVE-2021-20231.html",
+							"https://linux.oracle.com/errata/ELSA-2021-4451.html",
+						},
+						Severity: types.SeverityMedium,
+					},
+				},
+				{
+					Key:   []string{"vulnerability-id", "CVE-2021-20232"},
+					Value: map[string]interface{}{},
+				},
+				{
+					Key:   []string{"vulnerability-id", "CVE-2021-3580"},
+					Value: map[string]interface{}{},
+				},
+				{
+					Key:   []string{"vulnerability-id", "CVE-2021-20231"},
+					Value: map[string]interface{}{},
+				},
+			},
+		},
+		{
 			name: "happy path ELSA-ID",
 			dir:  filepath.Join("testdata", "elsa-id"),
 			wantValues: []vulnsrctest.WantValues{
@@ -211,6 +336,9 @@ func TestVulnSrc_Update(t *testing.T) {
 					Key: []string{"advisory-detail", "ELSA-2007-0057", "Oracle Linux 5", "bind-devel"},
 					Value: types.Advisory{
 						FixedVersion: "9.3.3-8.el5",
+						PatchedVersions: []string{
+							"9.3.3-8.el5",
+						},
 					},
 				},
 				{

--- a/pkg/vulnsrc/oracle-oval/testdata/fixtures/happy.yaml
+++ b/pkg/vulnsrc/oracle-oval/testdata/fixtures/happy.yaml
@@ -5,3 +5,5 @@
         - key: ELSA-2019-1145
           value:
             FixedVersion: "32:9.11.4-17.P2.el8_0"
+            PatchedVersions:
+              - "32:9.11.4-17.P2.el8_0"

--- a/pkg/vulnsrc/oracle-oval/testdata/multi-flavor/vuln-list/oval/oracle/2021/ELSA-2021-4451.json
+++ b/pkg/vulnsrc/oracle-oval/testdata/multi-flavor/vuln-list/oval/oracle/2021/ELSA-2021-4451.json
@@ -1,0 +1,81 @@
+{
+    "Title": "ELSA-2021-4451:  gnutls and nettle security, bug fix, and enhancement update (MODERATE)",
+    "Description": "gnutls\n[3.6.16-4]\n- p11tool: Document ID reuse behavior when importing certs (#1776250)\n\n[3.6.16-3]\n- Treat SHA-1 signed CA in the trusted set differently (#1965445)\n\n[3.6.16-2]\n- Filter certificate_types in TLS 1.2 CR based on signature algorithms (#1942216)\n\n[3.6.16-1]\n- Update to upstream 3.6.16 release (#1956783)\n- Fix potential use-after-free in key_share handling (#1927597)\n- Fix potential use-after-free in pre_shared_key handling (#1927593)\n- Stop gnutls-serv relying on AI_ADDRCONFIG to decide listening address (#1908334)\n- Fix cert expiration issue in tests (#1908110)\n\n[3.6.14-10]\n- Port fixes for potential miscalculation in ecdsa_verify (#1942931)\n\n[3.6.14-9]\n- Revert the previous change\n\nnettle\n[3.4.1-7]\n- Backport CVE-2021-3580 from upstream 3.7.3 release (#1967990)\n\n[3.4.1-6]\n- Enable CTR mode optimization when the block size is 16\n\n[3.4.1-5]\n- Backport powerpc64 optimization patches from upstream (#1855228)\n  Patch from Christopher M. Riedl.",
+    "Platform": [
+      "Oracle Linux 8"
+    ],
+    "References": [
+      {
+        "Source": "elsa",
+        "URI": "https://linux.oracle.com/errata/ELSA-2021-4451.html",
+        "ID": "ELSA-2021-4451"
+      },
+      {
+        "Source": "CVE",
+        "URI": "https://linux.oracle.com/cve/CVE-2021-20232.html",
+        "ID": "CVE-2021-20232"
+      },
+      {
+        "Source": "CVE",
+        "URI": "https://linux.oracle.com/cve/CVE-2021-20231.html",
+        "ID": "CVE-2021-20231"
+      }
+    ],
+    "Criteria": {
+      "Operator": "AND",
+      "Criterias": [
+        {
+          "Operator": "OR",
+          "Criterias": [
+            {
+              "Operator": "AND",
+              "Criterias": [
+                {
+                  "Operator": "OR",
+                  "Criterias": [
+                    {
+                      "Operator": "AND",
+                      "Criterias": null,
+                      "Criterions": [
+                        {
+                          "Comment": "gnutls is earlier than 0:3.6.16-4.el8"
+                        },
+                        {
+                          "Comment": "gnutls is signed with the Oracle Linux 8 key"
+                        }
+                      ]
+                    }
+                  ],
+                  "Criterions": null
+                }
+              ],
+              "Criterions": [
+                {
+                  "Comment": "Oracle Linux arch is x86_64"
+                }
+              ]
+            }
+          ],
+          "Criterions": null
+        }
+      ],
+      "Criterions": [
+        {
+          "Comment": "Oracle Linux 8 is installed"
+        }
+      ]
+    },
+    "Severity": "MODERATE",
+    "Cves": [
+      {
+        "Impact": "",
+        "Href": "https://linux.oracle.com/cve/CVE-2021-20232.html",
+        "ID": "CVE-2021-20232"
+      },
+      {
+        "Impact": "",
+        "Href": "https://linux.oracle.com/cve/CVE-2021-20231.html",
+        "ID": "CVE-2021-20231"
+      }
+    ]
+  }

--- a/pkg/vulnsrc/oracle-oval/testdata/multi-flavor/vuln-list/oval/oracle/2022/ELSA-2022-9221.json
+++ b/pkg/vulnsrc/oracle-oval/testdata/multi-flavor/vuln-list/oval/oracle/2022/ELSA-2022-9221.json
@@ -1,0 +1,84 @@
+{
+    "Title": "ELSA-2022-9221:  gnutls security update (MODERATE)",
+    "Description": "[3.6.16-4.0.1_fips]\n- Allow RSA keygen with modulus sizes bigger than 3072 bits and validate the seed length\n  as defined in FIPS 186-4 section B.3.2 [Orabug: 33200526]\n- Allow bigger known RSA modulus sizes when calling\n  rsa_generate_fips186_4_keypair directly [Orabug: 33200526]\n- Change Epoch from 1 to 10\n\n[3.6.16-4]\n- p11tool: Document ID reuse behavior when importing certs (#1776250)\n\n[3.6.16-3]\n- Treat SHA-1 signed CA in the trusted set differently (#1965445)\n\n[3.6.16-2]\n- Filter certificate_types in TLS 1.2 CR based on signature algorithms (#1942216)\n\n[3.6.16-1]\n- Update to upstream 3.6.16 release (#1956783)\n- Fix potential use-after-free in key_share handling (#1927597)\n- Fix potential use-after-free in pre_shared_key handling (#1927593)\n- Stop gnutls-serv relying on AI_ADDRCONFIG to decide listening address (#1908334)\n- Fix cert expiration issue in tests (#1908110)\n\n[3.6.14-10]\n- Port fixes for potential miscalculation in ecdsa_verify (#1942931)\n\n[3.6.14-9]\n- Revert the previous change",
+    "Platform": [
+      "Oracle Linux 8"
+    ],
+    "References": [
+      {
+        "Source": "elsa",
+        "URI": "https://linux.oracle.com/errata/ELSA-2022-9221.html",
+        "ID": "ELSA-2022-9221"
+      },
+      {
+        "Source": "CVE",
+        "URI": "https://linux.oracle.com/cve/CVE-2021-20232.html",
+        "ID": "CVE-2021-20232"
+      },
+      {
+        "Source": "CVE",
+        "URI": "https://linux.oracle.com/cve/CVE-2021-3580.html",
+        "ID": "CVE-2021-3580"
+      }
+    ],
+    "Criteria": {
+      "Operator": "AND",
+      "Criterias": [
+        {
+          "Operator": "OR",
+          "Criterias": [
+            {
+              "Operator": "AND",
+              "Criterias": [
+                {
+                  "Operator": "OR",
+                  "Criterias": [
+                    {
+                      "Operator": "AND",
+                      "Criterias": null,
+                      "Criterions": [
+                        {
+                          "Comment": "gnutls is earlier than 10:3.6.16-4.0.1.el8_fips"
+                        },
+                        {
+                          "Comment": "gnutls is signed with the Oracle Linux 8 key"
+                        },
+                        {
+                          "Comment": "gnutls is fips patched"
+                        }
+                      ]
+                    }
+                  ],
+                  "Criterions": null
+                }
+              ],
+              "Criterions": [
+                {
+                  "Comment": "Oracle Linux arch is x86_64"
+                }
+              ]
+            }
+          ],
+          "Criterions": null
+        }
+      ],
+      "Criterions": [
+        {
+          "Comment": "Oracle Linux 8 is installed"
+        }
+      ]
+    },
+    "Severity": "MODERATE",
+    "Cves": [
+      {
+        "Impact": "",
+        "Href": "https://linux.oracle.com/cve/CVE-2021-20232.html",
+        "ID": "CVE-2021-20232"
+      },
+      {
+        "Impact": "",
+        "Href": "https://linux.oracle.com/cve/CVE-2021-3580.html",
+        "ID": "CVE-2021-3580"
+      }
+    ]
+  }

--- a/pkg/vulnsrc/oracle-oval/types.go
+++ b/pkg/vulnsrc/oracle-oval/types.go
@@ -52,9 +52,3 @@ type Date struct {
 func (p *AffectedPackage) PlatformName() string {
 	return fmt.Sprintf(platformFormat, p.OSVer)
 }
-
-type vulnPkg struct {
-	OSVer   string
-	PkgName string
-	VulnID  string
-}

--- a/pkg/vulnsrc/oracle-oval/types.go
+++ b/pkg/vulnsrc/oracle-oval/types.go
@@ -52,3 +52,9 @@ type Date struct {
 func (p *AffectedPackage) PlatformName() string {
 	return fmt.Sprintf(platformFormat, p.OSVer)
 }
+
+type vulnPkg struct {
+	OSVer   string
+	PkgName string
+	VulnID  string
+}


### PR DESCRIPTION
## Description
Oracle Linux uses `normal`, `fips` (e.g. `3.6.16-4.0.1.el8_fips`) and `ksplice` (e.g. `2:2.28-151.0.1.ksplice2.el8`) version flavors.
We need to separate these versions so that we only compare version with same flavors.
See https://github.com/aquasecurity/trivy-db/issues/220 for more details.

### PR info
We are currently unable to change the database schema, so this PR is workaround to keep multiple versions for single CVE.
We currently use [FixedVersion](https://github.com/aquasecurity/trivy-db/blob/358e1d6974bba8e4031580fd490b82f7cac5080c/pkg/types/types.go#L119-L121) for OS advisories.
But in this case [PatchedVersions](https://github.com/aquasecurity/trivy-db/blob/358e1d6974bba8e4031580fd490b82f7cac5080c/pkg/types/types.go#L126) was used.

It adds options to save all flavors for single advisory.

To save backward compatibility - we only keep version with `normal` flavor in `FixedVersion`.


### DB sizes:
before:
```bash
-rw-r--r--@ 1 dmitriy  staff    53M Oct  8 16:51 db.tar.gz
-rw-------@ 1 dmitriy  staff   507M Oct  8 16:50 trivy.db

```

after
```bash
-rw-r--r--@ 1 dmitriy  staff    52M Oct 14 17:48 db.tar.gz
-rw-------@ 1 dmitriy  staff   523M Oct 14 17:47 trivy.db
```

## Related PRs
- https://github.com/aquasecurity/trivy-db/pull/221
- https://github.com/aquasecurity/trivy-db/pull/222