### PR TITLE
feat: match dockerfile to cron

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-FROM golang:1.17-alpine as builder
-
-ARG DB_TYPE=trivy
+FROM golang:1.22-alpine as builder
 
 WORKDIR /build
 COPY . /build
@@ -8,7 +6,13 @@ SHELL ["/bin/sh", "-o", "pipefail", "-c"]
 
 RUN apk --no-cache add make gzip
 
-RUN DB_TYPE=${DB_TYPE} make db-all
+RUN go install
+RUN make db-fetch-langs
+RUN make db-fetch-vuln-list
+RUN make build
+RUN make db-build
+RUN make db-compact
+RUN make db-compress
 
 FROM scratch
-COPY --from=builder /build/assets/trivy*.db.gz .
+COPY --from=builder /build/assets/db.tar.gz .


### PR DESCRIPTION
The Dockerfile hasn't been updated to match the new trivy-db build steps, so I matched the order or operations from the `cron` GitHub flow.