### PR TITLE
fix(azure): multiple criterions

### DIFF
--- a/pkg/vulnsrc/azure/azure_test.go
+++ b/pkg/vulnsrc/azure/azure_test.go
@@ -59,6 +59,17 @@ func TestVulnSrc_Update(t *testing.T) {
 				},
 				{
 					Key: []string{
+						"advisory-detail",
+						"CVE-2023-29409",
+						"Azure Linux 3.0",
+						"golang",
+					},
+					Value: types.Advisory{
+						FixedVersion: "0:1.20.7-1.azl3",
+					},
+				},
+				{
+					Key: []string{
 						"vulnerability-detail",
 						"CVE-2023-27534",
 						"azure",
@@ -85,6 +96,19 @@ func TestVulnSrc_Update(t *testing.T) {
 				},
 				{
 					Key: []string{
+						"vulnerability-detail",
+						"CVE-2023-29409",
+						"azure",
+					},
+					Value: types.VulnerabilityDetail{
+						Severity:    types.SeverityMedium,
+						Title:       "CVE-2023-29409 affecting package golang for versions less than 1.20.7-1",
+						Description: "CVE-2023-29409 affecting package golang for versions less than 1.20.7-1. A patched version of the package is available.",
+						References:  []string{"https://nvd.nist.gov/vuln/detail/CVE-2023-29409"},
+					},
+				},
+				{
+					Key: []string{
 						"vulnerability-id",
 						"CVE-2023-27534",
 					},
@@ -94,6 +118,13 @@ func TestVulnSrc_Update(t *testing.T) {
 					Key: []string{
 						"vulnerability-id",
 						"CVE-2018-1999023",
+					},
+					Value: map[string]interface{}{},
+				},
+				{
+					Key: []string{
+						"vulnerability-id",
+						"CVE-2023-29409",
 					},
 					Value: map[string]interface{}{},
 				},
@@ -271,6 +302,12 @@ func TestVulnSrc_Update(t *testing.T) {
 			dist:    azure.Mariner,
 			dir:     filepath.Join("testdata", "sad", "empty-stateref-tests"),
 			wantErr: "unable to follow test refs: invalid test, no state ref",
+		},
+		{
+			name:    "sad path Criterion is not array",
+			dist:    azure.Mariner,
+			dir:     filepath.Join("testdata", "sad", "criterion-is-not-array"),
+			wantErr: "cannot unmarshal object into Go struct field Criteria.Criteria.Criterion of type []oval.Criterion",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/vulnsrc/azure/oval/types.go
+++ b/pkg/vulnsrc/azure/oval/types.go
@@ -11,7 +11,7 @@ type Definition struct {
 
 type Criteria struct {
 	Operator  string
-	Criterion Criterion
+	Criterion []Criterion
 }
 
 type Criterion struct {

--- a/pkg/vulnsrc/azure/testdata/happy/vuln-list/azure/3.0/definitions/2018/38656-1.json
+++ b/pkg/vulnsrc/azure/testdata/happy/vuln-list/azure/3.0/definitions/2018/38656-1.json
@@ -21,9 +21,11 @@
   },
   "Criteria": {
     "Operator": "AND",
-    "Criterion": {
-      "Comment": "Package ceph is earlier than 18.2.1-1, affected by CVE-2018-1999023",
-      "TestRef": "oval:com.microsoft.azurelinux:tst:38656000"
-    }
+    "Criterion": [
+      {
+        "Comment": "Package ceph is earlier than 18.2.1-1, affected by CVE-2018-1999023",
+        "TestRef": "oval:com.microsoft.azurelinux:tst:38656000"
+      }
+    ]
   }
 }

--- a/pkg/vulnsrc/azure/testdata/happy/vuln-list/azure/3.0/definitions/2023/38611-1.json
+++ b/pkg/vulnsrc/azure/testdata/happy/vuln-list/azure/3.0/definitions/2023/38611-1.json
@@ -21,9 +21,11 @@
   },
   "Criteria": {
     "Operator": "AND",
-    "Criterion": {
-      "Comment": "Package tensorflow is earlier than 2.16.1-1, affected by CVE-2023-27534",
-      "TestRef": "oval:com.microsoft.azurelinux:tst:38611000"
-    }
+    "Criterion": [
+      {
+        "Comment": "Package tensorflow is earlier than 2.16.1-1, affected by CVE-2023-27534",
+        "TestRef": "oval:com.microsoft.azurelinux:tst:38611000"
+      }
+    ]
   }
 }

--- a/pkg/vulnsrc/azure/testdata/happy/vuln-list/azure/3.0/definitions/2023/52881-2.json
+++ b/pkg/vulnsrc/azure/testdata/happy/vuln-list/azure/3.0/definitions/2023/52881-2.json
@@ -1,0 +1,34 @@
+{
+  "Class": "vulnerability",
+  "ID": "oval:com.microsoft.azurelinux:def:52881",
+  "Version": "2",
+  "Metadata": {
+    "Title": "CVE-2023-29409 affecting package golang for versions less than 1.20.7-1",
+    "Affected": {
+      "Family": "unix",
+      "Platform": "Azure Linux"
+    },
+    "Reference": {
+      "RefID": "CVE-2023-29409",
+      "RefURL": "https://nvd.nist.gov/vuln/detail/CVE-2023-29409",
+      "Source": "CVE"
+    },
+    "Patchable": "true",
+    "AdvisoryID": "52881-2",
+    "Severity": "Medium",
+    "Description": "CVE-2023-29409 affecting package golang for versions less than 1.20.7-1. A patched version of the package is available."
+  },
+  "Criteria": {
+    "Operator": "AND",
+    "Criterion": [
+      {
+        "Comment": "Package golang is earlier than 1.20.7-1, affected by CVE-2023-29409",
+        "TestRef": "oval:com.microsoft.azurelinux:tst:52881000"
+      },
+      {
+        "Comment": "Package golang is greater than 0.0.0, affected by CVE-2023-29409",
+        "TestRef": "oval:com.microsoft.azurelinux:tst:52881003"
+      }
+    ]
+  }
+}

--- a/pkg/vulnsrc/azure/testdata/happy/vuln-list/azure/3.0/objects/objects.json
+++ b/pkg/vulnsrc/azure/testdata/happy/vuln-list/azure/3.0/objects/objects.json
@@ -9,6 +9,16 @@
       "ID": "oval:com.microsoft.azurelinux:obj:38611001",
       "Version": "1",
       "Name": "tensorflow"
+    },
+    {
+      "ID": "oval:com.microsoft.azurelinux:obj:52881004",
+      "Version": "1",
+      "Name": "golang"
+    },
+    {
+      "ID": "oval:com.microsoft.azurelinux:obj:52881001",
+      "Version": "1",
+      "Name": "golang"
     }
   ]
 }

--- a/pkg/vulnsrc/azure/testdata/happy/vuln-list/azure/3.0/states/states.json
+++ b/pkg/vulnsrc/azure/testdata/happy/vuln-list/azure/3.0/states/states.json
@@ -17,6 +17,24 @@
         "Datatype": "evr_string",
         "Operation": "less than"
       }
+    },
+    {
+      "ID": "oval:com.microsoft.azurelinux:ste:52881005",
+      "Version": "1",
+      "Evr": {
+        "Text": "0:0.0.0.azl3",
+        "Datatype": "evr_string",
+        "Operation": "greater than"
+      }
+    },
+    {
+      "ID": "oval:com.microsoft.azurelinux:ste:52881002",
+      "Version": "1",
+      "Evr": {
+        "Text": "0:1.20.7-1.azl3",
+        "Datatype": "evr_string",
+        "Operation": "less than"
+      }
     }
   ]
 }

--- a/pkg/vulnsrc/azure/testdata/happy/vuln-list/azure/3.0/tests/tests.json
+++ b/pkg/vulnsrc/azure/testdata/happy/vuln-list/azure/3.0/tests/tests.json
@@ -23,6 +23,30 @@
       "State": {
         "StateRef": "oval:com.microsoft.azurelinux:ste:38611002"
       }
+    },
+    {
+      "Check": "at least one",
+      "Comment": "Package golang is greater than 0.0.0, affected by CVE-2023-29409",
+      "ID": "oval:com.microsoft.azurelinux:tst:52881003",
+      "Version": "1",
+      "Object": {
+        "ObjectRef": "oval:com.microsoft.azurelinux:obj:52881004"
+      },
+      "State": {
+        "StateRef": "oval:com.microsoft.azurelinux:ste:52881005"
+      }
+    },
+    {
+      "Check": "at least one",
+      "Comment": "Package golang is earlier than 1.20.7-1, affected by CVE-2023-29409",
+      "ID": "oval:com.microsoft.azurelinux:tst:52881000",
+      "Version": "1",
+      "Object": {
+        "ObjectRef": "oval:com.microsoft.azurelinux:obj:52881001"
+      },
+      "State": {
+        "StateRef": "oval:com.microsoft.azurelinux:ste:52881002"
+      }
     }
   ]
 }

--- a/pkg/vulnsrc/azure/testdata/happy/vuln-list/mariner/2.0/definitions/2021/7412.json
+++ b/pkg/vulnsrc/azure/testdata/happy/vuln-list/mariner/2.0/definitions/2021/7412.json
@@ -20,9 +20,11 @@
   },
   "Criteria": {
     "Operator": "AND",
-    "Criterion": {
-      "Comment": "Package wireshark is installed with version 3.4.4 or earlier",
-      "TestRef": "oval:com.microsoft.cbl-mariner:tst:1643374850000435"
-    }
+    "Criterion": [
+      {
+        "Comment": "Package wireshark is installed with version 3.4.4 or earlier",
+        "TestRef": "oval:com.microsoft.cbl-mariner:tst:1643374850000435"
+      }
+    ]
   }
 }

--- a/pkg/vulnsrc/azure/testdata/happy/vuln-list/mariner/2.0/definitions/2023/31872-1.json
+++ b/pkg/vulnsrc/azure/testdata/happy/vuln-list/mariner/2.0/definitions/2023/31872-1.json
@@ -20,9 +20,11 @@
   },
   "Criteria": {
     "Operator": "AND",
-    "Criterion": {
-      "Comment": "Package edk2 is earlier than 20230301gitf80f052277c8-38, affected by CVE-2023-5678",
-      "TestRef": "oval:com.microsoft.cbl-mariner:tst:31872000"
-    }
+    "Criterion": [
+      {
+        "Comment": "Package edk2 is earlier than 20230301gitf80f052277c8-38, affected by CVE-2023-5678",
+        "TestRef": "oval:com.microsoft.cbl-mariner:tst:31872000"
+      }
+    ]
   }
 }

--- a/pkg/vulnsrc/azure/testdata/happy/vuln-list/mariner/2.0/definitions/2023/31880-1.json
+++ b/pkg/vulnsrc/azure/testdata/happy/vuln-list/mariner/2.0/definitions/2023/31880-1.json
@@ -20,9 +20,11 @@
   },
   "Criteria": {
     "Operator": "AND",
-    "Criterion": {
-      "Comment": "Package openssl is earlier than 1.1.1k-28, affected by CVE-2023-5678",
-      "TestRef": "oval:com.microsoft.cbl-mariner:tst:31880000"
-    }
+    "Criterion": [
+      {
+        "Comment": "Package openssl is earlier than 1.1.1k-28, affected by CVE-2023-5678",
+        "TestRef": "oval:com.microsoft.cbl-mariner:tst:31880000"
+      }
+    ]
   }
 }

--- a/pkg/vulnsrc/azure/testdata/not-applicable-definition/vuln-list/mariner/2.0/definitions/2013/6640.json
+++ b/pkg/vulnsrc/azure/testdata/not-applicable-definition/vuln-list/mariner/2.0/definitions/2013/6640.json
@@ -20,9 +20,11 @@
   },
   "Criteria": {
     "Operator": "AND",
-    "Criterion": {
-      "Comment": "Package libnotify is installed with version 0.7.9 or earlier",
-      "TestRef": "oval:com.microsoft.cbl-mariner:tst:1653048070000135"
-    }
+    "Criterion": [
+      {
+        "Comment": "Package libnotify is installed with version 0.7.9 or earlier",
+        "TestRef": "oval:com.microsoft.cbl-mariner:tst:1653048070000135"
+      }
+    ]
   }
 }

--- a/pkg/vulnsrc/azure/testdata/sad/criterion-is-not-array/vuln-list/mariner/1.0/definitions/2008/3173.json
+++ b/pkg/vulnsrc/azure/testdata/sad/criterion-is-not-array/vuln-list/mariner/1.0/definitions/2008/3173.json
@@ -21,11 +21,9 @@
   },
   "Criteria": {
     "Operator": "AND",
-    "Criterion": [
-      {
-        "Comment": "Package clamav is earlier than 0.103.2-1, affected by CVE-2008-3914",
-        "TestRef": "oval:com.microsoft.cbl-mariner:tst:1643374849000003"
-      }
-    ]
+    "Criterion": {
+      "Comment": "Package clamav is earlier than 0.103.2-1, affected by CVE-2008-3914",
+      "TestRef": "oval:com.microsoft.cbl-mariner:tst:1643374849000003"
+    }
   }
 }

--- a/pkg/vulnsrc/azure/testdata/sad/criterion-is-not-array/vuln-list/mariner/1.0/objects/objects.json
+++ b/pkg/vulnsrc/azure/testdata/sad/criterion-is-not-array/vuln-list/mariner/1.0/objects/objects.json
@@ -1,0 +1,9 @@
+{
+  "RpminfoObjects": [
+    {
+      "ID": "oval:com.microsoft.cbl-mariner:obj:1643374849000004",
+      "Version": "1643374849",
+      "Name": "clamav"
+    }
+  ]
+}

--- a/pkg/vulnsrc/azure/testdata/sad/criterion-is-not-array/vuln-list/mariner/1.0/states/states.json
+++ b/pkg/vulnsrc/azure/testdata/sad/criterion-is-not-array/vuln-list/mariner/1.0/states/states.json
@@ -1,0 +1,13 @@
+{
+  "RpminfoState": [
+    {
+      "ID": "oval:com.microsoft.cbl-mariner:ste:1643374849000005",
+      "Version": "1643374849",
+      "Evr": {
+        "Text": "0:0.103.2-1.cm1",
+        "Datatype": "evr_string",
+        "Operation": "less than"
+      }
+    }
+  ]
+}

--- a/pkg/vulnsrc/azure/testdata/sad/criterion-is-not-array/vuln-list/mariner/1.0/tests/tests.json
+++ b/pkg/vulnsrc/azure/testdata/sad/criterion-is-not-array/vuln-list/mariner/1.0/tests/tests.json
@@ -1,0 +1,16 @@
+{
+  "RpminfoTests": [
+    {
+      "Check": "at least one",
+      "Comment": "Package clamav is earlier than 0.103.2-1, affected by CVE-2008-3914",
+      "ID": "oval:com.microsoft.cbl-mariner:tst:1643374849000003",
+      "Version": "1643374849",
+      "Object": {
+        "ObjectRef": "oval:com.microsoft.cbl-mariner:obj:1643374849000004"
+      },
+      "State": {
+        "StateRef": "oval:com.microsoft.cbl-mariner:ste:1643374849000005"
+      }
+    }
+  ]
+}

--- a/pkg/vulnsrc/azure/testdata/sad/empty-stateref-tests/vuln-list/mariner/1.0/definitions/2008/3173.json
+++ b/pkg/vulnsrc/azure/testdata/sad/empty-stateref-tests/vuln-list/mariner/1.0/definitions/2008/3173.json
@@ -21,9 +21,11 @@
   },
   "Criteria": {
     "Operator": "AND",
-    "Criterion": {
-      "Comment": "Package clamav is earlier than 0.103.2-1, affected by CVE-2008-3914",
-      "TestRef": "oval:com.microsoft.cbl-mariner:tst:1643374849000003"
-    }
+    "Criterion": [
+      {
+        "Comment": "Package clamav is earlier than 0.103.2-1, affected by CVE-2008-3914",
+        "TestRef": "oval:com.microsoft.cbl-mariner:tst:1643374849000003"
+      }
+    ]
   }
 }

--- a/pkg/vulnsrc/azure/testdata/sad/empty-testref-definition/vuln-list/mariner/1.0/definitions/2008/3173.json
+++ b/pkg/vulnsrc/azure/testdata/sad/empty-testref-definition/vuln-list/mariner/1.0/definitions/2008/3173.json
@@ -21,8 +21,10 @@
   },
   "Criteria": {
     "Operator": "AND",
-    "Criterion": {
-      "Comment": "Package clamav is earlier than 0.103.2-1, affected by CVE-2008-3914"
-    }
+    "Criterion": [
+      {
+        "Comment": "Package clamav is earlier than 0.103.2-1, affected by CVE-2008-3914"
+      }
+    ]
   }
 }


### PR DESCRIPTION
## Description
`azure` has started using `criterion` as array.
See #468 for more details.

This PR updates logic to parse `criterion` as array.

Test trivy-db build - https://github.com/DmitriyLewen/trivy-db/actions/runs/11833760212/job/32973071628
![изображение](https://github.com/user-attachments/assets/10b2df09-5932-4333-9086-19511cf16c09)


## Related issues:
- Close #468

## Blocking PRs: 
- aquasecurity/vuln-list-update/pull/313