### PR TITLE
fix: set trivy.db file to be world-readable

### DIFF
--- a/pkg/build.go
+++ b/pkg/build.go
@@ -10,7 +10,7 @@ import (
 
 func build(c *cli.Context) error {
 	outputDir := c.String("output-dir")
-	if err := db.Init(outputDir); err != nil {
+	if err := db.Init(outputDir, db.WithMode(0644)); err != nil {
 		return xerrors.Errorf("db initialize error: %w", err)
 	}
 

--- a/pkg/build.go
+++ b/pkg/build.go
@@ -10,7 +10,7 @@ import (
 
 func build(c *cli.Context) error {
 	outputDir := c.String("output-dir")
-	if err := db.Init(outputDir, db.WithMode(0644)); err != nil {
+	if err := db.Init(outputDir); err != nil {
 		return xerrors.Errorf("db initialize error: %w", err)
 	}
 

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -3,7 +3,6 @@ package db
 import (
 	"bytes"
 	"encoding/json"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime/debug"

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -59,13 +59,6 @@ type Option func(*Options)
 
 type Options struct {
 	boltOptions *bolt.Options
-	mode        fs.FileMode
-}
-
-func WithMode(mode fs.FileMode) Option {
-	return func(opts *Options) {
-		opts.mode = mode
-	}
 }
 
 func WithBoltOptions(boltOpts *bolt.Options) Option {
@@ -75,9 +68,7 @@ func WithBoltOptions(boltOpts *bolt.Options) Option {
 }
 
 func Init(dbDir string, opts ...Option) (err error) {
-	dbOptions := &Options{
-		mode: 0600,
-	}
+	dbOptions := &Options{}
 	for _, opt := range opts {
 		opt(dbOptions)
 	}
@@ -100,7 +91,7 @@ func Init(dbDir string, opts ...Option) (err error) {
 		debug.SetPanicOnFault(false)
 	}()
 
-	db, err = bolt.Open(dbPath, dbOptions.mode, dbOptions.boltOptions)
+	db, err = bolt.Open(dbPath, 0644, dbOptions.boltOptions)
 	if err != nil {
 		return xerrors.Errorf("failed to open db: %w", err)
 	}


### PR DESCRIPTION
Currently the `trivy.db` file in the OCI artifact is set to be readable only by the `runner` user that created the file, unlike the `metadata.json` file:
```
$ crane export public.ecr.aws/aquasecurity/trivy-db:2 > trivy-db.tar
$ tar -tvf trivy-db.tar
-rw-------  0 runner docker 564006912 Nov 18 10:17 trivy.db
-rw-r--r--  0 runner docker       143 Nov 18 10:17 metadata.json
```
This is different from the `trivy-java.db` file:
```
$ crane export public.ecr.aws/aquasecurity/trivy-java-db:1 > trivy-java-db.tar
$ tar -tvf trivy-java-db.tar
-rw-r--r--  0 runner docker 1122304000 Nov 17 19:41 trivy-java.db
-rw-r--r--  0 runner docker        143 Nov 17 19:41 metadata.json
```
This PR modifies the default mode to be `0644` when built via this repository/GitHub actions runner, matching the Java DB behavior.

This doesn't have any impact during normal usage via `trivy` because it changes the ownership/mode to match the user `trivy` is running as (via `hashicorp/go-getter`). However, it is useful to change this behavior because it allows the DB OCI artifact layers can be directly appended to a trivy Docker image in some specialized use-cases without needing to download, decompress, modify, recompress, then upload as new layers (ex: when using AWS Lambda).