### PR TITLE
fix: set trivy.db file to be world-readable (follow-up)

### DIFF
--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -85,7 +85,7 @@ func Init(dbDir string, opts ...Option) (err error) {
 			if err = os.Remove(dbPath); err != nil {
 				return
 			}
-			db, err = bolt.Open(dbPath, 0600, dbOptions.boltOptions)
+			db, err = bolt.Open(dbPath, 0644, dbOptions.boltOptions)
 		}
 		debug.SetPanicOnFault(false)
 	}()


### PR DESCRIPTION
Address the feedback/missed change on #471 added after the PR was merged: https://github.com/aquasecurity/trivy-db/pull/471#discussion_r1847764433