### PR TITLE
refactor: use slog

### DIFF
--- a/cmd/trivy-db/main.go
+++ b/cmd/trivy-db/main.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-	"log"
 	"os"
 
 	"github.com/aquasecurity/trivy-db/pkg"
+	"github.com/aquasecurity/trivy-db/pkg/log"
 )
 
 var (
@@ -16,6 +16,7 @@ func main() {
 	app := ac.NewApp(version)
 	err := app.Run(os.Args)
 	if err != nil {
-		log.Fatalf("%+v", err)
+		log.Error("Failed to run app", log.Err(err))
+		os.Exit(1)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -35,21 +35,17 @@ require (
 	github.com/goccy/go-yaml v1.8.1 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
+	github.com/kr/text v0.2.0 // indirect
 	github.com/mattn/go-colorable v0.1.8 // indirect
 	github.com/mattn/go-isatty v0.0.12 // indirect
+	github.com/mattn/go-runewidth v0.0.4 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.12.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
-	go.uber.org/multierr v1.10.0 // indirect
 	golang.org/x/mod v0.22.0 // indirect
 	golang.org/x/sync v0.10.0 // indirect
 	golang.org/x/sys v0.28.0 // indirect
 	golang.org/x/term v0.1.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-)
-
-require (
-	github.com/mattn/go-runewidth v0.0.4 // indirect
-	go.uber.org/zap v1.27.0
 )

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,7 @@ github.com/briandowns/spinner v1.23.0/go.mod h1:rPG4gmXeN3wQV/TsAY4w8lPdIM6RX3yq
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.5 h1:ZtcqGrnekaHpVLArFSe4HK5DoKx1T0rq2DwVB0alcyc=
 github.com/cpuguy83/go-md2man/v2 v2.0.5/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -93,12 +94,6 @@ github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/X
 go.etcd.io/bbolt v1.3.5/go.mod h1:G5EMThwa9y8QZGBClrRx5EY+Yw9kAhnjy3bSjsnlVTQ=
 go.etcd.io/bbolt v1.3.11 h1:yGEzV1wPz2yVCLsD8ZAiGHhHVlczyC9d1rP43/VCRJ0=
 go.etcd.io/bbolt v1.3.11/go.mod h1:dksAq7YMXoljX0xu6VF5DMZGbhYYoLUalEiSySYAS4I=
-go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
-go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
-go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=
-go.uber.org/multierr v1.10.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
-go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=
-go.uber.org/zap v1.27.0/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
 golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 h1:k/i9J1pBpvlfR+9QsetwPyERsqu1GIbi967PQMq3Ivc=
 golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=
 golang.org/x/mod v0.22.0 h1:D4nJWe9zXqHOmWqj4VMOJhvzj7bEZg4wEYa759z1pH4=

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -214,7 +214,7 @@ func (dbc Config) forEach(bktNames []string) (map[string]Value, error) {
 
 			source, err := dbc.getDataSource(tx, r)
 			if err != nil {
-				log.Logger.Debugf("Data source error: %s", err)
+				log.WithPrefix("db").Debug("Data source error", log.Err(err))
 			}
 
 			bkt := root

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -42,6 +42,14 @@ func Err(err error) slog.Attr {
 	return slog.Attr{Key: "error", Value: slog.AnyValue(err)}
 }
 
+func FilePath(path string) slog.Attr {
+	return slog.Attr{Key: "file_path", Value: slog.AnyValue(path)}
+}
+
+func DirPath(path string) slog.Attr {
+	return slog.Attr{Key: "dir_path", Value: slog.AnyValue(path)}
+}
+
 // PrefixHandler is a simple wrapper around slog.Handler that adds a prefix to all messages
 type PrefixHandler struct {
 	prefix  string

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -1,22 +1,102 @@
 package log
 
 import (
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
 )
 
-var Logger *zap.SugaredLogger
+// Logger is an alias for slog.Logger
+type Logger = slog.Logger
 
-func init() {
-	conf := zap.NewDevelopmentConfig()
-	conf.DisableCaller = true
-	conf.DisableStacktrace = true
-	conf.EncoderConfig.EncodeTime = zapcore.RFC3339TimeEncoder
+var defaultLogger *Logger
 
-	logger, _ := conf.Build()
-	Logger = logger.Sugar()
+// Convenience variables to match slog's API
+var (
+	String = slog.String
+	Int    = slog.Int
+	Int64  = slog.Int64
+	Bool   = slog.Bool
+	Any    = slog.Any
+)
+
+// Package-level logging functions
+func Info(msg string, args ...any) {
+	defaultLogger.Info(msg, args...)
 }
 
-func SetLogger(l *zap.SugaredLogger) {
-	Logger = l
+func Warn(msg string, args ...any) {
+	defaultLogger.Warn(msg, args...)
+}
+
+func Error(msg string, args ...any) {
+	defaultLogger.Error(msg, args...)
+}
+
+func Debug(msg string, args ...any) {
+	defaultLogger.Debug(msg, args...)
+}
+
+func Err(err error) slog.Attr {
+	return slog.Attr{Key: "error", Value: slog.AnyValue(err)}
+}
+
+// PrefixHandler is a simple wrapper around slog.Handler that adds a prefix to all messages
+type PrefixHandler struct {
+	prefix  string
+	handler slog.Handler
+}
+
+func init() {
+	opts := &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}
+	baseHandler := slog.NewTextHandler(os.Stdout, opts)
+	prefixHandler := &PrefixHandler{
+		prefix:  "",
+		handler: baseHandler,
+	}
+	defaultLogger = slog.New(prefixHandler)
+}
+
+// WithPrefix returns a new logger with the specified prefix
+func WithPrefix(prefix string) *Logger {
+	return slog.New(&PrefixHandler{
+		prefix:  prefix,
+		handler: defaultLogger.Handler(),
+	})
+}
+
+func SetLogger(l *Logger) {
+	defaultLogger = l
+}
+
+// Handle implements slog.Handler interface
+func (h *PrefixHandler) Handle(ctx context.Context, r slog.Record) error {
+	if h.prefix != "" {
+		r.Message = fmt.Sprintf("[%s] %s", h.prefix, r.Message)
+	}
+	return h.handler.Handle(ctx, r)
+}
+
+// WithAttrs implements slog.Handler interface
+func (h *PrefixHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &PrefixHandler{
+		prefix:  h.prefix,
+		handler: h.handler.WithAttrs(attrs),
+	}
+}
+
+// WithGroup implements slog.Handler interface
+func (h *PrefixHandler) WithGroup(name string) slog.Handler {
+	return &PrefixHandler{
+		prefix:  h.prefix,
+		handler: h.handler.WithGroup(name),
+	}
+}
+
+// Enabled implements slog.Handler interface
+func (h *PrefixHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.handler.Enabled(ctx, level)
 }

--- a/pkg/utils/file.go
+++ b/pkg/utils/file.go
@@ -26,7 +26,7 @@ func FileWalk(root string, walkFn func(r io.Reader, path string) error) error {
 		}
 
 		if info.Size() == 0 {
-			log.Info("Invalid file size", log.String("path", path), log.Int64("size", info.Size()))
+			log.Info("Invalid file size", log.FilePath(path), log.Int64("size", info.Size()))
 			return nil
 		}
 

--- a/pkg/utils/file.go
+++ b/pkg/utils/file.go
@@ -4,11 +4,12 @@ import (
 	"encoding/json"
 	"io"
 	"io/fs"
-	"log"
 	"os"
 	"path/filepath"
 
 	"golang.org/x/xerrors"
+
+	"github.com/aquasecurity/trivy-db/pkg/log"
 )
 
 func FileWalk(root string, walkFn func(r io.Reader, path string) error) error {
@@ -25,7 +26,7 @@ func FileWalk(root string, walkFn func(r io.Reader, path string) error) error {
 		}
 
 		if info.Size() == 0 {
-			log.Printf("invalid size: %s\n", path)
+			log.Info("Invalid file size", log.String("path", path), log.Int64("size", info.Size()))
 			return nil
 		}
 

--- a/pkg/utils/time.go
+++ b/pkg/utils/time.go
@@ -1,14 +1,18 @@
 package utils
 
 import (
-	"log"
 	"time"
+
+	"github.com/aquasecurity/trivy-db/pkg/log"
 )
 
 func MustTimeParse(value string) *time.Time {
 	t, err := time.Parse(time.RFC3339, value)
 	if err != nil {
-		log.Fatalln(err)
+		log.Error("Failed to parse time",
+			log.String("value", value),
+			log.Err(err))
+		panic(err)
 	}
 
 	return &t

--- a/pkg/vulndb/db.go
+++ b/pkg/vulndb/db.go
@@ -1,7 +1,6 @@
 package vulndb
 
 import (
-	"log"
 	"time"
 
 	bolt "go.etcd.io/bbolt"
@@ -9,6 +8,7 @@ import (
 	"k8s.io/utils/clock"
 
 	"github.com/aquasecurity/trivy-db/pkg/db"
+	"github.com/aquasecurity/trivy-db/pkg/log"
 	"github.com/aquasecurity/trivy-db/pkg/metadata"
 	"github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc"
@@ -69,13 +69,13 @@ func New(cacheDir, outputDir string, updateInterval time.Duration, opts ...Optio
 }
 
 func (t TrivyDB) Insert(targets []string) error {
-	log.Println("Updating vulnerability database...")
+	log.Info("Updating vulnerability database...")
 	for _, target := range targets {
 		src, ok := t.vulnSrc(target)
 		if !ok {
 			return xerrors.Errorf("%s is not supported", target)
 		}
-		log.Printf("Updating %s data...\n", target)
+		log.WithPrefix(target).Info("Updating data...")
 
 		if err := src.Update(t.cacheDir); err != nil {
 			return xerrors.Errorf("%s update error: %w", target, err)

--- a/pkg/vulnsrc/alma/alma.go
+++ b/pkg/vulnsrc/alma/alma.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"path/filepath"
 	"strings"
 
@@ -13,6 +12,7 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy-db/pkg/db"
+	"github.com/aquasecurity/trivy-db/pkg/log"
 	"github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy-db/pkg/utils"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/vulnerability"
@@ -47,7 +47,8 @@ type DB interface {
 }
 
 type VulnSrc struct {
-	DB // Those who want to customize Trivy DB can override put/get methods.
+	DB     // Those who want to customize Trivy DB can override put/get methods.
+	logger *log.Logger
 }
 
 // Alma implements the DB interface
@@ -57,7 +58,8 @@ type Alma struct {
 
 func NewVulnSrc() *VulnSrc {
 	return &VulnSrc{
-		DB: &Alma{Operation: db.Config{}},
+		DB:     &Alma{Operation: db.Config{}},
+		logger: log.WithPrefix("alma"),
 	}
 }
 
@@ -89,7 +91,7 @@ func (vs *VulnSrc) parse(rootDir string) (map[string][]Erratum, error) {
 
 		dirs := strings.Split(path, string(filepath.Separator))
 		if len(dirs) < 3 {
-			log.Printf("invalid path: %s\n", path)
+			vs.logger.Warn("Invalid path", log.String("path", path))
 			return nil
 		}
 

--- a/pkg/vulnsrc/alma/alma.go
+++ b/pkg/vulnsrc/alma/alma.go
@@ -91,7 +91,7 @@ func (vs *VulnSrc) parse(rootDir string) (map[string][]Erratum, error) {
 
 		dirs := strings.Split(path, string(filepath.Separator))
 		if len(dirs) < 3 {
-			vs.logger.Warn("Invalid path", log.String("path", path))
+			vs.logger.Warn("Invalid path", log.FilePath(path))
 			return nil
 		}
 

--- a/pkg/vulnsrc/azure/azure.go
+++ b/pkg/vulnsrc/azure/azure.go
@@ -114,7 +114,7 @@ func (vs VulnSrc) Update(dir string) error {
 }
 
 func (vs VulnSrc) parseOVAL(dir string) ([]Entry, error) {
-	vs.logger.Info("Parsing OVAL", log.String("dir", dir))
+	vs.logger.Info("Parsing OVAL", log.DirPath(dir))
 
 	// Parse and resolve tests
 	tests, err := resolveTests(dir)

--- a/pkg/vulnsrc/ghsa/cocoapods.go
+++ b/pkg/vulnsrc/ghsa/cocoapods.go
@@ -3,12 +3,12 @@ package ghsa
 import (
 	"encoding/json"
 	"io"
-	"log"
 	"path/filepath"
 
 	"golang.org/x/exp/slices"
 	"golang.org/x/xerrors"
 
+	"github.com/aquasecurity/trivy-db/pkg/log"
 	"github.com/aquasecurity/trivy-db/pkg/utils"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/vulnerability"
 )
@@ -26,7 +26,7 @@ type Source struct {
 var cocoapodsSpecDir = filepath.Join("cocoapods-specs", "Specs")
 
 func walkCocoaPodsSpecs(root string) (map[string][]string, error) {
-	log.Printf("Walk `Cocoapods Specs` to convert Swift URLs to Cocoapods package names")
+	log.WithPrefix("cocoapods").Info("Walk `Cocoapods Specs` to convert Swift URLs to Cocoapods package names")
 	var specs = make(map[string][]string)
 	err := utils.FileWalk(filepath.Join(root, cocoapodsSpecDir), func(r io.Reader, path string) error {
 		if filepath.Ext(path) != ".json" {

--- a/pkg/vulnsrc/glad/glad_test.go
+++ b/pkg/vulnsrc/glad/glad_test.go
@@ -49,7 +49,7 @@ func TestVulnSrc_Update(t *testing.T) {
 		{
 			name:    "sad path",
 			dir:     filepath.Join("testdata", "sad"),
-			wantErr: "failed to decode GLAD",
+			wantErr: "failed to decode GitLab Advisory Database",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/vulnsrc/nvd/nvd.go
+++ b/pkg/vulnsrc/nvd/nvd.go
@@ -29,29 +29,21 @@ const (
 type DB interface {
 	db.Operation
 	Put(*bolt.Tx, Cve) error
-	Logger() *log.Logger // TODO: remove this
 }
 
 type VulnSrc struct {
 	DB
+	logger *log.Logger
 }
 
 type NVD struct {
 	db.Operation
-	logger *log.Logger
-}
-
-func (n *NVD) Logger() *log.Logger {
-	return n.logger
 }
 
 func NewVulnSrc() *VulnSrc {
-	nvd := &NVD{
-		Operation: db.Config{},
-		logger:    log.WithPrefix("nvd"),
-	}
 	return &VulnSrc{
-		DB: nvd,
+		DB:     &NVD{Operation: db.Config{}},
+		logger: log.WithPrefix("nvd"),
 	}
 }
 
@@ -97,7 +89,7 @@ func (vs *VulnSrc) commit(tx *bolt.Tx, cves []Cve) error {
 }
 
 func (vs *VulnSrc) save(cves []Cve) error {
-	vs.Logger().Info("NVD batch update")
+	vs.logger.Info("NVD batch update")
 	err := vs.BatchUpdate(func(tx *bolt.Tx) error {
 		return vs.commit(tx, cves)
 	})
@@ -137,16 +129,16 @@ func getCvssV3(metricsV31, metricsV30 []CvssMetricV3) (score float64, vector str
 }
 
 // getCvssV40 selects vector, score and severity from V40 metrics
-func (nvd *NVD) getCvssV40(metricsV40 []CvssMetricV40) (score float64, vector string, severity types.Severity) {
+func getCvssV40(metricsV40 []CvssMetricV40) (score float64, vector string, severity types.Severity) {
 	for _, metricV40 := range metricsV40 {
 		// save only NVD metric
 		if metricV40.Source == nvdSource {
 			score = metricV40.CvssData.BaseScore
 			cvss40, err := gocvss40.ParseVector(strings.TrimSuffix(metricV40.CvssData.VectorString, "/"))
 			if err != nil {
-				nvd.logger.Warn("failed to parse CVSSv4.0 vector",
+				log.WithPrefix("nvd").Warn("Failed to parse CVSSv4.0 vector",
 					log.String("vector", metricV40.CvssData.VectorString),
-					log.String("error", err.Error()))
+					log.Err(err))
 				return 0, "", types.SeverityUnknown
 			}
 			severity, _ = types.NewSeverity(metricV40.CvssData.BaseSeverity)
@@ -160,7 +152,7 @@ func (nvd *NVD) getCvssV40(metricsV40 []CvssMetricV40) (score float64, vector st
 func (nvd *NVD) Put(tx *bolt.Tx, cve Cve) error {
 	cvssScore, cvssVector, severity := getCvssV2(cve.Metrics.CvssMetricV2)
 	cvssScoreV3, cvssVectorV3, severityV3 := getCvssV3(cve.Metrics.CvssMetricV31, cve.Metrics.CvssMetricV30)
-	cvssScoreV40, cvssVectorV40, severityV40 := nvd.getCvssV40(cve.Metrics.CvssMetricV40)
+	cvssScoreV40, cvssVectorV40, severityV40 := getCvssV40(cve.Metrics.CvssMetricV40)
 
 	var references []string
 	for _, ref := range cve.References {

--- a/pkg/vulnsrc/osv/osv.go
+++ b/pkg/vulnsrc/osv/osv.go
@@ -12,7 +12,6 @@ import (
 	gocvss31 "github.com/pandatix/go-cvss/31"
 	"github.com/samber/lo"
 	bolt "go.etcd.io/bbolt"
-	"go.uber.org/zap"
 	"golang.org/x/exp/maps"
 	"golang.org/x/xerrors"
 
@@ -303,10 +302,10 @@ func parseAffectedVersions(affected Affected) ([]string, []string, error) {
 		// We don't need to add the versions that are already included in the ranges
 		ok, err := versionContains(affectedRanges, v)
 		if err != nil {
-			log.Logger.Errorw("Version comparison error",
-				zap.String("ecosystem", string(affected.Package.Ecosystem)),
-				zap.String("package", affected.Package.Name),
-				zap.Error(err),
+			log.WithPrefix("osv").Error("Version comparison error",
+				log.String("ecosystem", string(affected.Package.Ecosystem)),
+				log.String("package", affected.Package.Name),
+				log.Err(err),
 			)
 		}
 		if !ok {

--- a/pkg/vulnsrc/photon/photon.go
+++ b/pkg/vulnsrc/photon/photon.go
@@ -4,13 +4,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"path/filepath"
 
 	bolt "go.etcd.io/bbolt"
 	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy-db/pkg/db"
+	"github.com/aquasecurity/trivy-db/pkg/log"
 	"github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy-db/pkg/utils"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/vulnerability"
@@ -28,12 +28,14 @@ var source = types.DataSource{
 }
 
 type VulnSrc struct {
-	dbc db.Operation
+	dbc    db.Operation
+	logger *log.Logger
 }
 
 func NewVulnSrc() VulnSrc {
 	return VulnSrc{
-		dbc: db.Config{},
+		dbc:    db.Config{},
+		logger: log.WithPrefix("photon"),
 	}
 }
 
@@ -66,14 +68,13 @@ func (vs VulnSrc) Update(dir string) error {
 }
 
 func (vs VulnSrc) save(cves []PhotonCVE) error {
-	log.Println("Saving Photon DB")
+	vs.logger.Info("Saving DB")
 	err := vs.dbc.BatchUpdate(func(tx *bolt.Tx) error {
 		return vs.commit(tx, cves)
 	})
 	if err != nil {
 		return xerrors.Errorf("error in batch update: %w", err)
 	}
-
 	return nil
 }
 

--- a/pkg/vulnsrc/redhat-oval/redhat-oval.go
+++ b/pkg/vulnsrc/redhat-oval/redhat-oval.go
@@ -296,7 +296,7 @@ func (vs VulnSrc) Get(pkgName string, repositories, nvrs []string) ([]types.Advi
 }
 
 func (vs VulnSrc) parseOVALStream(dir string, uniqCPEs CPEMap) (map[bucket]Definition, error) {
-	vs.logger.Info("Parsing OVAL stream", log.String("dir", dir))
+	vs.logger.Info("Parsing OVAL stream", log.DirPath(dir))
 
 	// Parse tests
 	tests, err := parseTests(dir)

--- a/pkg/vulnsrc/redhat-oval/redhat-oval.go
+++ b/pkg/vulnsrc/redhat-oval/redhat-oval.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -16,6 +15,7 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy-db/pkg/db"
+	"github.com/aquasecurity/trivy-db/pkg/log"
 	"github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy-db/pkg/utils"
 	"github.com/aquasecurity/trivy-db/pkg/utils/ints"
@@ -42,17 +42,19 @@ var (
 )
 
 type VulnSrc struct {
-	dbc db.Operation
+	dbc    db.Operation
+	logger *log.Logger
 }
 
 func NewVulnSrc() VulnSrc {
 	return VulnSrc{
-		dbc: db.Config{},
+		dbc:    db.Config{},
+		logger: log.WithPrefix("redhat-oval"),
 	}
 }
 
 func (vs VulnSrc) Name() types.SourceID {
-	return vulnerability.RedHatOVAL
+	return source.ID
 }
 
 func (vs VulnSrc) Update(dir string) error {
@@ -88,7 +90,7 @@ func (vs VulnSrc) Update(dir string) error {
 				continue
 			}
 
-			definitions, err := parseOVALStream(filepath.Join(versionDir, f.Name()), uniqCPEs)
+			definitions, err := vs.parseOVALStream(filepath.Join(versionDir, f.Name()), uniqCPEs)
 			if err != nil {
 				return xerrors.Errorf("failed to parse OVAL stream: %w", err)
 			}
@@ -293,8 +295,8 @@ func (vs VulnSrc) Get(pkgName string, repositories, nvrs []string) ([]types.Advi
 	return advisories, nil
 }
 
-func parseOVALStream(dir string, uniqCPEs CPEMap) (map[bucket]Definition, error) {
-	log.Printf("    Parsing %s", dir)
+func (vs VulnSrc) parseOVALStream(dir string, uniqCPEs CPEMap) (map[bucket]Definition, error) {
+	vs.logger.Info("Parsing OVAL stream", log.String("dir", dir))
 
 	// Parse tests
 	tests, err := parseTests(dir)

--- a/pkg/vulnsrc/redhat/redhat.go
+++ b/pkg/vulnsrc/redhat/redhat.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -15,6 +14,7 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy-db/pkg/db"
+	"github.com/aquasecurity/trivy-db/pkg/log"
 	"github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy-db/pkg/utils"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/vulnerability"
@@ -28,12 +28,14 @@ const (
 )
 
 type VulnSrc struct {
-	dbc db.Operation
+	dbc    db.Operation
+	logger *log.Logger
 }
 
 func NewVulnSrc() VulnSrc {
 	return VulnSrc{
-		dbc: db.Config{},
+		dbc:    db.Config{},
+		logger: log.WithPrefix("redhat"),
 	}
 }
 
@@ -104,7 +106,7 @@ func (vs VulnSrc) Update(dir string) error {
 }
 
 func (vs VulnSrc) save(cves []RedhatCVE) error {
-	log.Println("Saving Red Hat DB")
+	vs.logger.Info("Saving DB")
 	err := vs.dbc.BatchUpdate(func(tx *bolt.Tx) error {
 		return vs.commit(tx, cves)
 	})

--- a/pkg/vulnsrc/rocky/rocky.go
+++ b/pkg/vulnsrc/rocky/rocky.go
@@ -101,7 +101,7 @@ func (vs *VulnSrc) parse(rootDir string) (map[string][]RLSA, error) {
 
 		dirs := strings.Split(strings.TrimPrefix(path, rootDir), string(filepath.Separator))[1:]
 		if len(dirs) != 5 {
-			vs.logger.Warn("Invalid path", log.String("path", path))
+			vs.logger.Warn("Invalid path", log.FilePath(path))
 			return nil
 		}
 

--- a/pkg/vulnsrc/suse-cvrf/suse-cvrf_test.go
+++ b/pkg/vulnsrc/suse-cvrf/suse-cvrf_test.go
@@ -649,7 +649,7 @@ func TestGetOSVersion(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.inputPlatformName, func(t *testing.T) {
-			vs := VulnSrc{} // Create VulnSrc instance
+			vs := NewVulnSrc(OpenSUSE)
 			actual := vs.getOSVersion(tc.inputPlatformName)
 			assert.Equal(t, tc.expectedPlatformName, actual, fmt.Sprintf("input data: %s", tc.inputPlatformName))
 		})

--- a/pkg/vulnsrc/suse-cvrf/suse-cvrf_test.go
+++ b/pkg/vulnsrc/suse-cvrf/suse-cvrf_test.go
@@ -649,7 +649,8 @@ func TestGetOSVersion(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.inputPlatformName, func(t *testing.T) {
-			actual := getOSVersion(tc.inputPlatformName)
+			vs := VulnSrc{} // Create VulnSrc instance
+			actual := vs.getOSVersion(tc.inputPlatformName)
 			assert.Equal(t, tc.expectedPlatformName, actual, fmt.Sprintf("input data: %s", tc.inputPlatformName))
 		})
 	}

--- a/pkg/vulnsrc/vulnerability/vulnerability.go
+++ b/pkg/vulnsrc/vulnerability/vulnerability.go
@@ -32,7 +32,7 @@ func New(dbc db.Operation) Vulnerability {
 func (v Vulnerability) GetDetails(vulnID string) map[types.SourceID]types.VulnerabilityDetail {
 	details, err := v.dbc.GetVulnerabilityDetail(vulnID)
 	if err != nil {
-		log.Logger.Warnf("Failed to get vulnerability detail: %s", err)
+		log.Warn("Failed to get vulnerability detail", log.Err(err))
 		return nil
 	} else if len(details) == 0 {
 		return nil


### PR DESCRIPTION
## Description
This PR replaces `log` with `log/slog` and standardizes the logger implementation across vulnerability source packages by introducing a consistent logging pattern with source-specific prefixes.

## Key changes
- Replace direct usage of `log` with `github.com/aquasecurity/trivy-db/pkg/log`
- Embed `*log.Logger` in `VulnSrc` structs
- Implement source-specific prefixes for each vulnerability source using `log.WithPrefix()`
- Standardize logging method calls (e.g., `vs.Info()`, `vs.Warn()`) across all sources

## Benefits
1. Improved log clarity:
   - Each log message is clearly tagged with its source
   - Easier to identify and debug source-specific issues
   - Better log filtering capabilities

2. Enhanced maintainability:
   - Consistent logging patterns across all vulnerability sources
   - Centralized logging configuration through the `pkg/log` package
   - Easier to modify logging behavior globally

3. Future-proof design:
   - Abstraction of logging implementation details
   - Easier to refactor or replace the underlying logging mechanism (`slog`)
   - Reduced dependency on external logging libraries in individual packages
