### PR TITLE
refactor: migrate from xerrors to samber/oops for enhanced error handling

### DIFF
--- a/cmd/trivy-db/main.go
+++ b/cmd/trivy-db/main.go
@@ -16,7 +16,7 @@ func main() {
 	app := ac.NewApp(version)
 	err := app.Run(os.Args)
 	if err != nil {
-		log.Error("Failed to run app", log.Err(err))
+		log.Errorf("%+v", err)
 		os.Exit(1)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -17,13 +17,13 @@ require (
 	github.com/masahiro331/go-mvn-version v0.0.0-20210429150710-d3157d602a08
 	github.com/pandatix/go-cvss v0.6.2
 	github.com/samber/lo v1.47.0
+	github.com/samber/oops v1.15.0
 	github.com/stretchr/testify v1.10.0
 	github.com/urfave/cli v1.22.16
 	go.etcd.io/bbolt v1.3.11
 	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1
 	golang.org/x/text v0.21.0
 	golang.org/x/tools v0.28.0
-	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 	gopkg.in/cheggaaa/pb.v1 v1.0.28
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/utils v0.0.0-20201110183641-67b214c5f920
@@ -35,17 +35,20 @@ require (
 	github.com/goccy/go-yaml v1.8.1 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
-	github.com/kr/text v0.2.0 // indirect
 	github.com/mattn/go-colorable v0.1.8 // indirect
 	github.com/mattn/go-isatty v0.0.12 // indirect
 	github.com/mattn/go-runewidth v0.0.4 // indirect
+	github.com/oklog/ulid/v2 v2.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.12.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
+	go.opentelemetry.io/otel v1.34.0 // indirect
+	go.opentelemetry.io/otel/trace v1.34.0 // indirect
 	golang.org/x/mod v0.22.0 // indirect
 	golang.org/x/sync v0.10.0 // indirect
 	golang.org/x/sys v0.28.0 // indirect
 	golang.org/x/term v0.1.0 // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -16,7 +16,6 @@ github.com/briandowns/spinner v1.23.0/go.mod h1:rPG4gmXeN3wQV/TsAY4w8lPdIM6RX3yq
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.5 h1:ZtcqGrnekaHpVLArFSe4HK5DoKx1T0rq2DwVB0alcyc=
 github.com/cpuguy83/go-md2man/v2 v2.0.5/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
-github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -60,8 +59,11 @@ github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHX
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-runewidth v0.0.4 h1:2BvfKmzob6Bmd4YsL0zygOqfdFnK7GR4QL06Do4/p7Y=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
+github.com/oklog/ulid/v2 v2.1.0 h1:+9lhoxAP56we25tyYETBBY1YLA2SaoLvUFgrP2miPJU=
+github.com/oklog/ulid/v2 v2.1.0/go.mod h1:rcEKHmBBKfef9DhnvX7y1HZBYxjXb0cP5ExxNsTT1QQ=
 github.com/pandatix/go-cvss v0.6.2 h1:TFiHlzUkT67s6UkelHmK6s1INKVUG7nlKYiWWDTITGI=
 github.com/pandatix/go-cvss v0.6.2/go.mod h1:jDXYlQBZrc8nvrMUVVvTG8PhmuShOnKrxP53nOFkt8Q=
+github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
@@ -71,6 +73,8 @@ github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/samber/lo v1.47.0 h1:z7RynLwP5nbyRscyvcD043DWYoOcYRv3mV8lBeqOCLc=
 github.com/samber/lo v1.47.0/go.mod h1:RmDH9Ct32Qy3gduHQuKJ3gW1fMHAnE/fAzQuf6He5cU=
+github.com/samber/oops v1.15.0 h1:/mF33KAqA2TugU6y/tomFpK6G6mJB7g0aqRyHkaSIeg=
+github.com/samber/oops v1.15.0/go.mod h1:9LpLZkpjojEt/of7EpG5o65i/Lp23ddDvGhg2L871Ow=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -94,6 +98,10 @@ github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/X
 go.etcd.io/bbolt v1.3.5/go.mod h1:G5EMThwa9y8QZGBClrRx5EY+Yw9kAhnjy3bSjsnlVTQ=
 go.etcd.io/bbolt v1.3.11 h1:yGEzV1wPz2yVCLsD8ZAiGHhHVlczyC9d1rP43/VCRJ0=
 go.etcd.io/bbolt v1.3.11/go.mod h1:dksAq7YMXoljX0xu6VF5DMZGbhYYoLUalEiSySYAS4I=
+go.opentelemetry.io/otel v1.34.0 h1:zRLXxLCgL1WyKsPVrgbSdMN4c0FMkDAskSTQP+0hdUY=
+go.opentelemetry.io/otel v1.34.0/go.mod h1:OWFPOQ+h4G8xpyjgqo4SxJYdDQ/qmRH+wivy7zzx9oI=
+go.opentelemetry.io/otel/trace v1.34.0 h1:+ouXS2V8Rd4hp4580a8q23bg0azF2nI8cqLYnC8mh/k=
+go.opentelemetry.io/otel/trace v1.34.0/go.mod h1:Svm7lSjQD7kG7KJ/MUHPVXSDGz2OX4h0M2jHBhmSfRE=
 golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 h1:k/i9J1pBpvlfR+9QsetwPyERsqu1GIbi967PQMq3Ivc=
 golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=
 golang.org/x/mod v0.22.0 h1:D4nJWe9zXqHOmWqj4VMOJhvzj7bEZg4wEYa759z1pH4=

--- a/pkg/build.go
+++ b/pkg/build.go
@@ -1,8 +1,8 @@
 package pkg
 
 import (
+	"github.com/samber/oops"
 	"github.com/urfave/cli"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy-db/pkg/db"
 	"github.com/aquasecurity/trivy-db/pkg/vulndb"
@@ -10,17 +10,20 @@ import (
 
 func build(c *cli.Context) error {
 	outputDir := c.String("output-dir")
+	eb := oops.With("output_dir", outputDir)
+
 	if err := db.Init(outputDir); err != nil {
-		return xerrors.Errorf("db initialize error: %w", err)
+		return eb.Wrapf(err, "db initialize error")
 	}
 
 	cacheDir := c.String("cache-dir")
 	targets := c.StringSlice("only-update")
 	updateInterval := c.Duration("update-interval")
+	eb = eb.With("cache_dir", cacheDir).With("update_interval", updateInterval).With("targets", targets)
 
 	vdb := vulndb.New(cacheDir, outputDir, updateInterval)
 	if err := vdb.Build(targets); err != nil {
-		return xerrors.Errorf("build error: %w", err)
+		return eb.Wrapf(err, "build error")
 	}
 
 	return nil

--- a/pkg/db/advisory.go
+++ b/pkg/db/advisory.go
@@ -3,15 +3,15 @@ package db
 import (
 	"encoding/json"
 
+	"github.com/samber/oops"
 	bolt "go.etcd.io/bbolt"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy-db/pkg/types"
 )
 
 func (dbc Config) PutAdvisory(tx *bolt.Tx, bktNames []string, key string, advisory interface{}) error {
 	if err := dbc.put(tx, bktNames, key, advisory); err != nil {
-		return xerrors.Errorf("failed to put advisory: %w", err)
+		return oops.With("bucket_names", bktNames).With("key", key).Wrapf(err, "failed to put advisory")
 	}
 	return nil
 }
@@ -21,9 +21,10 @@ func (dbc Config) ForEachAdvisory(sources []string, pkgName string) (map[string]
 }
 
 func (dbc Config) GetAdvisories(source, pkgName string) ([]types.Advisory, error) {
+	eb := oops.With("source", source).With("pkg_name", pkgName)
 	advisories, err := dbc.ForEachAdvisory([]string{source}, pkgName)
 	if err != nil {
-		return nil, xerrors.Errorf("advisory foreach error: %w", err)
+		return nil, eb.Wrapf(err, "advisory foreach error")
 	}
 	if len(advisories) == 0 {
 		return nil, nil
@@ -33,7 +34,7 @@ func (dbc Config) GetAdvisories(source, pkgName string) ([]types.Advisory, error
 	for vulnID, v := range advisories {
 		var advisory types.Advisory
 		if err = json.Unmarshal(v.Content, &advisory); err != nil {
-			return nil, xerrors.Errorf("failed to unmarshal advisory JSON: %w", err)
+			return nil, oops.With("vuln_id", vulnID).Wrapf(err, "json unmarshal error")
 		}
 
 		advisory.VulnerabilityID = vulnID

--- a/pkg/db/advisory.go
+++ b/pkg/db/advisory.go
@@ -34,7 +34,7 @@ func (dbc Config) GetAdvisories(source, pkgName string) ([]types.Advisory, error
 	for vulnID, v := range advisories {
 		var advisory types.Advisory
 		if err = json.Unmarshal(v.Content, &advisory); err != nil {
-			return nil, oops.With("vuln_id", vulnID).Wrapf(err, "json unmarshal error")
+			return nil, eb.With("vuln_id", vulnID).Wrapf(err, "json unmarshal error")
 		}
 
 		advisory.VulnerabilityID = vulnID

--- a/pkg/db/advisory.go
+++ b/pkg/db/advisory.go
@@ -21,7 +21,7 @@ func (dbc Config) ForEachAdvisory(sources []string, pkgName string) (map[string]
 }
 
 func (dbc Config) GetAdvisories(source, pkgName string) ([]types.Advisory, error) {
-	eb := oops.With("source", source).With("pkg_name", pkgName)
+	eb := oops.With("source", source).With("package_name", pkgName)
 	advisories, err := dbc.ForEachAdvisory([]string{source}, pkgName)
 	if err != nil {
 		return nil, eb.Wrapf(err, "advisory foreach error")

--- a/pkg/db/advisory.go
+++ b/pkg/db/advisory.go
@@ -11,7 +11,7 @@ import (
 
 func (dbc Config) PutAdvisory(tx *bolt.Tx, bktNames []string, key string, advisory interface{}) error {
 	if err := dbc.put(tx, bktNames, key, advisory); err != nil {
-		return oops.With("bucket_names", bktNames).With("key", key).Wrapf(err, "failed to put advisory")
+		return oops.With("key", key).Wrapf(err, "failed to put advisory")
 	}
 	return nil
 }

--- a/pkg/db/advisory_detail.go
+++ b/pkg/db/advisory_detail.go
@@ -14,7 +14,8 @@ const (
 func (dbc Config) PutAdvisoryDetail(tx *bolt.Tx, vulnID, pkgName string, nestedBktNames []string, advisory interface{}) error {
 	bktNames := append([]string{advisoryDetailBucket, vulnID}, nestedBktNames...)
 	if err := dbc.put(tx, bktNames, pkgName, advisory); err != nil {
-		return oops.With("vuln_id", vulnID).With("package_name", pkgName).Wrapf(err, "failed to put advisory detail")
+		return oops.With("vuln_id", vulnID).With("package_name", pkgName).
+			With("bucket_names", bktNames).Wrapf(err, "failed to put advisory detail")
 	}
 	return nil
 }

--- a/pkg/db/advisory_detail.go
+++ b/pkg/db/advisory_detail.go
@@ -14,8 +14,7 @@ const (
 func (dbc Config) PutAdvisoryDetail(tx *bolt.Tx, vulnID, pkgName string, nestedBktNames []string, advisory interface{}) error {
 	bktNames := append([]string{advisoryDetailBucket, vulnID}, nestedBktNames...)
 	if err := dbc.put(tx, bktNames, pkgName, advisory); err != nil {
-		return oops.With("vuln_id", vulnID).With("package_name", pkgName).
-			With("bucket_names", bktNames).Wrapf(err, "failed to put advisory detail")
+		return oops.With("vuln_id", vulnID).With("package_name", pkgName).Wrapf(err, "failed to put advisory detail")
 	}
 	return nil
 }

--- a/pkg/db/advisory_detail.go
+++ b/pkg/db/advisory_detail.go
@@ -3,8 +3,8 @@ package db
 import (
 	"encoding/json"
 
+	"github.com/samber/oops"
 	bolt "go.etcd.io/bbolt"
-	"golang.org/x/xerrors"
 )
 
 const (
@@ -14,7 +14,7 @@ const (
 func (dbc Config) PutAdvisoryDetail(tx *bolt.Tx, vulnID, pkgName string, nestedBktNames []string, advisory interface{}) error {
 	bktNames := append([]string{advisoryDetailBucket, vulnID}, nestedBktNames...)
 	if err := dbc.put(tx, bktNames, pkgName, advisory); err != nil {
-		return xerrors.Errorf("failed to put advisory detail: %w", err)
+		return oops.With("vuln_id", vulnID).With("pkg_name", pkgName).Wrapf(err, "failed to put advisory detail")
 	}
 	return nil
 }
@@ -32,7 +32,7 @@ func (dbc Config) SaveAdvisoryDetails(tx *bolt.Tx, vulnID string) error {
 	}
 
 	if err := dbc.saveAdvisories(tx, cveBucket, []string{}, vulnID); err != nil {
-		return xerrors.Errorf("walk advisories error: %w", err)
+		return oops.With("vuln_id", vulnID).Wrapf(err, "unable to save advisories")
 	}
 
 	return nil
@@ -43,31 +43,32 @@ func (dbc Config) saveAdvisories(tx *bolt.Tx, bkt *bolt.Bucket, bktNames []strin
 	if bkt == nil {
 		return nil
 	}
+	eb := oops.With("bucket_names", bktNames).With("vuln_id", vulnID)
 
 	err := bkt.ForEach(func(k, v []byte) error {
 		// When the key is a bucket, it walks recursively.
 		if v == nil {
 			bkts := append(bktNames, string(k))
 			if err := dbc.saveAdvisories(tx, bkt.Bucket(k), bkts, vulnID); err != nil {
-				return xerrors.Errorf("walk advisories error: %w", err)
+				return eb.Wrapf(err, "unable to save advisories")
 			}
 		} else {
 			detail := map[string]interface{}{}
 			if err := json.Unmarshal(v, &detail); err != nil {
-				return xerrors.Errorf("failed to unmarshall the advisory detail: %w", err)
+				return eb.Wrapf(err, "json unmarshal error")
 			}
 
 			// Put the advisory in vendor's bucket such as Debian and Ubuntu
 			bkts := append(bktNames, string(k))
 			if err := dbc.put(tx, bkts, vulnID, detail); err != nil {
-				return xerrors.Errorf("database put error: %w", err)
+				return eb.Wrapf(err, "database put error")
 			}
 		}
 
 		return nil
 	})
 	if err != nil {
-		return xerrors.Errorf("foreach error: %w", err)
+		return eb.Wrapf(err, "foreach error")
 	}
 
 	return nil

--- a/pkg/db/advisory_detail.go
+++ b/pkg/db/advisory_detail.go
@@ -14,7 +14,7 @@ const (
 func (dbc Config) PutAdvisoryDetail(tx *bolt.Tx, vulnID, pkgName string, nestedBktNames []string, advisory interface{}) error {
 	bktNames := append([]string{advisoryDetailBucket, vulnID}, nestedBktNames...)
 	if err := dbc.put(tx, bktNames, pkgName, advisory); err != nil {
-		return oops.With("vuln_id", vulnID).With("pkg_name", pkgName).Wrapf(err, "failed to put advisory detail")
+		return oops.With("vuln_id", vulnID).With("package_name", pkgName).Wrapf(err, "failed to put advisory detail")
 	}
 	return nil
 }

--- a/pkg/db/data_source.go
+++ b/pkg/db/data_source.go
@@ -3,8 +3,8 @@ package db
 import (
 	"encoding/json"
 
+	"github.com/samber/oops"
 	bolt "go.etcd.io/bbolt"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy-db/pkg/types"
 )
@@ -14,19 +14,21 @@ const (
 )
 
 func (dbc Config) PutDataSource(tx *bolt.Tx, bktName string, source types.DataSource) error {
+	eb := oops.With("root_bucket", dataSourceBucket).With("bucket_name", bktName)
 	bucket, err := tx.CreateBucketIfNotExists([]byte(dataSourceBucket))
 	if err != nil {
-		return xerrors.Errorf("failed to create %s bucket: %w", dataSourceBucket, err)
+		return eb.Wrapf(err, "failed to create bucket")
 	}
 	b, err := json.Marshal(source)
 	if err != nil {
-		return xerrors.Errorf("JSON marshal error: %w", err)
+		return eb.Wrapf(err, "json marshal error")
 	}
 
 	return bucket.Put([]byte(bktName), b)
 }
 
 func (dbc Config) getDataSource(tx *bolt.Tx, bktName string) (types.DataSource, error) {
+	eb := oops.With("root_bucket", dataSourceBucket).With("bucket_name", bktName)
 	bucket := tx.Bucket([]byte(dataSourceBucket))
 	if bucket == nil {
 		return types.DataSource{}, nil
@@ -39,7 +41,7 @@ func (dbc Config) getDataSource(tx *bolt.Tx, bktName string) (types.DataSource, 
 
 	var source types.DataSource
 	if err := json.Unmarshal(b, &source); err != nil {
-		return types.DataSource{}, xerrors.Errorf("JSON unmarshal error: %w", err)
+		return types.DataSource{}, eb.Wrapf(err, "json unmarshal error")
 	}
 
 	return source, nil

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -8,8 +8,8 @@ import (
 	"runtime/debug"
 	"strings"
 
+	"github.com/samber/oops"
 	bolt "go.etcd.io/bbolt"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy-db/pkg/log"
 	"github.com/aquasecurity/trivy-db/pkg/types"
@@ -72,10 +72,12 @@ func Init(dbDir string, opts ...Option) (err error) {
 		opt(dbOptions)
 	}
 
+	eb := oops.With("db_dir", dbDir)
 	if err = os.MkdirAll(dbDir, 0700); err != nil {
-		return xerrors.Errorf("failed to mkdir: %w", err)
+		return eb.Wrapf(err, "failed to mkdir")
 	}
 	dbPath := Path(dbDir)
+	eb = eb.With("db_path", dbPath)
 
 	// bbolt sometimes occurs the fatal error of "unexpected fault address".
 	// In that case, the local DB should be broken and needs to be removed.
@@ -92,7 +94,7 @@ func Init(dbDir string, opts ...Option) (err error) {
 
 	db, err = bolt.Open(dbPath, 0644, dbOptions.boltOptions)
 	if err != nil {
-		return xerrors.Errorf("failed to open db: %w", err)
+		return eb.Wrapf(err, "failed to open db")
 	}
 	return nil
 }
@@ -108,7 +110,7 @@ func Close() error {
 		return nil
 	}
 	if err := db.Close(); err != nil {
-		return xerrors.Errorf("failed to close DB: %w", err)
+		return oops.Wrapf(err, "failed to close DB")
 	}
 	return nil
 }
@@ -120,39 +122,41 @@ func (dbc Config) Connection() *bolt.DB {
 func (dbc Config) BatchUpdate(fn func(tx *bolt.Tx) error) error {
 	err := db.Batch(fn)
 	if err != nil {
-		return xerrors.Errorf("error in batch update: %w", err)
+		return oops.Wrapf(err, "batch update error")
 	}
 	return nil
 }
 
 func (dbc Config) put(tx *bolt.Tx, bktNames []string, key string, value interface{}) error {
 	if len(bktNames) == 0 {
-		return xerrors.Errorf("empty bucket name")
+		return oops.Errorf("empty bucket name")
 	}
 
+	eb := oops.With("bucket_names", bktNames)
 	bkt, err := tx.CreateBucketIfNotExists([]byte(bktNames[0]))
 	if err != nil {
-		return xerrors.Errorf("failed to create '%s' bucket: %w", bktNames[0], err)
+		return eb.Wrapf(err, "failed to create bucket")
 	}
 
 	for _, bktName := range bktNames[1:] {
 		bkt, err = bkt.CreateBucketIfNotExists([]byte(bktName))
 		if err != nil {
-			return xerrors.Errorf("failed to create a bucket: %w", err)
+			return eb.Wrapf(err, "failed to create bucket")
 		}
 	}
 	v, err := json.Marshal(value)
 	if err != nil {
-		return xerrors.Errorf("failed to unmarshal JSON: %w", err)
+		return eb.Wrapf(err, "json marshal error")
 	}
 
 	return bkt.Put([]byte(key), v)
 }
 
 func (dbc Config) get(bktNames []string, key string) (value []byte, err error) {
+	eb := oops.With("bucket_names", bktNames)
 	err = db.View(func(tx *bolt.Tx) error {
 		if len(bktNames) == 0 {
-			return xerrors.Errorf("empty bucket name")
+			return eb.Errorf("empty bucket name")
 		}
 
 		bkt := tx.Bucket([]byte(bktNames[0]))
@@ -174,7 +178,7 @@ func (dbc Config) get(bktNames []string, key string) (value []byte, err error) {
 		return nil
 	})
 	if err != nil {
-		return nil, xerrors.Errorf("failed to get data from db: %w", err)
+		return nil, eb.Wrapf(err, "failed to get data from db")
 	}
 	return value, nil
 }
@@ -185,8 +189,9 @@ type Value struct {
 }
 
 func (dbc Config) forEach(bktNames []string) (map[string]Value, error) {
+	eb := oops.With("bucket_names", bktNames)
 	if len(bktNames) < 2 {
-		return nil, xerrors.Errorf("bucket must be nested: %v", bktNames)
+		return nil, eb.Errorf("bucket must be nested")
 	}
 	rootBucket, nestedBuckets := bktNames[0], bktNames[1:]
 
@@ -243,13 +248,13 @@ func (dbc Config) forEach(bktNames []string) (map[string]Value, error) {
 				return nil
 			})
 			if err != nil {
-				return xerrors.Errorf("db foreach error: %w", err)
+				return eb.Wrapf(err, "db foreach error")
 			}
 		}
 		return nil
 	})
 	if err != nil {
-		return nil, xerrors.Errorf("failed to get all key/value in the specified bucket: %w", err)
+		return nil, eb.Wrapf(err, "failed to get all key/value in the specified bucket")
 	}
 	return values, nil
 }
@@ -257,7 +262,7 @@ func (dbc Config) forEach(bktNames []string) (map[string]Value, error) {
 func (dbc Config) deleteBucket(bucketName string) error {
 	return db.Update(func(tx *bolt.Tx) error {
 		if err := tx.DeleteBucket([]byte(bucketName)); err != nil {
-			return xerrors.Errorf("failed to delete bucket: %w", err)
+			return oops.With("bucket_name", bucketName).Wrapf(err, "failed to delete bucket")
 		}
 		return nil
 	})

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -135,13 +135,13 @@ func (dbc Config) put(tx *bolt.Tx, bktNames []string, key string, value interfac
 	eb := oops.With("bucket_names", bktNames)
 	bkt, err := tx.CreateBucketIfNotExists([]byte(bktNames[0]))
 	if err != nil {
-		return eb.Wrapf(err, "failed to create bucket")
+		return eb.With("bucket_name", bktNames[0]).Wrapf(err, "failed to create bucket")
 	}
 
 	for _, bktName := range bktNames[1:] {
 		bkt, err = bkt.CreateBucketIfNotExists([]byte(bktName))
 		if err != nil {
-			return eb.Wrapf(err, "failed to create bucket")
+			return eb.With("bucket_name", bktName).Wrapf(err, "failed to create bucket")
 		}
 	}
 	v, err := json.Marshal(value)

--- a/pkg/db/redhat_cpe.go
+++ b/pkg/db/redhat_cpe.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/samber/oops"
 	bolt "go.etcd.io/bbolt"
-	"golang.org/x/xerrors"
 )
 
 const (
@@ -19,7 +19,7 @@ const (
 
 func (dbc Config) PutRedHatRepositories(tx *bolt.Tx, repository string, cpeIndices []int) error {
 	if err := dbc.put(tx, []string{redhatCPERootBucket, redhatRepoBucket}, repository, cpeIndices); err != nil {
-		return xerrors.Errorf("Red Hat CPE error: %w", err)
+		return oops.With("repository", repository).Wrapf(err, "failed to put Red Hat repositories")
 	}
 
 	return nil
@@ -27,7 +27,7 @@ func (dbc Config) PutRedHatRepositories(tx *bolt.Tx, repository string, cpeIndic
 
 func (dbc Config) PutRedHatNVRs(tx *bolt.Tx, nvr string, cpeIndices []int) error {
 	if err := dbc.put(tx, []string{redhatCPERootBucket, redhatNVRBucket}, nvr, cpeIndices); err != nil {
-		return xerrors.Errorf("Red Hat CPE error: %w", err)
+		return oops.With("nvr", nvr).Wrapf(err, "failed to put Red Hat NVRs")
 	}
 
 	return nil
@@ -36,7 +36,7 @@ func (dbc Config) PutRedHatNVRs(tx *bolt.Tx, nvr string, cpeIndices []int) error
 func (dbc Config) PutRedHatCPEs(tx *bolt.Tx, cpeIndex int, cpe string) error {
 	index := fmt.Sprint(cpeIndex)
 	if err := dbc.put(tx, []string{redhatCPERootBucket, redhatCPEBucket}, index, cpe); err != nil {
-		return xerrors.Errorf("Red Hat CPE error: %w", err)
+		return oops.With("cpe_index", cpeIndex).With("cpe", cpe).Wrapf(err, "failed to put Red Hat CPEs")
 	}
 
 	return nil
@@ -51,16 +51,17 @@ func (dbc Config) RedHatNVRToCPEs(repository string) ([]int, error) {
 }
 
 func (dbc Config) getCPEs(bucket, key string) ([]int, error) {
+	eb := oops.With("bucket", bucket).With("key", key)
 	value, err := dbc.get([]string{redhatCPERootBucket, bucket}, key)
 	if err != nil {
-		return nil, xerrors.Errorf("unable to get '%s': %w", key, err)
+		return nil, eb.Wrapf(err, "failed to get CPEs")
 	} else if len(value) == 0 {
 		return nil, nil
 	}
 
 	var cpes []int
 	if err = json.Unmarshal(value, &cpes); err != nil {
-		return nil, xerrors.Errorf("JSON unmarshal error: %w", err)
+		return nil, eb.Wrapf(err, "json unmarshal error")
 	}
 	return cpes, nil
 }

--- a/pkg/db/redhat_cpe.go
+++ b/pkg/db/redhat_cpe.go
@@ -51,7 +51,7 @@ func (dbc Config) RedHatNVRToCPEs(repository string) ([]int, error) {
 }
 
 func (dbc Config) getCPEs(bucket, key string) ([]int, error) {
-	eb := oops.With("bucket", bucket).With("key", key)
+	eb := oops.With("bucket_name", bucket).With("key", key)
 	value, err := dbc.get([]string{redhatCPERootBucket, bucket}, key)
 	if err != nil {
 		return nil, eb.Wrapf(err, "failed to get CPEs")

--- a/pkg/db/redhat_cpe_test.go
+++ b/pkg/db/redhat_cpe_test.go
@@ -34,7 +34,7 @@ func TestConfig_GetRedHatCPEs(t *testing.T) {
 			name:       "broken value",
 			fixtures:   []string{"testdata/fixtures/redhat-cpe.yaml"},
 			repository: "broken",
-			wantErr:    "JSON unmarshal error",
+			wantErr:    "json unmarshal error",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/db/vulnerability.go
+++ b/pkg/db/vulnerability.go
@@ -3,8 +3,8 @@ package db
 import (
 	"encoding/json"
 
+	"github.com/samber/oops"
 	bolt "go.etcd.io/bbolt"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy-db/pkg/types"
 )
@@ -15,25 +15,26 @@ const (
 
 func (dbc Config) PutVulnerability(tx *bolt.Tx, cveID string, vuln types.Vulnerability) error {
 	if err := dbc.put(tx, []string{vulnerabilityBucket}, cveID, vuln); err != nil {
-		return xerrors.Errorf("failed to put severity: %w", err)
+		return oops.With("cve_id", cveID).Wrapf(err, "failed to put severity")
 	}
 	return nil
 }
 
 func (dbc Config) GetVulnerability(cveID string) (vuln types.Vulnerability, err error) {
+	eb := oops.With("cve_id", cveID)
 	err = db.View(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket([]byte(vulnerabilityBucket))
 		value := bucket.Get([]byte(cveID))
 		if value == nil {
-			return xerrors.Errorf("no vulnerability details for %s", cveID)
+			return eb.Errorf("no vulnerability details")
 		}
 		if err = json.Unmarshal(value, &vuln); err != nil {
-			return xerrors.Errorf("failed to unmarshal JSON: %w", err)
+			return eb.Wrapf(err, "json unmarshal error")
 		}
 		return nil
 	})
 	if err != nil {
-		return types.Vulnerability{}, xerrors.Errorf("failed to get the vulnerability %q: %w", cveID, err)
+		return types.Vulnerability{}, eb.Wrapf(err, "failed to get vulnerability")
 	}
 	return vuln, nil
 }

--- a/pkg/db/vulnerability.go
+++ b/pkg/db/vulnerability.go
@@ -15,13 +15,13 @@ const (
 
 func (dbc Config) PutVulnerability(tx *bolt.Tx, cveID string, vuln types.Vulnerability) error {
 	if err := dbc.put(tx, []string{vulnerabilityBucket}, cveID, vuln); err != nil {
-		return oops.With("cve_id", cveID).Wrapf(err, "failed to put severity")
+		return oops.With("vuln_id", cveID).Wrapf(err, "failed to put severity")
 	}
 	return nil
 }
 
 func (dbc Config) GetVulnerability(cveID string) (vuln types.Vulnerability, err error) {
-	eb := oops.With("cve_id", cveID)
+	eb := oops.With("vuln_id", cveID)
 	err = db.View(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket([]byte(vulnerabilityBucket))
 		value := bucket.Get([]byte(cveID))

--- a/pkg/db/vulnerability_detail.go
+++ b/pkg/db/vulnerability_detail.go
@@ -15,13 +15,13 @@ const (
 
 func (dbc Config) PutVulnerabilityDetail(tx *bolt.Tx, cveID string, source types.SourceID, vuln types.VulnerabilityDetail) error {
 	if err := dbc.put(tx, []string{vulnerabilityDetailBucket, cveID}, string(source), vuln); err != nil {
-		return oops.With("cve_id", cveID).With("source", source).Wrapf(err, "failed to put vulnerability detail")
+		return oops.With("vuln_id", cveID).With("source_id", source).Wrapf(err, "failed to put vulnerability detail")
 	}
 	return nil
 }
 
 func (dbc Config) GetVulnerabilityDetail(cveID string) (map[types.SourceID]types.VulnerabilityDetail, error) {
-	eb := oops.With("cve_id", cveID)
+	eb := oops.With("vuln_id", cveID)
 	values, err := dbc.forEach([]string{vulnerabilityDetailBucket, cveID})
 	if err != nil {
 		return nil, eb.Wrapf(err, "unable to get vulnerability detail")

--- a/pkg/db/vulnerability_detail.go
+++ b/pkg/db/vulnerability_detail.go
@@ -3,8 +3,8 @@ package db
 import (
 	"encoding/json"
 
+	"github.com/samber/oops"
 	bolt "go.etcd.io/bbolt"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy-db/pkg/types"
 )
@@ -15,15 +15,16 @@ const (
 
 func (dbc Config) PutVulnerabilityDetail(tx *bolt.Tx, cveID string, source types.SourceID, vuln types.VulnerabilityDetail) error {
 	if err := dbc.put(tx, []string{vulnerabilityDetailBucket, cveID}, string(source), vuln); err != nil {
-		return xerrors.Errorf("failed to put vulnerability detail: %w", err)
+		return oops.With("cve_id", cveID).With("source", source).Wrapf(err, "failed to put vulnerability detail")
 	}
 	return nil
 }
 
 func (dbc Config) GetVulnerabilityDetail(cveID string) (map[types.SourceID]types.VulnerabilityDetail, error) {
+	eb := oops.With("cve_id", cveID)
 	values, err := dbc.forEach([]string{vulnerabilityDetailBucket, cveID})
 	if err != nil {
-		return nil, xerrors.Errorf("error in NVD get: %w", err)
+		return nil, eb.Wrapf(err, "unable to get vulnerability detail")
 	}
 	if len(values) == 0 {
 		return nil, nil
@@ -33,7 +34,7 @@ func (dbc Config) GetVulnerabilityDetail(cveID string) (map[types.SourceID]types
 	for source, value := range values {
 		var vuln types.VulnerabilityDetail
 		if err = json.Unmarshal(value.Content, &vuln); err != nil {
-			return nil, xerrors.Errorf("failed to unmarshal Vulnerability JSON: %w", err)
+			return nil, eb.Wrapf(err, "json unmarshal error")
 		}
 		vulns[types.SourceID(source)] = vuln
 	}

--- a/pkg/db/vulnid.go
+++ b/pkg/db/vulnid.go
@@ -1,8 +1,8 @@
 package db
 
 import (
+	"github.com/samber/oops"
 	bolt "go.etcd.io/bbolt"
-	"golang.org/x/xerrors"
 )
 
 const (
@@ -12,25 +12,26 @@ const (
 func (dbc Config) PutVulnerabilityID(tx *bolt.Tx, vulnID string) error {
 	bucket, err := tx.CreateBucketIfNotExists([]byte(vulnerabilityIDBucket))
 	if err != nil {
-		return xerrors.Errorf("failed to create %s bucket: %w", vulnerabilityIDBucket, err)
+		return oops.With("bucket", vulnerabilityIDBucket).With("vuln_id", vulnID).Wrapf(err, "failed to create bucket")
 	}
 	return bucket.Put([]byte(vulnID), []byte("{}"))
 }
 
 func (dbc Config) ForEachVulnerabilityID(f func(tx *bolt.Tx, vulnID string) error) error {
+	eb := oops.With("bucket", vulnerabilityIDBucket)
 	err := db.Batch(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket([]byte(vulnerabilityIDBucket))
 		if bucket == nil {
-			return xerrors.Errorf("no such bucket: %s", vulnerabilityIDBucket)
+			return eb.Errorf("no such bucket: %s", vulnerabilityIDBucket)
 		}
 		err := bucket.ForEach(func(vulnID, _ []byte) error {
 			if err := f(tx, string(vulnID)); err != nil {
-				return xerrors.Errorf("something wrong: %w", err)
+				return eb.With("vuln_id", vulnID).Wrapf(err, "something wrong")
 			}
 			return nil
 		})
 		if err != nil {
-			return xerrors.Errorf("error in for each: %w", err)
+			return eb.Wrapf(err, "for each error")
 		}
 		return nil
 	})

--- a/pkg/db/vulnid.go
+++ b/pkg/db/vulnid.go
@@ -12,17 +12,17 @@ const (
 func (dbc Config) PutVulnerabilityID(tx *bolt.Tx, vulnID string) error {
 	bucket, err := tx.CreateBucketIfNotExists([]byte(vulnerabilityIDBucket))
 	if err != nil {
-		return oops.With("bucket", vulnerabilityIDBucket).With("vuln_id", vulnID).Wrapf(err, "failed to create bucket")
+		return oops.With("bucket_name", vulnerabilityIDBucket).With("vuln_id", vulnID).Wrapf(err, "failed to create bucket")
 	}
 	return bucket.Put([]byte(vulnID), []byte("{}"))
 }
 
 func (dbc Config) ForEachVulnerabilityID(f func(tx *bolt.Tx, vulnID string) error) error {
-	eb := oops.With("bucket", vulnerabilityIDBucket)
+	eb := oops.With("bucket_name", vulnerabilityIDBucket)
 	err := db.Batch(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket([]byte(vulnerabilityIDBucket))
 		if bucket == nil {
-			return eb.Errorf("no such bucket: %s", vulnerabilityIDBucket)
+			return eb.Errorf("no such bucket")
 		}
 		err := bucket.ForEach(func(vulnID, _ []byte) error {
 			if err := f(tx, string(vulnID)); err != nil {

--- a/pkg/dbtest/assert.go
+++ b/pkg/dbtest/assert.go
@@ -67,12 +67,12 @@ func get(t *testing.T, dbPath string, keys []string, msgAndArgs ...interface{}) 
 	var b []byte
 	err := db.View(func(tx *bolt.Tx) error {
 		bkts, key := keys[:len(keys)-1], keys[len(keys)-1]
-		eb := oops.With("buckets", bkts).With("key", key)
+		eb := oops.With("bucket_names", bkts).With("key", key)
 
 		var bucket bucketer = tx
 		for _, k := range bkts {
 			if reflect.ValueOf(bucket).IsNil() {
-				return eb.With("bucket", k).Wrapf(ErrNoBucket, "bucket error")
+				return eb.With("bucket_name", k).Wrapf(ErrNoBucket, "bucket error")
 			}
 			bucket = bucket.Bucket([]byte(k))
 		}
@@ -105,11 +105,11 @@ func open(t *testing.T, dbPath string) *bolt.DB {
 }
 
 func nestedBuckets(start bucketer, buckets []string) (*bolt.Bucket, error) {
-	eb := oops.With("buckets", buckets)
+	eb := oops.With("bucket_names", buckets)
 	bucket := start
 	for _, k := range buckets {
 		if reflect.ValueOf(bucket).IsNil() {
-			return nil, eb.With("bucket", k).Wrapf(ErrNoBucket, "bucket error")
+			return nil, eb.With("bucket_name", k).Wrapf(ErrNoBucket, "bucket error")
 		}
 		bucket = bucket.Bucket([]byte(k))
 	}

--- a/pkg/dbtest/assert.go
+++ b/pkg/dbtest/assert.go
@@ -5,14 +5,14 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/samber/oops"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	bolt "go.etcd.io/bbolt"
-	"golang.org/x/xerrors"
 )
 
 var (
-	ErrNoBucket = xerrors.New("no such bucket")
+	ErrNoBucket = oops.Errorf("no such bucket")
 )
 
 func NoKey(t *testing.T, dbPath string, keys []string, msgAndArgs ...interface{}) {
@@ -67,19 +67,20 @@ func get(t *testing.T, dbPath string, keys []string, msgAndArgs ...interface{}) 
 	var b []byte
 	err := db.View(func(tx *bolt.Tx) error {
 		bkts, key := keys[:len(keys)-1], keys[len(keys)-1]
+		eb := oops.With("buckets", bkts).With("key", key)
 
 		var bucket bucketer = tx
 		for _, k := range bkts {
 			if reflect.ValueOf(bucket).IsNil() {
-				return xerrors.Errorf("bucket error %s: %w", k, ErrNoBucket)
+				return eb.With("bucket", k).Wrapf(ErrNoBucket, "bucket error")
 			}
 			bucket = bucket.Bucket([]byte(k))
 		}
 		bkt, ok := bucket.(*bolt.Bucket)
 		if !ok {
-			return xerrors.Errorf("bucket error %v: %w", keys, ErrNoBucket)
+			return eb.Wrapf(ErrNoBucket, "bucket error")
 		} else if bkt == nil {
-			return xerrors.Errorf("empty bucket %v: %w", keys, ErrNoBucket)
+			return eb.Wrapf(ErrNoBucket, "empty bucket")
 		}
 		res := bkt.Get([]byte(key))
 		if res == nil {
@@ -104,16 +105,17 @@ func open(t *testing.T, dbPath string) *bolt.DB {
 }
 
 func nestedBuckets(start bucketer, buckets []string) (*bolt.Bucket, error) {
+	eb := oops.With("buckets", buckets)
 	bucket := start
 	for _, k := range buckets {
 		if reflect.ValueOf(bucket).IsNil() {
-			return nil, xerrors.Errorf("bucket error %v: %w", buckets, ErrNoBucket)
+			return nil, eb.With("bucket", k).Wrapf(ErrNoBucket, "bucket error")
 		}
 		bucket = bucket.Bucket([]byte(k))
 	}
 	bkt, ok := bucket.(*bolt.Bucket)
 	if !ok {
-		return nil, xerrors.Errorf("bucket error %v: %w", buckets, ErrNoBucket)
+		return nil, eb.Wrapf(ErrNoBucket, "bucket error")
 	}
 	return bkt, nil
 }

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"os"
 )
 
 // Logger is an alias for slog.Logger
@@ -34,6 +33,10 @@ func Error(msg string, args ...any) {
 	defaultLogger.Error(msg, args...)
 }
 
+func Errorf(format string, args ...any) {
+	defaultLogger.Error(fmt.Sprintf(format, args...))
+}
+
 func Debug(msg string, args ...any) {
 	defaultLogger.Debug(msg, args...)
 }
@@ -57,13 +60,10 @@ type PrefixHandler struct {
 }
 
 func init() {
-	opts := &slog.HandlerOptions{
-		Level: slog.LevelDebug,
-	}
-	baseHandler := slog.NewTextHandler(os.Stdout, opts)
+	slog.SetLogLoggerLevel(slog.LevelDebug)
 	prefixHandler := &PrefixHandler{
 		prefix:  "",
-		handler: baseHandler,
+		handler: slog.Default().Handler(),
 	}
 	defaultLogger = slog.New(prefixHandler)
 }

--- a/pkg/metadata/metadata.go
+++ b/pkg/metadata/metadata.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"golang.org/x/xerrors"
+	"github.com/samber/oops"
 )
 
 const metadataFile = "metadata.json"
@@ -36,40 +36,46 @@ func Path(dbDir string) string {
 
 // Get returns the file metadata
 func (c Client) Get() (Metadata, error) {
+	eb := oops.With("file_path", c.filePath)
+
 	f, err := os.Open(c.filePath)
 	if err != nil {
-		return Metadata{}, xerrors.Errorf("unable to open a file: %w", err)
+		return Metadata{}, eb.Wrapf(err, "file open error")
 	}
 	defer f.Close()
 
 	var metadata Metadata
 	if err = json.NewDecoder(f).Decode(&metadata); err != nil {
-		return Metadata{}, xerrors.Errorf("unable to decode metadata: %w", err)
+		return Metadata{}, eb.Wrapf(err, "json decode error")
 	}
 	return metadata, nil
 }
 
 func (c Client) Update(meta Metadata) error {
+	eb := oops.With("file_path", c.filePath)
+
 	if err := os.MkdirAll(filepath.Dir(c.filePath), 0744); err != nil {
-		return xerrors.Errorf("mkdir error: %w", err)
+		return eb.Wrapf(err, "mkdir error")
 	}
 
 	f, err := os.Create(c.filePath)
 	if err != nil {
-		return xerrors.Errorf("unable to open a file: %w", err)
+		return eb.Wrapf(err, "file create error")
 	}
 	defer f.Close()
 
 	if err = json.NewEncoder(f).Encode(&meta); err != nil {
-		return xerrors.Errorf("unable to decode metadata: %w", err)
+		return eb.Wrapf(err, "json encode error")
 	}
 	return nil
 }
 
 // Delete deletes the file of database metadata
 func (c Client) Delete() error {
+	eb := oops.With("file_path", c.filePath)
+
 	if err := os.Remove(c.filePath); err != nil {
-		return xerrors.Errorf("unable to remove the metadata file: %w", err)
+		return eb.Wrapf(err, "file remove error")
 	}
 	return nil
 }

--- a/pkg/metadata/metadata.go
+++ b/pkg/metadata/metadata.go
@@ -72,10 +72,8 @@ func (c Client) Update(meta Metadata) error {
 
 // Delete deletes the file of database metadata
 func (c Client) Delete() error {
-	eb := oops.With("file_path", c.filePath)
-
 	if err := os.Remove(c.filePath); err != nil {
-		return eb.Wrapf(err, "file remove error")
+		return oops.With("file_path", c.filePath).Wrapf(err, "file remove error")
 	}
 	return nil
 }

--- a/pkg/utils/file.go
+++ b/pkg/utils/file.go
@@ -18,7 +18,7 @@ func FileWalk(root string, walkFn func(r io.Reader, path string) error) error {
 	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		eb := eb.With("path", path)
 		if err != nil {
-			return eb.Wrapf(err, "file info error")
+			return eb.Wrapf(err, "walk dir error")
 		} else if d.IsDir() {
 			return nil
 		}

--- a/pkg/utils/file.go
+++ b/pkg/utils/file.go
@@ -13,7 +13,7 @@ import (
 )
 
 func FileWalk(root string, walkFn func(r io.Reader, path string) error) error {
-	eb := oops.With("root", root)
+	eb := oops.With("root_dir", root)
 
 	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		eb := eb.With("path", path)

--- a/pkg/utils/file.go
+++ b/pkg/utils/file.go
@@ -7,22 +7,25 @@ import (
 	"os"
 	"path/filepath"
 
-	"golang.org/x/xerrors"
+	"github.com/samber/oops"
 
 	"github.com/aquasecurity/trivy-db/pkg/log"
 )
 
 func FileWalk(root string, walkFn func(r io.Reader, path string) error) error {
+	eb := oops.With("root", root)
+
 	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		eb := eb.With("path", path)
 		if err != nil {
-			return err
+			return eb.Wrapf(err, "file info error")
 		} else if d.IsDir() {
 			return nil
 		}
 
 		info, err := d.Info()
 		if err != nil {
-			return xerrors.Errorf("file info error: %w", err)
+			return eb.Wrapf(err, "file info error")
 		}
 
 		if info.Size() == 0 {
@@ -32,17 +35,17 @@ func FileWalk(root string, walkFn func(r io.Reader, path string) error) error {
 
 		f, err := os.Open(path)
 		if err != nil {
-			return xerrors.Errorf("failed to open file: %w", err)
+			return eb.Wrapf(err, "file open error")
 		}
 		defer f.Close()
 
 		if err = walkFn(f, path); err != nil {
-			return err
+			return eb.Wrapf(err, "walk error")
 		}
 		return nil
 	})
 	if err != nil {
-		return xerrors.Errorf("file walk error: %w", err)
+		return eb.Wrapf(err, "file walk error")
 	}
 	return nil
 }
@@ -59,14 +62,16 @@ func Exists(path string) (bool, error) {
 }
 
 func UnmarshalJSONFile(v interface{}, fileName string) error {
+	eb := oops.With("file_name", fileName)
+
 	f, err := os.Open(fileName)
 	if err != nil {
-		return xerrors.Errorf("unable to open a file (%s): %w", fileName, err)
+		return eb.Wrapf(err, "file open error")
 	}
 	defer f.Close()
 
 	if err = json.NewDecoder(f).Decode(v); err != nil {
-		return xerrors.Errorf("failed to decode file (%s): %w", fileName, err)
+		return eb.Wrapf(err, "json decode error")
 	}
 	return nil
 }

--- a/pkg/vulndb/db.go
+++ b/pkg/vulndb/db.go
@@ -133,7 +133,7 @@ func (t TrivyDB) optimize() error {
 	// Trivy DB will not store them so that it could reduce the database size.
 	// This bucket has only vulnerability IDs provided by vendors. They must be stored.
 	err := t.dbc.ForEachVulnerabilityID(func(tx *bolt.Tx, cveID string) error {
-		eb := oops.With("cve_id", cveID)
+		eb := oops.With("vuln_id", cveID)
 		details := t.vulnClient.GetDetails(cveID)
 		if t.vulnClient.IsRejected(details) {
 			return nil

--- a/pkg/vulndb/db.go
+++ b/pkg/vulndb/db.go
@@ -3,8 +3,8 @@ package vulndb
 import (
 	"time"
 
+	"github.com/samber/oops"
 	bolt "go.etcd.io/bbolt"
-	"golang.org/x/xerrors"
 	"k8s.io/utils/clock"
 
 	"github.com/aquasecurity/trivy-db/pkg/db"
@@ -70,15 +70,18 @@ func New(cacheDir, outputDir string, updateInterval time.Duration, opts ...Optio
 
 func (t TrivyDB) Insert(targets []string) error {
 	log.Info("Updating vulnerability database...")
+	eb := oops.In("db")
+
 	for _, target := range targets {
+		eb := eb.With("target", target)
 		src, ok := t.vulnSrc(target)
 		if !ok {
-			return xerrors.Errorf("%s is not supported", target)
+			return eb.Errorf("target not supported")
 		}
 		log.WithPrefix(target).Info("Updating data...")
 
 		if err := src.Update(t.cacheDir); err != nil {
-			return xerrors.Errorf("%s update error: %w", target, err)
+			return eb.Wrapf(err, "update error")
 		}
 	}
 
@@ -89,26 +92,28 @@ func (t TrivyDB) Insert(targets []string) error {
 	}
 
 	if err := t.metadata.Update(md); err != nil {
-		return xerrors.Errorf("metadata update error: %w", err)
+		return eb.Wrapf(err, "metadata update error")
 	}
 
 	return nil
 }
 
 func (t TrivyDB) Build(targets []string) error {
+	eb := oops.In("db")
+
 	// Insert all security advisories
 	if err := t.Insert(targets); err != nil {
-		return xerrors.Errorf("insert error: %w", err)
+		return eb.Wrapf(err, "insert error")
 	}
 
 	// Remove unnecessary details
 	if err := t.optimize(); err != nil {
-		return xerrors.Errorf("optimize error: %w", err)
+		return eb.Wrapf(err, "optimize error")
 	}
 
 	// Remove unnecessary buckets
 	if err := t.cleanup(); err != nil {
-		return xerrors.Errorf("cleanup error: %w", err)
+		return eb.Wrapf(err, "cleanup error")
 	}
 
 	return nil
@@ -128,13 +133,14 @@ func (t TrivyDB) optimize() error {
 	// Trivy DB will not store them so that it could reduce the database size.
 	// This bucket has only vulnerability IDs provided by vendors. They must be stored.
 	err := t.dbc.ForEachVulnerabilityID(func(tx *bolt.Tx, cveID string) error {
+		eb := oops.With("cve_id", cveID)
 		details := t.vulnClient.GetDetails(cveID)
 		if t.vulnClient.IsRejected(details) {
 			return nil
 		}
 
 		if err := t.dbc.SaveAdvisoryDetails(tx, cveID); err != nil {
-			return xerrors.Errorf("failed to save advisories: %w", err)
+			return eb.Wrapf(err, "failed to save advisories")
 		}
 
 		if len(details) == 0 {
@@ -143,14 +149,14 @@ func (t TrivyDB) optimize() error {
 
 		vuln := t.vulnClient.Normalize(details)
 		if err := t.dbc.PutVulnerability(tx, cveID, vuln); err != nil {
-			return xerrors.Errorf("failed to put vulnerability: %w", err)
+			return eb.Wrapf(err, "failed to put vulnerability")
 		}
 
 		return nil
 	})
 
 	if err != nil {
-		return xerrors.Errorf("failed to iterate severity: %w", err)
+		return oops.Wrapf(err, "failed to iterate severity")
 	}
 
 	return nil
@@ -158,15 +164,15 @@ func (t TrivyDB) optimize() error {
 
 func (t TrivyDB) cleanup() error {
 	if err := t.dbc.DeleteVulnerabilityIDBucket(); err != nil {
-		return xerrors.Errorf("failed to delete severity bucket: %w", err)
+		return oops.Wrapf(err, "failed to delete severity bucket")
 	}
 
 	if err := t.dbc.DeleteVulnerabilityDetailBucket(); err != nil {
-		return xerrors.Errorf("failed to delete vulnerability detail bucket: %w", err)
+		return oops.Wrapf(err, "failed to delete vulnerability detail bucket")
 	}
 
 	if err := t.dbc.DeleteAdvisoryDetailBucket(); err != nil {
-		return xerrors.Errorf("failed to delete advisory detail bucket: %w", err)
+		return oops.Wrapf(err, "failed to delete advisory detail bucket")
 	}
 
 	return nil

--- a/pkg/vulnsrc/alma/alma.go
+++ b/pkg/vulnsrc/alma/alma.go
@@ -188,7 +188,7 @@ func (vs *VulnSrc) commit(tx *bolt.Tx, platformName string, errata []Erratum) er
 				Erratum:      erratum,
 			})
 			if err != nil {
-				return oops.With("cve_id", cveID).With("platform", platformName).Wrapf(err, "db put error")
+				return oops.With("vuln_id", cveID).With("platform", platformName).Wrapf(err, "db put error")
 			}
 		}
 	}
@@ -196,7 +196,7 @@ func (vs *VulnSrc) commit(tx *bolt.Tx, platformName string, errata []Erratum) er
 }
 
 func (a *Alma) Put(tx *bolt.Tx, input PutInput) error {
-	eb := oops.With("cve_id", input.CveID).With("platform", input.PlatformName)
+	eb := oops.With("vuln_id", input.CveID).With("platform", input.PlatformName)
 	if err := a.PutVulnerabilityDetail(tx, input.CveID, source.ID, input.Vuln); err != nil {
 		return eb.Wrapf(err, "failed to save vulnerability detail")
 	}
@@ -218,7 +218,7 @@ func (a *Alma) Get(release, pkgName string) ([]types.Advisory, error) {
 	bucket := fmt.Sprintf(platformFormat, release)
 	advisories, err := a.GetAdvisories(bucket, pkgName)
 	if err != nil {
-		return nil, oops.With("release", release).With("pkg_name", pkgName).Wrapf(err, "failed to get advisories")
+		return nil, oops.With("release", release).With("package_name", pkgName).Wrapf(err, "failed to get advisories")
 	}
 	return advisories, nil
 }

--- a/pkg/vulnsrc/alma/alma.go
+++ b/pkg/vulnsrc/alma/alma.go
@@ -196,19 +196,18 @@ func (vs *VulnSrc) commit(tx *bolt.Tx, platformName string, errata []Erratum) er
 }
 
 func (a *Alma) Put(tx *bolt.Tx, input PutInput) error {
-	eb := oops.With("vuln_id", input.CveID).With("platform", input.PlatformName)
 	if err := a.PutVulnerabilityDetail(tx, input.CveID, source.ID, input.Vuln); err != nil {
-		return eb.Wrapf(err, "failed to save vulnerability detail")
+		return oops.Wrapf(err, "failed to save vulnerability detail")
 	}
 
 	// for optimization
 	if err := a.PutVulnerabilityID(tx, input.CveID); err != nil {
-		return eb.Wrapf(err, "failed to save vulnerability ID")
+		return oops.Wrapf(err, "failed to save vulnerability ID")
 	}
 
 	for pkgName, advisory := range input.Advisories {
 		if err := a.PutAdvisoryDetail(tx, input.CveID, pkgName, []string{input.PlatformName}, advisory); err != nil {
-			return eb.Wrapf(err, "failed to save advisory")
+			return oops.Wrapf(err, "failed to save advisory")
 		}
 	}
 	return nil

--- a/pkg/vulnsrc/alma/alma.go
+++ b/pkg/vulnsrc/alma/alma.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 
 	version "github.com/knqyf263/go-rpm-version"
+	"github.com/samber/oops"
 	bolt "go.etcd.io/bbolt"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy-db/pkg/db"
 	"github.com/aquasecurity/trivy-db/pkg/log"
@@ -69,12 +69,14 @@ func (vs *VulnSrc) Name() types.SourceID {
 
 func (vs *VulnSrc) Update(dir string) error {
 	rootDir := filepath.Join(dir, "vuln-list", almaDir)
+	eb := oops.In("alma").With("root_dir", rootDir)
+
 	errata, err := vs.parse(rootDir)
 	if err != nil {
-		return err
+		return eb.Wrap(err)
 	}
 	if err = vs.put(errata); err != nil {
-		return xerrors.Errorf("error in Alma save: %w", err)
+		return eb.Wrapf(err, "put error")
 	}
 
 	return nil
@@ -84,9 +86,11 @@ func (vs *VulnSrc) Update(dir string) error {
 func (vs *VulnSrc) parse(rootDir string) (map[string][]Erratum, error) {
 	errata := map[string][]Erratum{}
 	err := utils.FileWalk(rootDir, func(r io.Reader, path string) error {
+		eb := oops.With("file_path", path)
+
 		var erratum Erratum
 		if err := json.NewDecoder(r).Decode(&erratum); err != nil {
-			return xerrors.Errorf("failed to decode Alma erratum: %w", err)
+			return eb.Wrapf(err, "json decode error")
 		}
 
 		dirs := strings.Split(path, string(filepath.Separator))
@@ -100,7 +104,7 @@ func (vs *VulnSrc) parse(rootDir string) (map[string][]Erratum, error) {
 		return nil
 	})
 	if err != nil {
-		return nil, xerrors.Errorf("error in Alma walk: %w", err)
+		return nil, oops.Wrapf(err, "walk error")
 	}
 
 	return errata, nil
@@ -110,18 +114,19 @@ func (vs *VulnSrc) put(errataVer map[string][]Erratum) error {
 	err := vs.BatchUpdate(func(tx *bolt.Tx) error {
 		for majorVer, errata := range errataVer {
 			platformName := fmt.Sprintf(platformFormat, majorVer)
+			eb := oops.With("platform", platformName).With("major_version", majorVer)
 			if err := vs.PutDataSource(tx, platformName, source); err != nil {
-				return xerrors.Errorf("failed to put data source: %w", err)
+				return eb.Wrapf(err, "failed to put data source")
 			}
 
 			if err := vs.commit(tx, platformName, errata); err != nil {
-				return xerrors.Errorf("Alma %s commit error: %w", majorVer, err)
+				return eb.Wrapf(err, "commit error")
 			}
 		}
 		return nil
 	})
 	if err != nil {
-		return xerrors.Errorf("error in db batch update: %w", err)
+		return oops.Wrapf(err, "db batch update error")
 	}
 	return nil
 }
@@ -183,7 +188,7 @@ func (vs *VulnSrc) commit(tx *bolt.Tx, platformName string, errata []Erratum) er
 				Erratum:      erratum,
 			})
 			if err != nil {
-				return xerrors.Errorf("db put error: %w", err)
+				return oops.With("cve_id", cveID).With("platform", platformName).Wrapf(err, "db put error")
 			}
 		}
 	}
@@ -191,18 +196,19 @@ func (vs *VulnSrc) commit(tx *bolt.Tx, platformName string, errata []Erratum) er
 }
 
 func (a *Alma) Put(tx *bolt.Tx, input PutInput) error {
+	eb := oops.With("cve_id", input.CveID).With("platform", input.PlatformName)
 	if err := a.PutVulnerabilityDetail(tx, input.CveID, source.ID, input.Vuln); err != nil {
-		return xerrors.Errorf("failed to save Alma vulnerability: %w", err)
+		return eb.Wrapf(err, "failed to save vulnerability detail")
 	}
 
 	// for optimization
 	if err := a.PutVulnerabilityID(tx, input.CveID); err != nil {
-		return xerrors.Errorf("failed to save the vulnerability ID: %w", err)
+		return eb.Wrapf(err, "failed to save vulnerability ID")
 	}
 
 	for pkgName, advisory := range input.Advisories {
 		if err := a.PutAdvisoryDetail(tx, input.CveID, pkgName, []string{input.PlatformName}, advisory); err != nil {
-			return xerrors.Errorf("failed to save Alma advisory: %w", err)
+			return eb.Wrapf(err, "failed to save advisory")
 		}
 	}
 	return nil
@@ -212,7 +218,7 @@ func (a *Alma) Get(release, pkgName string) ([]types.Advisory, error) {
 	bucket := fmt.Sprintf(platformFormat, release)
 	advisories, err := a.GetAdvisories(bucket, pkgName)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to get Alma advisories: %w", err)
+		return nil, oops.With("release", release).With("pkg_name", pkgName).Wrapf(err, "failed to get advisories")
 	}
 	return advisories, nil
 }

--- a/pkg/vulnsrc/alma/alma_test.go
+++ b/pkg/vulnsrc/alma/alma_test.go
@@ -112,7 +112,7 @@ func TestVulnSrc_Update(t *testing.T) {
 		{
 			name:    "sad path",
 			dir:     filepath.Join("testdata", "sad"),
-			wantErr: "failed to decode Alma erratum",
+			wantErr: "json decode error",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/vulnsrc/alpine/alpine.go
+++ b/pkg/vulnsrc/alpine/alpine.go
@@ -111,7 +111,7 @@ func (vs VulnSrc) saveSecFixes(tx *bolt.Tx, platform, pkgName string, secfixes m
 
 				// for optimization
 				if err := vs.dbc.PutVulnerabilityID(tx, cveID); err != nil {
-					return eb.With("vuln_id", cveID).Wrapf(err, "failed to save the vulnerability ID")
+					return eb.Wrapf(err, "failed to save the vulnerability ID")
 				}
 			}
 		}

--- a/pkg/vulnsrc/alpine/alpine.go
+++ b/pkg/vulnsrc/alpine/alpine.go
@@ -90,7 +90,6 @@ func (vs VulnSrc) save(advisories []advisory) error {
 }
 
 func (vs VulnSrc) saveSecFixes(tx *bolt.Tx, platform, pkgName string, secfixes map[string][]string) error {
-	eb := oops.With("platform", platform).With("package_name", pkgName)
 	for fixedVersion, vulnIDs := range secfixes {
 		advisory := types.Advisory{
 			FixedVersion: fixedVersion,
@@ -104,14 +103,13 @@ func (vs VulnSrc) saveSecFixes(tx *bolt.Tx, platform, pkgName string, secfixes m
 				if !strings.HasPrefix(cveID, "CVE-") {
 					continue
 				}
-				eb := eb.With("vuln_id", cveID)
 				if err := vs.dbc.PutAdvisoryDetail(tx, cveID, pkgName, []string{platform}, advisory); err != nil {
-					return eb.Wrapf(err, "failed to save advisory")
+					return oops.Wrapf(err, "failed to save advisory")
 				}
 
 				// for optimization
 				if err := vs.dbc.PutVulnerabilityID(tx, cveID); err != nil {
-					return eb.Wrapf(err, "failed to save the vulnerability ID")
+					return oops.Wrapf(err, "failed to save the vulnerability ID")
 				}
 			}
 		}
@@ -120,7 +118,7 @@ func (vs VulnSrc) saveSecFixes(tx *bolt.Tx, platform, pkgName string, secfixes m
 }
 
 func (vs VulnSrc) Get(release, pkgName string) ([]types.Advisory, error) {
-	eb := oops.In("alpine").With("release", release).With("package_name", pkgName)
+	eb := oops.In("alpine").With("release", release)
 	bucket := fmt.Sprintf(platformFormat, release)
 	advisories, err := vs.dbc.GetAdvisories(bucket, pkgName)
 	if err != nil {

--- a/pkg/vulnsrc/amazon/amazon.go
+++ b/pkg/vulnsrc/amazon/amazon.go
@@ -139,31 +139,30 @@ func (vs VulnSrc) commit(tx *bolt.Tx) error {
 					advisory := types.Advisory{
 						FixedVersion: utils.ConstructVersion(pkg.Epoch, pkg.Version, pkg.Release),
 					}
-					eb := eb.With("vuln_id", cveID).With("package_name", pkg.Name).With("fixed_version", advisory.FixedVersion)
-
+					eb := eb.With("vuln_id", cveID).With("package_name", pkg.Name).With("platform", platformName)
 					if err := vs.dbc.PutAdvisoryDetail(tx, cveID, pkg.Name, []string{platformName}, advisory); err != nil {
 						return eb.Wrapf(err, "failed to save advisory")
 					}
 
-					var references []string
-					for _, ref := range alas.References {
-						references = append(references, ref.Href)
-					}
+				}
+				var references []string
+				for _, ref := range alas.References {
+					references = append(references, ref.Href)
+				}
 
-					vuln := types.VulnerabilityDetail{
-						Severity:    severityFromPriority(alas.Severity),
-						References:  references,
-						Description: alas.Description,
-						Title:       "",
-					}
-					if err := vs.dbc.PutVulnerabilityDetail(tx, cveID, source.ID, vuln); err != nil {
-						return eb.Wrapf(err, "failed to save vulnerability detail")
-					}
+				vuln := types.VulnerabilityDetail{
+					Severity:    severityFromPriority(alas.Severity),
+					References:  references,
+					Description: alas.Description,
+					Title:       "",
+				}
+				if err := vs.dbc.PutVulnerabilityDetail(tx, cveID, source.ID, vuln); err != nil {
+					return eb.Wrapf(err, "failed to save vulnerability detail")
+				}
 
-					// for optimization
-					if err := vs.dbc.PutVulnerabilityID(tx, cveID); err != nil {
-						return eb.Wrapf(err, "failed to save vulnerability ID")
-					}
+				// for optimization
+				if err := vs.dbc.PutVulnerabilityID(tx, cveID); err != nil {
+					return eb.Wrapf(err, "failed to save vulnerability ID")
 				}
 			}
 		}

--- a/pkg/vulnsrc/amazon/amazon.go
+++ b/pkg/vulnsrc/amazon/amazon.go
@@ -139,7 +139,7 @@ func (vs VulnSrc) commit(tx *bolt.Tx) error {
 					advisory := types.Advisory{
 						FixedVersion: utils.ConstructVersion(pkg.Epoch, pkg.Version, pkg.Release),
 					}
-					eb = eb.With("cve_id", cveID).With("pkg_name", pkg.Name).With("fixed_version", advisory.FixedVersion)
+					eb := eb.With("vuln_id", cveID).With("package_name", pkg.Name).With("fixed_version", advisory.FixedVersion)
 
 					if err := vs.dbc.PutAdvisoryDetail(tx, cveID, pkg.Name, []string{platformName}, advisory); err != nil {
 						return eb.Wrapf(err, "failed to save advisory")
@@ -173,7 +173,7 @@ func (vs VulnSrc) commit(tx *bolt.Tx) error {
 
 // Get returns a security advisory
 func (vs VulnSrc) Get(version string, pkgName string) ([]types.Advisory, error) {
-	eb := oops.In("amazon").With("version", version).With("pkg_name", pkgName)
+	eb := oops.In("amazon").With("version", version).With("package_name", pkgName)
 	bucket := fmt.Sprintf(platformFormat, version)
 	advisories, err := vs.dbc.GetAdvisories(bucket, pkgName)
 	if err != nil {

--- a/pkg/vulnsrc/amazon/amazon.go
+++ b/pkg/vulnsrc/amazon/amazon.go
@@ -93,7 +93,6 @@ func (vs VulnSrc) Update(dir string) error {
 }
 
 func (vs *VulnSrc) walkFunc(r io.Reader, path string) error {
-	eb := oops.With("file_path", path)
 	paths := strings.Split(path, string(filepath.Separator))
 	if len(paths) < 2 {
 		return nil
@@ -103,7 +102,6 @@ func (vs *VulnSrc) walkFunc(r io.Reader, path string) error {
 		vs.logger.Warn("Unsupported Amazon version", "version", version)
 		return nil
 	}
-	eb = eb.With("version", version)
 
 	var alas ALAS
 	if err := json.NewDecoder(r).Decode(&alas); err != nil {

--- a/pkg/vulnsrc/amazon/amazon.go
+++ b/pkg/vulnsrc/amazon/amazon.go
@@ -107,7 +107,7 @@ func (vs *VulnSrc) walkFunc(r io.Reader, path string) error {
 
 	var alas ALAS
 	if err := json.NewDecoder(r).Decode(&alas); err != nil {
-		return eb.Wrapf(err, "json decode error")
+		return oops.With("file_path", path).With("version", version).Wrapf(err, "json decode error")
 	}
 
 	vs.advisories[version] = append(vs.advisories[version], alas)

--- a/pkg/vulnsrc/amazon/amazon_test.go
+++ b/pkg/vulnsrc/amazon/amazon_test.go
@@ -95,7 +95,7 @@ func TestVulnSrc_Update(t *testing.T) {
 		{
 			name:    "sad path",
 			dir:     filepath.Join("testdata", "sad"),
-			wantErr: "failed to decode Amazon JSON",
+			wantErr: "json decode error",
 		},
 		{
 			name:    "no such directory",
@@ -142,7 +142,7 @@ func TestVulnSrc_Get(t *testing.T) {
 			version:  "1",
 			pkgName:  "curl",
 			fixtures: []string{"testdata/fixtures/sad.yaml"},
-			wantErr:  "failed to unmarshal advisory JSON",
+			wantErr:  "json unmarshal error",
 		},
 	}
 

--- a/pkg/vulnsrc/aqua/aqua_test.go
+++ b/pkg/vulnsrc/aqua/aqua_test.go
@@ -100,7 +100,7 @@ func TestVulnSrc_Update(t *testing.T) {
 		{
 			name:    "sad path (failed to decode)",
 			dir:     filepath.Join("testdata", "sad"),
-			wantErr: "JSON decode error",
+			wantErr: "json decode error",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/vulnsrc/arch-linux/archlinux.go
+++ b/pkg/vulnsrc/arch-linux/archlinux.go
@@ -94,7 +94,7 @@ func (vs VulnSrc) commit(tx *bolt.Tx, avgs []ArchVulnGroup) error {
 			for _, pkg := range avg.Packages {
 				eb := oops.With("vuln_id", cveId).With("package_name", pkg)
 				if err := vs.dbc.PutAdvisoryDetail(tx, cveId, pkg, []string{platformName}, advisory); err != nil {
-					return eb.Wrapf(err, "failed to save advisory")
+					return eb.With("platform", platformName).Wrapf(err, "failed to save advisory")
 				}
 
 				vuln := types.VulnerabilityDetail{

--- a/pkg/vulnsrc/arch-linux/archlinux.go
+++ b/pkg/vulnsrc/arch-linux/archlinux.go
@@ -6,8 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/samber/oops"
 	bolt "go.etcd.io/bbolt"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy-db/pkg/db"
 	"github.com/aquasecurity/trivy-db/pkg/types"
@@ -44,23 +44,24 @@ func (vs VulnSrc) Name() types.SourceID {
 
 func (vs VulnSrc) Update(dir string) error {
 	rootDir := filepath.Join(dir, "vuln-list", archLinuxDir)
+	eb := oops.In("arch-linux").With("root_dir", rootDir)
 
 	var avgs []ArchVulnGroup
 
 	err := utils.FileWalk(rootDir, func(r io.Reader, path string) error {
 		var avg ArchVulnGroup
 		if err := json.NewDecoder(r).Decode(&avg); err != nil {
-			return xerrors.Errorf("failed to decode arch linux json (%s): %w", path, err)
+			return eb.Wrapf(err, "json decode error")
 		}
 		avgs = append(avgs, avg)
 		return nil
 	})
 	if err != nil {
-		return xerrors.Errorf("error in arch linux walk: %w", err)
+		return eb.Wrapf(err, "walk error")
 	}
 
 	if err = vs.save(avgs); err != nil {
-		return xerrors.Errorf("error in arch linux save: %w", err)
+		return eb.Wrapf(err, "save error")
 	}
 
 	return nil
@@ -69,15 +70,15 @@ func (vs VulnSrc) Update(dir string) error {
 func (vs VulnSrc) save(avgs []ArchVulnGroup) error {
 	err := vs.dbc.BatchUpdate(func(tx *bolt.Tx) error {
 		if err := vs.dbc.PutDataSource(tx, platformName, source); err != nil {
-			return xerrors.Errorf("failed to put data source: %w", err)
+			return oops.Wrapf(err, "failed to put data source")
 		}
 		if err := vs.commit(tx, avgs); err != nil {
-			return xerrors.Errorf("commit error: %w", err)
+			return oops.Wrapf(err, "commit error")
 		}
 		return nil
 	})
 	if err != nil {
-		return xerrors.Errorf("error in batch update: %w", err)
+		return oops.Wrapf(err, "batch update failed")
 	}
 	return nil
 }
@@ -91,20 +92,21 @@ func (vs VulnSrc) commit(tx *bolt.Tx, avgs []ArchVulnGroup) error {
 			}
 
 			for _, pkg := range avg.Packages {
+				eb := oops.With("cve_id", cveId).With("package_name", pkg)
 				if err := vs.dbc.PutAdvisoryDetail(tx, cveId, pkg, []string{platformName}, advisory); err != nil {
-					return xerrors.Errorf("failed to save arch linux advisory: %w", err)
+					return eb.Wrapf(err, "failed to save advisory")
 				}
 
 				vuln := types.VulnerabilityDetail{
 					Severity: convertSeverity(avg.Severity),
 				}
 				if err := vs.dbc.PutVulnerabilityDetail(tx, cveId, source.ID, vuln); err != nil {
-					return xerrors.Errorf("failed to save arch linux vulnerability: %w", err)
+					return eb.Wrapf(err, "failed to save vulnerability")
 				}
 
 				// for optimization
 				if err := vs.dbc.PutVulnerabilityID(tx, cveId); err != nil {
-					return xerrors.Errorf("failed to save the vulnerability ID: %w", err)
+					return eb.Wrapf(err, "failed to save the vulnerability ID")
 				}
 			}
 
@@ -114,9 +116,10 @@ func (vs VulnSrc) commit(tx *bolt.Tx, avgs []ArchVulnGroup) error {
 }
 
 func (vs VulnSrc) Get(pkgName string) ([]types.Advisory, error) {
+	eb := oops.In("arch-linux").With("pkg_name", pkgName)
 	advisories, err := vs.dbc.GetAdvisories(platformName, pkgName)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to get Arch Linux advisories: %w", err)
+		return nil, eb.Wrapf(err, "failed to get Arch Linux advisories")
 	}
 	return advisories, nil
 }

--- a/pkg/vulnsrc/arch-linux/archlinux.go
+++ b/pkg/vulnsrc/arch-linux/archlinux.go
@@ -92,7 +92,7 @@ func (vs VulnSrc) commit(tx *bolt.Tx, avgs []ArchVulnGroup) error {
 			}
 
 			for _, pkg := range avg.Packages {
-				eb := oops.With("cve_id", cveId).With("package_name", pkg)
+				eb := oops.With("vuln_id", cveId).With("package_name", pkg)
 				if err := vs.dbc.PutAdvisoryDetail(tx, cveId, pkg, []string{platformName}, advisory); err != nil {
 					return eb.Wrapf(err, "failed to save advisory")
 				}
@@ -116,7 +116,7 @@ func (vs VulnSrc) commit(tx *bolt.Tx, avgs []ArchVulnGroup) error {
 }
 
 func (vs VulnSrc) Get(pkgName string) ([]types.Advisory, error) {
-	eb := oops.In("arch-linux").With("pkg_name", pkgName)
+	eb := oops.In("arch-linux").With("package_name", pkgName)
 	advisories, err := vs.dbc.GetAdvisories(platformName, pkgName)
 	if err != nil {
 		return nil, eb.Wrapf(err, "failed to get Arch Linux advisories")

--- a/pkg/vulnsrc/arch-linux/archlinux.go
+++ b/pkg/vulnsrc/arch-linux/archlinux.go
@@ -93,9 +93,8 @@ func (vs VulnSrc) commit(tx *bolt.Tx, avgs []ArchVulnGroup) error {
 			eb := oops.With("vuln_id", cveId)
 
 			for _, pkg := range avg.Packages {
-				eb := eb.With("package_name", pkg).With("platform", platformName)
 				if err := vs.dbc.PutAdvisoryDetail(tx, cveId, pkg, []string{platformName}, advisory); err != nil {
-					return eb.With("platform", platformName).Wrapf(err, "failed to save advisory")
+					return eb.With("package_name", pkg).With("platform", platformName).Wrapf(err, "failed to save advisory")
 				}
 
 			}

--- a/pkg/vulnsrc/arch-linux/archlinux_test.go
+++ b/pkg/vulnsrc/arch-linux/archlinux_test.go
@@ -54,7 +54,7 @@ func TestVulnSrc_Update(t *testing.T) {
 		{
 			name:    "sad path",
 			dir:     filepath.Join("testdata", "sad"),
-			wantErr: "failed to decode arch linux json",
+			wantErr: "json decode error",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/vulnsrc/azure/azure.go
+++ b/pkg/vulnsrc/azure/azure.go
@@ -280,7 +280,7 @@ func (vs VulnSrc) commit(tx *bolt.Tx, platformName string, entries []Entry) erro
 			continue
 		}
 
-		eb := oops.With("cve_id", cveID).With("package_name", entry.PkgName).With("platform", platformName)
+		eb := oops.With("vuln_id", cveID).With("package_name", entry.PkgName).With("platform", platformName)
 		if err := vs.dbc.PutAdvisoryDetail(tx, cveID, entry.PkgName, []string{platformName}, advisory); err != nil {
 			return eb.Wrapf(err, "failed to save advisory detail")
 		}
@@ -297,7 +297,7 @@ func (vs VulnSrc) commit(tx *bolt.Tx, platformName string, entries []Entry) erro
 		}
 
 		if err := vs.dbc.PutVulnerabilityID(tx, cveID); err != nil {
-			return oops.Wrapf(err, "failed to save the vulnerability ID")
+			return eb.Wrapf(err, "failed to save the vulnerability ID")
 		}
 	}
 	return nil

--- a/pkg/vulnsrc/azure/azure.go
+++ b/pkg/vulnsrc/azure/azure.go
@@ -250,7 +250,6 @@ func (vs VulnSrc) save(majorVer string, entries []Entry) error {
 
 	err := vs.dbc.BatchUpdate(func(tx *bolt.Tx) error {
 		platformName := fmt.Sprintf(vs.platformFormat, majorVer)
-		eb := eb.With("platform", platformName)
 		if err := vs.dbc.PutDataSource(tx, platformName, vs.source); err != nil {
 			return eb.Wrapf(err, "failed to put data source")
 		}
@@ -279,9 +278,8 @@ func (vs VulnSrc) commit(tx *bolt.Tx, platformName string, entries []Entry) erro
 			continue
 		}
 
-		eb := oops.With("vuln_id", cveID).With("package_name", entry.PkgName).With("platform", platformName)
 		if err := vs.dbc.PutAdvisoryDetail(tx, cveID, entry.PkgName, []string{platformName}, advisory); err != nil {
-			return eb.Wrapf(err, "failed to save advisory detail")
+			return oops.Wrapf(err, "failed to save advisory detail")
 		}
 
 		severity, _ := types.NewSeverity(strings.ToUpper(entry.Metadata.Severity))
@@ -292,11 +290,11 @@ func (vs VulnSrc) commit(tx *bolt.Tx, platformName string, entries []Entry) erro
 			References:  []string{entry.Metadata.Reference.RefURL},
 		}
 		if err := vs.dbc.PutVulnerabilityDetail(tx, cveID, vs.source.ID, vuln); err != nil {
-			return eb.Wrapf(err, "failed to save vulnerability detail")
+			return oops.Wrapf(err, "failed to save vulnerability detail")
 		}
 
 		if err := vs.dbc.PutVulnerabilityID(tx, cveID); err != nil {
-			return eb.Wrapf(err, "failed to save the vulnerability ID")
+			return oops.Wrapf(err, "failed to save the vulnerability ID")
 		}
 	}
 	return nil

--- a/pkg/vulnsrc/azure/azure.go
+++ b/pkg/vulnsrc/azure/azure.go
@@ -225,7 +225,6 @@ func followTestRefs(test oval.RpmInfoTest, objects map[string]string, states map
 		return resolvedTest{}, eb.Errorf("invalid tests data, can't find ovalstate ref")
 	}
 
-	eb = eb.With("data_type", state.Evr.Datatype)
 	if state.Evr.Datatype != "evr_string" {
 		return resolvedTest{}, eb.With("data_type", state.Evr.Datatype).Wrapf(ErrNotSupported, "state data type")
 	}

--- a/pkg/vulnsrc/azure/azure.go
+++ b/pkg/vulnsrc/azure/azure.go
@@ -6,8 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/samber/oops"
 	bolt "go.etcd.io/bbolt"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy-db/pkg/db"
 	"github.com/aquasecurity/trivy-db/pkg/log"
@@ -30,7 +30,7 @@ const (
 )
 
 var (
-	ErrNotSupported = xerrors.New("format not supported")
+	ErrNotSupported = oops.Errorf("format not supported")
 
 	azureSource = types.DataSource{
 		ID:   vulnerability.AzureLinux,
@@ -93,20 +93,24 @@ func (vs VulnSrc) Name() types.SourceID {
 
 func (vs VulnSrc) Update(dir string) error {
 	rootDir := filepath.Join(dir, "vuln-list", vs.azureDir)
+	eb := oops.In(string(vs.source.ID)).With("root_dir", rootDir)
+
 	versions, err := os.ReadDir(rootDir)
 	if err != nil {
-		return xerrors.Errorf("unable to list directory entries (%s): %w", rootDir, err)
+		return eb.Wrapf(err, "unable to list directory entries")
 	}
 
 	for _, ver := range versions {
 		versionDir := filepath.Join(rootDir, ver.Name())
-		entries, err := vs.parseOVAL(filepath.Join(versionDir))
+		eb := eb.With("version_dir", versionDir)
+
+		entries, err := vs.parseOVAL(versionDir)
 		if err != nil {
-			return xerrors.Errorf("failed to parse CBL-Mariner OVAL: %w ", err)
+			return eb.Wrapf(err, "failed to parse OVAL")
 		}
 
 		if err = vs.save(ver.Name(), entries); err != nil {
-			return xerrors.Errorf("error in CBL-Mariner save: %w", err)
+			return eb.Wrapf(err, "save error")
 		}
 	}
 
@@ -119,12 +123,12 @@ func (vs VulnSrc) parseOVAL(dir string) ([]Entry, error) {
 	// Parse and resolve tests
 	tests, err := resolveTests(dir)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to resolve tests: %w", err)
+		return nil, oops.Wrapf(err, "failed to resolve tests")
 	}
 
 	defs, err := oval.ParseDefinitions(dir)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to parse definitions: %w", err)
+		return nil, oops.Wrapf(err, "failed to parse definitions")
 	}
 
 	return resolveDefinitions(defs, tests), nil
@@ -165,17 +169,17 @@ const (
 func resolveTests(dir string) (map[string]resolvedTest, error) {
 	objects, err := oval.ParseObjects(dir)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to parse objects: %w", err)
+		return nil, oops.Wrapf(err, "failed to parse objects")
 	}
 
 	states, err := oval.ParseStates(dir)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to parse states: %w", err)
+		return nil, oops.Wrapf(err, "failed to parse states")
 	}
 
 	tt, err := oval.ParseTests(dir)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to parse tests: %w", err)
+		return nil, oops.Wrapf(err, "failed to parse tests")
 	}
 
 	tests := map[string]resolvedTest{}
@@ -187,7 +191,7 @@ func resolveTests(dir string) (map[string]resolvedTest, error) {
 
 		t, err := followTestRefs(test, objects, states)
 		if err != nil {
-			return nil, xerrors.Errorf("unable to follow test refs: %w", err)
+			return nil, oops.Wrapf(err, "unable to follow test refs")
 		}
 
 		if t.Name != "" {
@@ -199,30 +203,31 @@ func resolveTests(dir string) (map[string]resolvedTest, error) {
 }
 
 func followTestRefs(test oval.RpmInfoTest, objects map[string]string, states map[string]oval.RpmInfoState) (resolvedTest, error) {
+	eb := oops.With("object_ref", test.Object.ObjectRef).With("state_ref", test.State.StateRef).With("test_ref", test.ID)
+
 	// Follow object ref
 	if test.Object.ObjectRef == "" {
-		return resolvedTest{}, xerrors.New("invalid test, no object ref")
+		return resolvedTest{}, eb.Errorf("invalid test, no object ref")
 	}
 
 	pkgName, ok := objects[test.Object.ObjectRef]
 	if !ok {
-		return resolvedTest{}, xerrors.Errorf("invalid test data, can't find object ref: %s, test ref: %s",
-			test.Object.ObjectRef, test.ID)
+		return resolvedTest{}, eb.Errorf("invalid test data, can't find object ref")
 	}
 
 	// Follow state ref
 	if test.State.StateRef == "" {
-		return resolvedTest{}, xerrors.New("invalid test, no state ref")
+		return resolvedTest{}, eb.Errorf("invalid test, no state ref")
 	}
 
 	state, ok := states[test.State.StateRef]
 	if !ok {
-		return resolvedTest{}, xerrors.Errorf("invalid tests data, can't find ovalstate ref %s, test ref: %s",
-			test.State.StateRef, test.ID)
+		return resolvedTest{}, eb.Errorf("invalid tests data, can't find ovalstate ref")
 	}
 
+	eb = eb.With("data_type", state.Evr.Datatype)
 	if state.Evr.Datatype != "evr_string" {
-		return resolvedTest{}, xerrors.Errorf("state data type (%s): %w", state.Evr.Datatype, ErrNotSupported)
+		return resolvedTest{}, eb.Wrapf(ErrNotSupported, "state data type")
 	}
 
 	// We don't currently support `greater than` operator
@@ -231,7 +236,7 @@ func followTestRefs(test oval.RpmInfoTest, objects map[string]string, states map
 	}
 
 	if state.Evr.Operation != string(lte) && state.Evr.Operation != string(lt) {
-		return resolvedTest{}, xerrors.Errorf("state operation (%s): %w", state.Evr.Operation, ErrNotSupported)
+		return resolvedTest{}, eb.Wrapf(ErrNotSupported, "state operation")
 	}
 
 	return resolvedTest{
@@ -242,19 +247,22 @@ func followTestRefs(test oval.RpmInfoTest, objects map[string]string, states map
 }
 
 func (vs VulnSrc) save(majorVer string, entries []Entry) error {
+	eb := oops.With("major_version", majorVer)
+
 	err := vs.dbc.BatchUpdate(func(tx *bolt.Tx) error {
 		platformName := fmt.Sprintf(vs.platformFormat, majorVer)
+		eb := eb.With("platform", platformName)
 		if err := vs.dbc.PutDataSource(tx, platformName, vs.source); err != nil {
-			return xerrors.Errorf("failed to put data source: %w", err)
+			return eb.Wrapf(err, "failed to put data source")
 		}
 
 		if err := vs.commit(tx, platformName, entries); err != nil {
-			return xerrors.Errorf("%s commit error: %w", platformName, err)
+			return eb.Wrapf(err, "failed to commit entries")
 		}
 		return nil
 	})
 	if err != nil {
-		return xerrors.Errorf("error in db batch update: %w", err)
+		return eb.Wrapf(err, "batch update failed")
 	}
 	return nil
 }
@@ -272,8 +280,9 @@ func (vs VulnSrc) commit(tx *bolt.Tx, platformName string, entries []Entry) erro
 			continue
 		}
 
+		eb := oops.With("cve_id", cveID).With("package_name", entry.PkgName).With("platform", platformName)
 		if err := vs.dbc.PutAdvisoryDetail(tx, cveID, entry.PkgName, []string{platformName}, advisory); err != nil {
-			return xerrors.Errorf("failed to save %s advisory detail: %w", platformName, err)
+			return eb.Wrapf(err, "failed to save advisory detail")
 		}
 
 		severity, _ := types.NewSeverity(strings.ToUpper(entry.Metadata.Severity))
@@ -284,21 +293,22 @@ func (vs VulnSrc) commit(tx *bolt.Tx, platformName string, entries []Entry) erro
 			References:  []string{entry.Metadata.Reference.RefURL},
 		}
 		if err := vs.dbc.PutVulnerabilityDetail(tx, cveID, vs.source.ID, vuln); err != nil {
-			return xerrors.Errorf("failed to save %s vulnerability detail: %w", platformName, err)
+			return eb.Wrapf(err, "failed to save vulnerability detail")
 		}
 
 		if err := vs.dbc.PutVulnerabilityID(tx, cveID); err != nil {
-			return xerrors.Errorf("failed to save the vulnerability ID: %w", err)
+			return oops.Wrapf(err, "failed to save the vulnerability ID")
 		}
 	}
 	return nil
 }
 
 func (vs VulnSrc) Get(release, pkgName string) ([]types.Advisory, error) {
+	eb := oops.In(string(vs.source.ID)).With("release", release).With("package_name", pkgName)
 	bucket := fmt.Sprintf(vs.platformFormat, release)
 	advisories, err := vs.dbc.GetAdvisories(bucket, pkgName)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to get %s advisories: %w", bucket, err)
+		return nil, eb.Wrapf(err, "failed to get advisories")
 	}
 	return advisories, nil
 }

--- a/pkg/vulnsrc/azure/azure.go
+++ b/pkg/vulnsrc/azure/azure.go
@@ -236,7 +236,7 @@ func followTestRefs(test oval.RpmInfoTest, objects map[string]string, states map
 	}
 
 	if state.Evr.Operation != string(lte) && state.Evr.Operation != string(lt) {
-		return resolvedTest{}, eb.Wrapf(ErrNotSupported, "state operation")
+		return resolvedTest{}, eb.With("operation", state.Evr.Operation).Wrapf(ErrNotSupported, "state operation")
 	}
 
 	return resolvedTest{

--- a/pkg/vulnsrc/azure/azure.go
+++ b/pkg/vulnsrc/azure/azure.go
@@ -227,7 +227,7 @@ func followTestRefs(test oval.RpmInfoTest, objects map[string]string, states map
 
 	eb = eb.With("data_type", state.Evr.Datatype)
 	if state.Evr.Datatype != "evr_string" {
-		return resolvedTest{}, eb.Wrapf(ErrNotSupported, "state data type")
+		return resolvedTest{}, eb.With("data_type", state.Evr.Datatype).Wrapf(ErrNotSupported, "state data type")
 	}
 
 	// We don't currently support `greater than` operator

--- a/pkg/vulnsrc/azure/azure_test.go
+++ b/pkg/vulnsrc/azure/azure_test.go
@@ -393,7 +393,7 @@ func TestVulnSrc_Get(t *testing.T) {
 			release:  "1.0",
 			pkgName:  "clamav",
 			fixtures: []string{"testdata/fixtures/broken.yaml"},
-			wantErr:  "failed to unmarshal advisory JSON",
+			wantErr:  "json unmarshal error",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/vulnsrc/azure/oval/oval.go
+++ b/pkg/vulnsrc/azure/oval/oval.go
@@ -23,7 +23,7 @@ func ParseDefinitions(dir string) ([]Definition, error) {
 	err := utils.FileWalk(dir, func(r io.Reader, path string) error {
 		var def Definition
 		if err := json.NewDecoder(r).Decode(&def); err != nil {
-			return eb.With("path", path).Wrapf(err, "failed to decode")
+			return eb.With("file_path", path).Wrapf(err, "failed to decode")
 		}
 		defs = append(defs, def)
 		return nil

--- a/pkg/vulnsrc/azure/oval/oval.go
+++ b/pkg/vulnsrc/azure/oval/oval.go
@@ -5,15 +5,17 @@ import (
 	"io"
 	"path/filepath"
 
-	"golang.org/x/xerrors"
+	"github.com/samber/oops"
 
 	"github.com/aquasecurity/trivy-db/pkg/utils"
 )
 
 func ParseDefinitions(dir string) ([]Definition, error) {
 	dir = filepath.Join(dir, "definitions")
+	eb := oops.In("azure").Tags("oval").With("dir", dir)
+
 	if exists, _ := utils.Exists(dir); !exists {
-		return nil, xerrors.Errorf("no definitions dir")
+		return nil, eb.Errorf("no definitions dir")
 	}
 
 	var defs []Definition
@@ -21,30 +23,32 @@ func ParseDefinitions(dir string) ([]Definition, error) {
 	err := utils.FileWalk(dir, func(r io.Reader, path string) error {
 		var def Definition
 		if err := json.NewDecoder(r).Decode(&def); err != nil {
-			return xerrors.Errorf("failed to decode %s: %w", path, err)
+			return eb.With("path", path).Wrapf(err, "failed to decode")
 		}
 		defs = append(defs, def)
 		return nil
 	})
 	if err != nil {
-		return nil, xerrors.Errorf("Azure Linux OVAL walk error: %w", err)
+		return nil, eb.Wrapf(err, "walk error")
 	}
 
 	return defs, nil
 }
 
 func ParseTests(dir string) (Tests, error) {
+	eb := oops.In("azure").Tags("oval").With("dir", dir)
 	var tests Tests
 	if err := utils.UnmarshalJSONFile(&tests, filepath.Join(dir, "tests", "tests.json")); err != nil {
-		return tests, xerrors.Errorf("failed to unmarshal tests: %w", err)
+		return tests, eb.Wrapf(err, "json unmarshal error")
 	}
 	return tests, nil
 }
 
 func ParseObjects(dir string) (map[string]string, error) {
+	eb := oops.In("azure").Tags("oval").With("dir", dir)
 	var objects Objects
 	if err := utils.UnmarshalJSONFile(&objects, filepath.Join(dir, "objects", "objects.json")); err != nil {
-		return nil, xerrors.Errorf("failed to unmarshal objects: %w", err)
+		return nil, eb.Wrapf(err, "json unmarshal error")
 	}
 	objs := map[string]string{}
 	for _, obj := range objects.RpminfoObjects {
@@ -54,9 +58,10 @@ func ParseObjects(dir string) (map[string]string, error) {
 }
 
 func ParseStates(dir string) (map[string]RpmInfoState, error) {
+	eb := oops.In("azure").Tags("oval").With("dir", dir)
 	var ss States
 	if err := utils.UnmarshalJSONFile(&ss, filepath.Join(dir, "states", "states.json")); err != nil {
-		return nil, xerrors.Errorf("failed to unmarshal states: %w", err)
+		return nil, eb.Wrapf(err, "json unmarshal error")
 	}
 
 	states := map[string]RpmInfoState{}

--- a/pkg/vulnsrc/bitnami/bitnami.go
+++ b/pkg/vulnsrc/bitnami/bitnami.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"golang.org/x/xerrors"
+	"github.com/samber/oops"
 
 	"github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/osv"
@@ -35,7 +35,7 @@ type DatabaseSpecific struct {
 func (t *transformer) TransformAdvisories(advs []osv.Advisory, entry osv.Entry) ([]osv.Advisory, error) {
 	var specific DatabaseSpecific
 	if err := json.Unmarshal(entry.DatabaseSpecific, &specific); err != nil {
-		return nil, xerrors.Errorf("JSON decode error: %w", err)
+		return nil, oops.Tags("bitnami").With("vuln_id", entry.ID).With("aliases", entry.Aliases).Wrapf(err, "json decode error")
 	}
 
 	severity := convertSeverity(specific.Severity)

--- a/pkg/vulnsrc/bitnami/bitnami_test.go
+++ b/pkg/vulnsrc/bitnami/bitnami_test.go
@@ -91,7 +91,7 @@ func TestVulnSrc_Update(t *testing.T) {
 		{
 			name:    "sad path",
 			dir:     filepath.Join("testdata", "sad"),
-			wantErr: "JSON decode error",
+			wantErr: "json decode error",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/vulnsrc/bundler/bundler.go
+++ b/pkg/vulnsrc/bundler/bundler.go
@@ -6,8 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/samber/oops"
 	bolt "go.etcd.io/bbolt"
-	"golang.org/x/xerrors"
 	"gopkg.in/yaml.v2"
 
 	"github.com/aquasecurity/trivy-db/pkg/db"
@@ -70,8 +70,9 @@ func (vs VulnSrc) Name() types.SourceID {
 
 func (vs VulnSrc) Update(dir string) error {
 	repoPath := filepath.Join(dir, bundlerDir)
+	eb := oops.In("bundler").With("repo_path", repoPath)
 	if err := vs.update(repoPath); err != nil {
-		return xerrors.Errorf("failed to update bundler vulnerabilities: %w", err)
+		return eb.Wrapf(err, "update error")
 	}
 	return nil
 }
@@ -81,16 +82,16 @@ func (vs VulnSrc) update(repoPath string) error {
 
 	err := vs.dbc.BatchUpdate(func(tx *bolt.Tx) error {
 		if err := vs.dbc.PutDataSource(tx, bucketName, source); err != nil {
-			return xerrors.Errorf("failed to put data source: %w", err)
+			return oops.Wrapf(err, "failed to put data source")
 		}
 
 		if err := vs.walk(tx, root); err != nil {
-			return xerrors.Errorf("failed to walk ruby advisories: %w", err)
+			return oops.Wrapf(err, "walk error")
 		}
 		return nil
 	})
 	if err != nil {
-		return xerrors.Errorf("batch update failed: %w", err)
+		return oops.Wrapf(err, "batch update failed")
 	}
 	return nil
 }
@@ -112,15 +113,17 @@ func (vs VulnSrc) walkFunc(err error, info os.FileInfo, path string, tx *bolt.Tx
 		return nil
 	}
 
+	eb := oops.With("file_path", path)
+
 	buf, err := os.ReadFile(path)
 	if err != nil {
-		return xerrors.Errorf("failed to read a file: %w", err)
+		return eb.Wrapf(err, "file read error")
 	}
 
 	advisory := RawAdvisory{}
 	err = yaml.Unmarshal(buf, &advisory)
 	if err != nil {
-		return xerrors.Errorf("failed to unmarshal YAML: %w", err)
+		return eb.Wrapf(err, "yaml unmarshal error")
 	}
 	if strings.Contains(strings.ToLower(advisory.Url), "osvdb.org") {
 		advisory.Url = ""
@@ -135,6 +138,8 @@ func (vs VulnSrc) walkFunc(err error, info os.FileInfo, path string, tx *bolt.Tx
 		return nil
 	}
 
+	eb = eb.With("vuln_id", vulnerabilityID)
+
 	// for detecting vulnerabilities
 	a := types.Advisory{
 		PatchedVersions:    advisory.PatchedVersions,
@@ -143,7 +148,7 @@ func (vs VulnSrc) walkFunc(err error, info os.FileInfo, path string, tx *bolt.Tx
 
 	err = vs.dbc.PutAdvisoryDetail(tx, vulnerabilityID, advisory.Gem, []string{bucketName}, a)
 	if err != nil {
-		return xerrors.Errorf("failed to save ruby advisory: %w", err)
+		return eb.Wrapf(err, "failed to save advisory")
 	}
 
 	// for displaying vulnerability detail
@@ -156,12 +161,12 @@ func (vs VulnSrc) walkFunc(err error, info os.FileInfo, path string, tx *bolt.Tx
 	}
 
 	if err = vs.dbc.PutVulnerabilityDetail(tx, vulnerabilityID, source.ID, vuln); err != nil {
-		return xerrors.Errorf("failed to save ruby vulnerability detail: %w", err)
+		return eb.Wrapf(err, "failed to save vulnerability detail")
 	}
 
 	// for optimization
 	if err = vs.dbc.PutVulnerabilityID(tx, vulnerabilityID); err != nil {
-		return xerrors.Errorf("failed to save the vulnerability ID: %w", err)
+		return eb.Wrapf(err, "failed to save vulnerability ID")
 	}
 	return nil
 }

--- a/pkg/vulnsrc/bundler/bundler.go
+++ b/pkg/vulnsrc/bundler/bundler.go
@@ -146,9 +146,8 @@ func (vs VulnSrc) walkFunc(err error, info os.FileInfo, path string, tx *bolt.Tx
 		UnaffectedVersions: advisory.UnaffectedVersions,
 	}
 
-	err = vs.dbc.PutAdvisoryDetail(tx, vulnerabilityID, advisory.Gem, []string{bucketName}, a)
-	if err != nil {
-		return eb.Wrapf(err, "failed to save advisory")
+	if err = vs.dbc.PutAdvisoryDetail(tx, vulnerabilityID, advisory.Gem, []string{bucketName}, a); err != nil {
+		return eb.With("package_name", advisory.Gem).With("bucket_name", bucketName).Wrapf(err, "failed to save advisory")
 	}
 
 	// for displaying vulnerability detail

--- a/pkg/vulnsrc/bundler/bundler_test.go
+++ b/pkg/vulnsrc/bundler/bundler_test.go
@@ -54,7 +54,7 @@ func TestVulnSrc_Update(t *testing.T) {
 		{
 			name:    "sad path",
 			dir:     filepath.Join("testdata", "sad"),
-			wantErr: "failed to unmarshal YAML",
+			wantErr: "yaml unmarshal error",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/vulnsrc/chainguard/chainguard.go
+++ b/pkg/vulnsrc/chainguard/chainguard.go
@@ -6,8 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/samber/oops"
 	bolt "go.etcd.io/bbolt"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy-db/pkg/db"
 	"github.com/aquasecurity/trivy-db/pkg/types"
@@ -44,21 +44,25 @@ func (vs VulnSrc) Name() types.SourceID {
 
 func (vs VulnSrc) Update(dir string) error {
 	rootDir := filepath.Join(dir, "vuln-list", chainguardDir)
+	eb := oops.With("root_dir", rootDir)
+
 	var advisories []advisory
 	err := utils.FileWalk(rootDir, func(r io.Reader, path string) error {
+		eb := eb.With("file_path", path)
+
 		var advisory advisory
 		if err := json.NewDecoder(r).Decode(&advisory); err != nil {
-			return xerrors.Errorf("failed to decode Chainguard advisory: %w", err)
+			return eb.Wrapf(err, "json decode error")
 		}
 		advisories = append(advisories, advisory)
 		return nil
 	})
 	if err != nil {
-		return xerrors.Errorf("error in Chainguard walk: %w", err)
+		return eb.Wrapf(err, "walk error")
 	}
 
 	if err = vs.save(advisories); err != nil {
-		return xerrors.Errorf("error in Chainguard save: %w", err)
+		return eb.Wrapf(err, "save error")
 	}
 
 	return nil
@@ -69,16 +73,16 @@ func (vs VulnSrc) save(advisories []advisory) error {
 		for _, adv := range advisories {
 			bucket := distroName
 			if err := vs.dbc.PutDataSource(tx, bucket, source); err != nil {
-				return xerrors.Errorf("failed to put data source: %w", err)
+				return oops.Wrapf(err, "failed to put data source")
 			}
 			if err := vs.saveSecFixes(tx, distroName, adv.PkgName, adv.Secfixes); err != nil {
-				return err
+				return oops.Wrapf(err, "save sec fixes error")
 			}
 		}
 		return nil
 	})
 	if err != nil {
-		return xerrors.Errorf("error in db batch update: %w", err)
+		return oops.Wrapf(err, "db batch update error")
 	}
 	return nil
 }
@@ -93,14 +97,15 @@ func (vs VulnSrc) saveSecFixes(tx *bolt.Tx, platform, pkgName string, secfixes m
 			if !strings.HasPrefix(vulnID, "CVE-") {
 				continue
 			}
+			eb := oops.With("platform", platform).With("package_name", pkgName).With("vuln_id", vulnID)
 
 			if err := vs.dbc.PutAdvisoryDetail(tx, vulnID, pkgName, []string{platform}, advisory); err != nil {
-				return xerrors.Errorf("failed to save Chainguard advisory: %w", err)
+				return eb.Wrapf(err, "failed to save advisory")
 			}
 
 			// for optimization
 			if err := vs.dbc.PutVulnerabilityID(tx, vulnID); err != nil {
-				return xerrors.Errorf("failed to save the vulnerability ID: %w", err)
+				return eb.Wrapf(err, "failed to save the vulnerability ID")
 			}
 		}
 	}
@@ -109,10 +114,11 @@ func (vs VulnSrc) saveSecFixes(tx *bolt.Tx, platform, pkgName string, secfixes m
 }
 
 func (vs VulnSrc) Get(_, pkgName string) ([]types.Advisory, error) {
+	eb := oops.In("chainguard").With("package_name", pkgName)
 	bucket := distroName
 	advisories, err := vs.dbc.GetAdvisories(bucket, pkgName)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to get Chainguard advisories: %w", err)
+		return nil, eb.Wrapf(err, "failed to get advisories")
 	}
 	return advisories, nil
 }

--- a/pkg/vulnsrc/chainguard/chainguard.go
+++ b/pkg/vulnsrc/chainguard/chainguard.go
@@ -62,7 +62,7 @@ func (vs VulnSrc) Update(dir string) error {
 	}
 
 	if err = vs.save(advisories); err != nil {
-		return eb.Wrapf(err, "save error")
+		return eb.Wrapf(err, "save advisories error")
 	}
 
 	return nil

--- a/pkg/vulnsrc/chainguard/chainguard.go
+++ b/pkg/vulnsrc/chainguard/chainguard.go
@@ -97,15 +97,14 @@ func (vs VulnSrc) saveSecFixes(tx *bolt.Tx, platform, pkgName string, secfixes m
 			if !strings.HasPrefix(vulnID, "CVE-") {
 				continue
 			}
-			eb := oops.With("platform", platform).With("package_name", pkgName).With("vuln_id", vulnID)
 
 			if err := vs.dbc.PutAdvisoryDetail(tx, vulnID, pkgName, []string{platform}, advisory); err != nil {
-				return eb.Wrapf(err, "failed to save advisory")
+				return oops.Wrapf(err, "failed to save advisory")
 			}
 
 			// for optimization
 			if err := vs.dbc.PutVulnerabilityID(tx, vulnID); err != nil {
-				return eb.Wrapf(err, "failed to save the vulnerability ID")
+				return oops.Wrapf(err, "failed to save the vulnerability ID")
 			}
 		}
 	}
@@ -114,7 +113,7 @@ func (vs VulnSrc) saveSecFixes(tx *bolt.Tx, platform, pkgName string, secfixes m
 }
 
 func (vs VulnSrc) Get(_, pkgName string) ([]types.Advisory, error) {
-	eb := oops.In("chainguard").With("package_name", pkgName)
+	eb := oops.In("chainguard")
 	bucket := distroName
 	advisories, err := vs.dbc.GetAdvisories(bucket, pkgName)
 	if err != nil {

--- a/pkg/vulnsrc/chainguard/chainguard_test.go
+++ b/pkg/vulnsrc/chainguard/chainguard_test.go
@@ -46,7 +46,7 @@ func TestVulnSrc_Update(t *testing.T) {
 		{
 			name:    "sad path",
 			dir:     filepath.Join("testdata", "sad"),
-			wantErr: "failed to decode Chainguard advisory",
+			wantErr: "json decode error",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/vulnsrc/composer/composer.go
+++ b/pkg/vulnsrc/composer/composer.go
@@ -88,8 +88,7 @@ func (vs VulnSrc) walk(tx *bolt.Tx, root string) error {
 		eb := oops.With("file_path", path)
 		if err != nil {
 			return eb.Wrapf(err, "walk error")
-		}
-		if info.IsDir() || !strings.HasPrefix(info.Name(), "CVE-") {
+		} else if info.IsDir() || !strings.HasPrefix(info.Name(), "CVE-") {
 			return nil
 		}
 
@@ -99,8 +98,7 @@ func (vs VulnSrc) walk(tx *bolt.Tx, root string) error {
 		}
 
 		advisory := RawAdvisory{}
-		err = yaml.Unmarshal(buf, &advisory)
-		if err != nil {
+		if err := yaml.Unmarshal(buf, &advisory); err != nil {
 			return eb.Wrapf(err, "yaml unmarshal error")
 		}
 
@@ -123,10 +121,7 @@ func (vs VulnSrc) walk(tx *bolt.Tx, root string) error {
 		pkgName := strings.TrimPrefix(advisory.Reference, "composer://")
 		pkgName = vulnerability.NormalizePkgName(vulnerability.Composer, pkgName)
 
-		eb = eb.With("vuln_id", vulnID).With("package_name", pkgName)
-
-		err = vs.dbc.PutAdvisoryDetail(tx, vulnID, pkgName, []string{bucketName}, a)
-		if err != nil {
+		if err = vs.dbc.PutAdvisoryDetail(tx, vulnID, pkgName, []string{bucketName}, a); err != nil {
 			return eb.Wrapf(err, "failed to save advisory")
 		}
 

--- a/pkg/vulnsrc/composer/composer.go
+++ b/pkg/vulnsrc/composer/composer.go
@@ -85,13 +85,13 @@ func (vs VulnSrc) update(repoPath string) error {
 
 func (vs VulnSrc) walk(tx *bolt.Tx, root string) error {
 	return filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		eb := oops.With("file_path", path)
 		if err != nil {
-			return oops.Wrapf(err, "walk error")
+			return eb.Wrapf(err, "walk error")
 		}
 		if info.IsDir() || !strings.HasPrefix(info.Name(), "CVE-") {
 			return nil
 		}
-		eb := oops.With("file_path", path)
 
 		buf, err := os.ReadFile(path)
 		if err != nil {
@@ -123,7 +123,7 @@ func (vs VulnSrc) walk(tx *bolt.Tx, root string) error {
 		pkgName := strings.TrimPrefix(advisory.Reference, "composer://")
 		pkgName = vulnerability.NormalizePkgName(vulnerability.Composer, pkgName)
 
-		eb = eb.With("vuln_id", vulnID).With("pkg_name", pkgName)
+		eb = eb.With("vuln_id", vulnID).With("package_name", pkgName)
 
 		err = vs.dbc.PutAdvisoryDetail(tx, vulnID, pkgName, []string{bucketName}, a)
 		if err != nil {

--- a/pkg/vulnsrc/composer/composer.go
+++ b/pkg/vulnsrc/composer/composer.go
@@ -5,8 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/samber/oops"
 	bolt "go.etcd.io/bbolt"
-	"golang.org/x/xerrors"
 	"gopkg.in/yaml.v2"
 
 	"github.com/aquasecurity/trivy-db/pkg/db"
@@ -60,8 +60,9 @@ func (vs VulnSrc) Name() types.SourceID {
 
 func (vs VulnSrc) Update(dir string) (err error) {
 	repoPath := filepath.Join(dir, composerDir)
+	eb := oops.In("composer").With("repo_path", repoPath)
 	if err := vs.update(repoPath); err != nil {
-		return xerrors.Errorf("failed to update compose vulnerabilities: %w", err)
+		return eb.Wrapf(err, "update error")
 	}
 	return nil
 }
@@ -69,15 +70,15 @@ func (vs VulnSrc) Update(dir string) (err error) {
 func (vs VulnSrc) update(repoPath string) error {
 	err := vs.dbc.BatchUpdate(func(tx *bolt.Tx) error {
 		if err := vs.dbc.PutDataSource(tx, bucketName, source); err != nil {
-			return xerrors.Errorf("failed to put data source: %w", err)
+			return oops.Wrapf(err, "failed to put data source")
 		}
 		if err := vs.walk(tx, repoPath); err != nil {
-			return xerrors.Errorf("failed to walk compose advisories: %w", err)
+			return oops.Wrapf(err, "walk error")
 		}
 		return nil
 	})
 	if err != nil {
-		return xerrors.Errorf("batch update failed: %w", err)
+		return oops.Wrapf(err, "batch update failed")
 	}
 	return nil
 }
@@ -85,20 +86,22 @@ func (vs VulnSrc) update(repoPath string) error {
 func (vs VulnSrc) walk(tx *bolt.Tx, root string) error {
 	return filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
-			return err
+			return oops.Wrapf(err, "walk error")
 		}
 		if info.IsDir() || !strings.HasPrefix(info.Name(), "CVE-") {
 			return nil
 		}
+		eb := oops.With("file_path", path)
+
 		buf, err := os.ReadFile(path)
 		if err != nil {
-			return xerrors.Errorf("failed to read a file: %w", err)
+			return eb.Wrapf(err, "file read error")
 		}
 
 		advisory := RawAdvisory{}
 		err = yaml.Unmarshal(buf, &advisory)
 		if err != nil {
-			return xerrors.Errorf("failed to unmarshal YAML: %w", err)
+			return eb.Wrapf(err, "yaml unmarshal error")
 		}
 
 		// for detecting vulnerabilities
@@ -120,9 +123,11 @@ func (vs VulnSrc) walk(tx *bolt.Tx, root string) error {
 		pkgName := strings.TrimPrefix(advisory.Reference, "composer://")
 		pkgName = vulnerability.NormalizePkgName(vulnerability.Composer, pkgName)
 
+		eb = eb.With("vuln_id", vulnID).With("pkg_name", pkgName)
+
 		err = vs.dbc.PutAdvisoryDetail(tx, vulnID, pkgName, []string{bucketName}, a)
 		if err != nil {
-			return xerrors.Errorf("failed to save php advisory: %w", err)
+			return eb.Wrapf(err, "failed to save advisory")
 		}
 
 		// for displaying vulnerability detail
@@ -132,12 +137,12 @@ func (vs VulnSrc) walk(tx *bolt.Tx, root string) error {
 			Title:      advisory.Title,
 		}
 		if err = vs.dbc.PutVulnerabilityDetail(tx, vulnID, source.ID, vuln); err != nil {
-			return xerrors.Errorf("failed to save php vulnerability detail: %w", err)
+			return eb.Wrapf(err, "failed to save vulnerability detail")
 		}
 
 		// for optimization
 		if err = vs.dbc.PutVulnerabilityID(tx, vulnID); err != nil {
-			return xerrors.Errorf("failed to save the vulnerability ID: %w", err)
+			return eb.Wrapf(err, "failed to save vulnerability ID")
 		}
 		return nil
 	})

--- a/pkg/vulnsrc/composer/composer_test.go
+++ b/pkg/vulnsrc/composer/composer_test.go
@@ -58,7 +58,7 @@ func TestVulnSrc_Update(t *testing.T) {
 		{
 			name:    "sad path (failed to decode)",
 			dir:     filepath.Join("testdata", "sad"),
-			wantErr: "failed to unmarshal YAML",
+			wantErr: "yaml unmarshal error",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/vulnsrc/debian/debian.go
+++ b/pkg/vulnsrc/debian/debian.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 
 	debver "github.com/knqyf263/go-deb-version"
+	"github.com/samber/oops"
 	bolt "go.etcd.io/bbolt"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy-db/pkg/db"
 	"github.com/aquasecurity/trivy-db/pkg/log"
@@ -118,12 +118,13 @@ func (vs VulnSrc) Name() types.SourceID {
 }
 
 func (vs VulnSrc) Update(dir string) error {
+	eb := oops.In("debian")
 	if err := vs.parse(dir); err != nil {
-		return xerrors.Errorf("parse error: %w", err)
+		return eb.Wrapf(err, "parse error")
 	}
 
 	if err := vs.save(); err != nil {
-		return xerrors.Errorf("save error: %w", err)
+		return eb.Wrapf(err, "save error")
 	}
 
 	return nil
@@ -131,55 +132,58 @@ func (vs VulnSrc) Update(dir string) error {
 
 func (vs VulnSrc) parse(dir string) error {
 	rootDir := filepath.Join(dir, debianDir, "tracker")
+	eb := oops.With("root_dir", rootDir)
 
 	// Parse distributions.json
 	if err := vs.parseDistributions(rootDir); err != nil {
-		return xerrors.Errorf("distributions error: %w", err)
+		return eb.Wrapf(err, "distributions error")
 	}
 
 	// Parse source/**.json
 	if err := vs.parseSources(filepath.Join(rootDir, sourcesDir)); err != nil {
-		return xerrors.Errorf("source parse error: %w", err)
+		return eb.Wrapf(err, "source parse error")
 	}
 
 	// Parse updates-source/**.json
 	if err := vs.parseSources(filepath.Join(rootDir, updateSourcesDir)); err != nil {
-		return xerrors.Errorf("updates-source parse error: %w", err)
+		return eb.Wrapf(err, "updates-source parse error")
 	}
 
 	// Parse CVE/*.json
 	if err := vs.parseCVE(rootDir); err != nil {
-		return xerrors.Errorf("CVE error: %w", err)
+		return eb.Wrapf(err, "CVE error")
 	}
 
 	// Parse DLA/*.json
 	if err := vs.parseDLA(rootDir); err != nil {
-		return xerrors.Errorf("DLA error: %w", err)
+		return eb.Wrapf(err, "DLA error")
 	}
 
 	// Parse DSA/*.json
 	if err := vs.parseDSA(rootDir); err != nil {
-		return xerrors.Errorf("DSA error: %w", err)
+		return eb.Wrapf(err, "DSA error")
 	}
 
 	return nil
 }
 
 func (vs VulnSrc) parseBug(dir string, fn func(bug) error) error {
+	eb := oops.With("dir", dir)
 	err := utils.FileWalk(dir, func(r io.Reader, path string) error {
+		eb = eb.With("file_path", path)
 		var bg bug
 		if err := json.NewDecoder(r).Decode(&bg); err != nil {
-			return xerrors.Errorf("json decode error: %w", err)
+			return eb.Wrapf(err, "json decode error")
 		}
 
 		if err := fn(bg); err != nil {
-			return xerrors.Errorf("parse debian bug error: %w", err)
+			return eb.Wrapf(err, "parse debian bug error")
 		}
 		return nil
 	})
 
 	if err != nil {
-		return xerrors.Errorf("walk error: %w", err)
+		return eb.Wrapf(err, "walk error")
 	}
 	return nil
 }
@@ -257,7 +261,7 @@ func (vs VulnSrc) parseCVE(dir string) error {
 		return nil
 	})
 	if err != nil {
-		return xerrors.Errorf("CVE parse error: %w", err)
+		return oops.Wrapf(err, "CVE parse error")
 	}
 	return nil
 }
@@ -265,7 +269,7 @@ func (vs VulnSrc) parseCVE(dir string) error {
 func (vs VulnSrc) parseDLA(dir string) error {
 	vs.logger.Info("Parsing DLA JSON files...")
 	if err := vs.parseAdvisory(filepath.Join(dir, dlaDir)); err != nil {
-		return xerrors.Errorf("DLA parse error: %w", err)
+		return oops.Wrapf(err, "DLA parse error")
 	}
 	return nil
 }
@@ -273,7 +277,7 @@ func (vs VulnSrc) parseDLA(dir string) error {
 func (vs VulnSrc) parseDSA(dir string) error {
 	vs.logger.Info("Parsing DSA JSON files...")
 	if err := vs.parseAdvisory(filepath.Join(dir, dsaDir)); err != nil {
-		return xerrors.Errorf("DSA parse error: %w", err)
+		return oops.Wrapf(err, "DSA parse error")
 	}
 	return nil
 }
@@ -310,6 +314,7 @@ func (vs VulnSrc) parseAdvisory(dir string) error {
 					pkgName:  ann.Package,
 					vulnID:   vulnID,
 				}
+				eb := oops.With("vuln_id", vulnID).With("pkg_name", ann.Package).With("code_name", ann.Release)
 
 				// Skip not-affected, removed or undetermined advisories
 				if slices.Contains(skipStatuses, ann.Kind) {
@@ -323,7 +328,7 @@ func (vs VulnSrc) parseAdvisory(dir string) error {
 					// We assume that the first fix was insufficient and the next advisory fixed it correctly.
 					res, err := compareVersions(ann.Version, adv.FixedVersion)
 					if err != nil {
-						return xerrors.Errorf("version error %s: %w", advisoryID, err)
+						return eb.Wrapf(err, "version error")
 					}
 
 					// Replace the fixed version with the newer version.
@@ -353,7 +358,7 @@ func (vs VulnSrc) save() error {
 		return vs.commit(tx)
 	})
 	if err != nil {
-		return xerrors.Errorf("batch update error: %w", err)
+		return oops.Wrapf(err, "batch update error")
 	}
 	vs.logger.Info("Saved DB")
 	return nil
@@ -380,6 +385,7 @@ func (vs VulnSrc) commit(tx *bolt.Tx) error {
 				pkgName:  pkgName,
 				vulnID:   cveID,
 			}
+			eb := oops.With("sid", sidVer).With("pkg_name", pkgName).With("cve_id", cveID).With("code_name", code)
 
 			// Skip if the advisory is stated as "not-affected" for the specific distribution.
 			if _, ok := vs.notAffected[bkt]; ok {
@@ -413,7 +419,7 @@ func (vs VulnSrc) commit(tx *bolt.Tx) error {
 			// Check if the release has the fixed version
 			fixed, err := hasFixedVersion(sidVer, codeVer)
 			if err != nil {
-				return xerrors.Errorf("version error: %w", err)
+				return eb.Wrapf(err, "version error")
 			}
 
 			if fixed {
@@ -427,7 +433,7 @@ func (vs VulnSrc) commit(tx *bolt.Tx) error {
 
 			bkt.vulnID = cveID
 			if err = vs.putAdvisory(tx, bkt, adv); err != nil {
-				return xerrors.Errorf("put advisory error: %w", err)
+				return eb.Wrapf(err, "put advisory error")
 			}
 		}
 	}
@@ -435,7 +441,7 @@ func (vs VulnSrc) commit(tx *bolt.Tx) error {
 	// All advisories with codename and fixed version are inserted into DB here.
 	for bkt, advisory := range vs.bktAdvisories {
 		if err := vs.putAdvisory(tx, bkt, advisory); err != nil {
-			return xerrors.Errorf("put advisory error: %w", err)
+			return oops.Wrapf(err, "put advisory error")
 		}
 	}
 	return nil
@@ -456,8 +462,9 @@ func (vs VulnSrc) putAdvisory(tx *bolt.Tx, bkt bucket, advisory Advisory) error 
 	advisory.Platform = fmt.Sprintf(platformFormat, majorVersion)
 	advisory.Title = vs.details[bkt.vulnID].Description // The Debian description is short, so we'll use it as a title.
 
+	eb := oops.With("vuln_id", advisory.VulnerabilityID).With("pkg_name", advisory.PkgName).With("platform", advisory.Platform)
 	if err := vs.put(vs.dbc, tx, advisory); err != nil {
-		return xerrors.Errorf("put error: %w", err)
+		return eb.Wrapf(err, "put error")
 	}
 
 	return nil
@@ -467,7 +474,7 @@ func (vs VulnSrc) putAdvisory(tx *bolt.Tx, bkt bucket, advisory Advisory) error 
 func defaultPut(dbc db.Operation, tx *bolt.Tx, advisory interface{}) error {
 	adv, ok := advisory.(Advisory)
 	if !ok {
-		return xerrors.New("unknown type")
+		return oops.Errorf("unknown type")
 	}
 
 	detail := types.Advisory{
@@ -477,34 +484,38 @@ func defaultPut(dbc db.Operation, tx *bolt.Tx, advisory interface{}) error {
 		FixedVersion: adv.FixedVersion,
 	}
 
+	eb := oops.With("vuln_id", adv.VulnerabilityID).With("pkg_name", adv.PkgName).With("platform", adv.Platform).
+		With("fixed_version", adv.FixedVersion).With("vendor_ids", adv.VendorIDs)
+
 	if err := dbc.PutAdvisoryDetail(tx, adv.VulnerabilityID, adv.PkgName, []string{adv.Platform}, &detail); err != nil {
-		return xerrors.Errorf("failed to save Debian advisory: %w", err)
+		return eb.Wrapf(err, "failed to save advisory")
 	}
 
 	vuln := types.VulnerabilityDetail{
 		Title: adv.Title,
 	}
 	if err := dbc.PutVulnerabilityDetail(tx, adv.VulnerabilityID, source.ID, vuln); err != nil {
-		return xerrors.Errorf("failed to save Debian vulnerability detail: %w", err)
+		return eb.Wrapf(err, "failed to save vulnerability detail")
 	}
 
 	// for optimization
 	if err := dbc.PutVulnerabilityID(tx, adv.VulnerabilityID); err != nil {
-		return xerrors.Errorf("failed to save the vulnerability ID: %w", err)
+		return eb.Wrapf(err, "failed to save vulnerability ID")
 	}
 
 	if err := dbc.PutDataSource(tx, adv.Platform, source); err != nil {
-		return xerrors.Errorf("failed to put data source: %w", err)
+		return eb.Wrapf(err, "failed to put data source")
 	}
 
 	return nil
 }
 
 func (vs VulnSrc) Get(release string, pkgName string) ([]types.Advisory, error) {
+	eb := oops.In("debian").With("release", release).With("pkg_name", pkgName)
 	bkt := fmt.Sprintf(platformFormat, release)
 	advisories, err := vs.dbc.GetAdvisories(bkt, pkgName)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to get Debian advisories: %w", err)
+		return nil, eb.Wrapf(err, "failed to get advisories")
 	}
 
 	return advisories, nil
@@ -530,9 +541,12 @@ func severityFromUrgency(urgency string) types.Severity {
 
 func (vs VulnSrc) parseDistributions(rootDir string) error {
 	vs.logger.Info("Parsing distributions...")
-	f, err := os.Open(filepath.Join(rootDir, distributionsFile))
+	filePath := filepath.Join(rootDir, distributionsFile)
+	eb := oops.With("root_dir", rootDir).With("file_path", filePath)
+
+	f, err := os.Open(filePath)
 	if err != nil {
-		return xerrors.Errorf("failed to open file: %w", err)
+		return eb.Wrapf(err, "failed to open file")
 	}
 	defer f.Close()
 
@@ -541,7 +555,7 @@ func (vs VulnSrc) parseDistributions(rootDir string) error {
 		MajorVersion string `json:"major-version"`
 	}
 	if err = json.NewDecoder(f).Decode(&parsed); err != nil {
-		return xerrors.Errorf("failed to decode Debian distribution JSON: %w", err)
+		return eb.Wrapf(err, "json decode error")
 	}
 	for dist, val := range parsed {
 		if val.MajorVersion == "" {
@@ -555,21 +569,25 @@ func (vs VulnSrc) parseDistributions(rootDir string) error {
 }
 
 func (vs VulnSrc) parseSources(dir string) error {
+	eb := oops.With("dir", dir)
 	for code := range vs.distributions {
 		codePath := filepath.Join(dir, code)
 		if ok, _ := utils.Exists(codePath); !ok {
 			continue
 		}
+		eb = eb.With("code_name", code)
 
 		vs.logger.Info("Parsing sources...", log.String("code", code))
 		err := utils.FileWalk(codePath, func(r io.Reader, path string) error {
+			eb = eb.With("file_path", path)
+
 			// To parse Sources.json
 			var pkg struct {
 				Package []string
 				Version []string
 			}
 			if err := json.NewDecoder(r).Decode(&pkg); err != nil {
-				return xerrors.Errorf("failed to decode %s: %w", path, err)
+				return eb.Wrapf(err, "json decode error")
 			}
 
 			if len(pkg.Package) == 0 || len(pkg.Version) == 0 {
@@ -582,12 +600,13 @@ func (vs VulnSrc) parseSources(dir string) error {
 			}
 
 			version := pkg.Version[0]
+			eb = eb.With("pkg_name", bkt.pkgName).With("version", version)
 
 			// Skip the update when the stored version is greater than the processing version.
 			if v, ok := vs.pkgVersions[bkt]; ok {
 				res, err := compareVersions(v, version)
 				if err != nil {
-					return xerrors.Errorf("version comparison error: %w", err)
+					return eb.Wrapf(err, "version comparison error")
 				}
 
 				if res >= 0 {
@@ -601,7 +620,7 @@ func (vs VulnSrc) parseSources(dir string) error {
 			return nil
 		})
 		if err != nil {
-			return xerrors.Errorf("filepath walk error: %w", err)
+			return eb.Wrapf(err, "walk error")
 		}
 	}
 
@@ -642,9 +661,11 @@ func hasFixedVersion(sidVer, codeVer string) (bool, error) {
 		return false, nil
 	}
 
+	eb := oops.With("sid_ver", sidVer).With("code_ver", codeVer)
+
 	res, err := compareVersions(codeVer, sidVer)
 	if err != nil {
-		return false, xerrors.Errorf("version comparison error")
+		return false, eb.Wrapf(err, "version comparison error")
 	}
 
 	// Greater than or equal
@@ -664,12 +685,12 @@ func compareVersions(v1, v2 string) (int, error) {
 
 	ver1, err := debver.NewVersion(v1)
 	if err != nil {
-		return 0, xerrors.Errorf("version error: %w", err)
+		return 0, oops.Wrapf(err, "version error")
 	}
 
 	ver2, err := debver.NewVersion(v2)
 	if err != nil {
-		return 0, xerrors.Errorf("version error: %w", err)
+		return 0, oops.Wrapf(err, "version error")
 	}
 
 	return ver1.Compare(ver2), nil

--- a/pkg/vulnsrc/debian/debian.go
+++ b/pkg/vulnsrc/debian/debian.go
@@ -484,27 +484,24 @@ func defaultPut(dbc db.Operation, tx *bolt.Tx, advisory interface{}) error {
 		FixedVersion: adv.FixedVersion,
 	}
 
-	eb := oops.With("vuln_id", adv.VulnerabilityID).With("package_name", adv.PkgName).With("platform", adv.Platform).
-		With("fixed_version", adv.FixedVersion).With("vendor_ids", adv.VendorIDs)
-
 	if err := dbc.PutAdvisoryDetail(tx, adv.VulnerabilityID, adv.PkgName, []string{adv.Platform}, &detail); err != nil {
-		return eb.Wrapf(err, "failed to save advisory")
+		return oops.Wrapf(err, "failed to save advisory")
 	}
 
 	vuln := types.VulnerabilityDetail{
 		Title: adv.Title,
 	}
 	if err := dbc.PutVulnerabilityDetail(tx, adv.VulnerabilityID, source.ID, vuln); err != nil {
-		return eb.Wrapf(err, "failed to save vulnerability detail")
+		return oops.Wrapf(err, "failed to save vulnerability detail")
 	}
 
 	// for optimization
 	if err := dbc.PutVulnerabilityID(tx, adv.VulnerabilityID); err != nil {
-		return eb.Wrapf(err, "failed to save vulnerability ID")
+		return oops.Wrapf(err, "failed to save vulnerability ID")
 	}
 
 	if err := dbc.PutDataSource(tx, adv.Platform, source); err != nil {
-		return eb.Wrapf(err, "failed to put data source")
+		return oops.Wrapf(err, "failed to put data source")
 	}
 
 	return nil

--- a/pkg/vulnsrc/debian/debian_test.go
+++ b/pkg/vulnsrc/debian/debian_test.go
@@ -200,12 +200,12 @@ func TestVulnSrc_Update(t *testing.T) {
 		{
 			name:    "sad broken distributions",
 			dir:     filepath.Join("testdata", "broken-distributions"),
-			wantErr: "failed to decode Debian distribution JSON",
+			wantErr: "distributions error",
 		},
 		{
 			name:    "sad broken packages",
 			dir:     filepath.Join("testdata", "broken-packages"),
-			wantErr: "failed to decode testdata/broken-packages/",
+			wantErr: "source parse error",
 		},
 		{
 			name:    "sad broken CVE",
@@ -263,7 +263,7 @@ func TestVulnSrc_Get(t *testing.T) {
 				release: "10",
 				pkgName: "alpine",
 			},
-			wantErr: "failed to get Debian advisories",
+			wantErr: "failed to get advisories",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/vulnsrc/ghsa/cocoapods.go
+++ b/pkg/vulnsrc/ghsa/cocoapods.go
@@ -5,8 +5,8 @@ import (
 	"io"
 	"path/filepath"
 
+	"github.com/samber/oops"
 	"golang.org/x/exp/slices"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy-db/pkg/log"
 	"github.com/aquasecurity/trivy-db/pkg/utils"
@@ -27,6 +27,8 @@ var cocoapodsSpecDir = filepath.Join("cocoapods-specs", "Specs")
 
 func walkCocoaPodsSpecs(root string) (map[string][]string, error) {
 	log.WithPrefix("cocoapods").Info("Walk `Cocoapods Specs` to convert Swift URLs to Cocoapods package names")
+	eb := oops.In("cocoapods").With("root_dir", root)
+
 	var specs = make(map[string][]string)
 	err := utils.FileWalk(filepath.Join(root, cocoapodsSpecDir), func(r io.Reader, path string) error {
 		if filepath.Ext(path) != ".json" {
@@ -34,7 +36,7 @@ func walkCocoaPodsSpecs(root string) (map[string][]string, error) {
 		}
 		var spec Spec
 		if err := json.NewDecoder(r).Decode(&spec); err != nil {
-			return xerrors.Errorf("failed to decode CocoaPods Spec: %w", err)
+			return eb.With("file_path", path).Wrapf(err, "json decode error")
 		}
 		if spec.Source.Git == "" {
 			return nil
@@ -54,7 +56,7 @@ func walkCocoaPodsSpecs(root string) (map[string][]string, error) {
 		return nil
 	})
 	if err != nil {
-		return nil, xerrors.Errorf("error in CocoaPods walk: %w", err)
+		return nil, eb.Wrapf(err, "walk error")
 	}
 	return specs, nil
 }

--- a/pkg/vulnsrc/ghsa/ghsa.go
+++ b/pkg/vulnsrc/ghsa/ghsa.go
@@ -6,8 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/samber/oops"
 	"golang.org/x/tools/go/packages"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/osv"
@@ -68,6 +68,7 @@ func (GHSA) Name() types.SourceID {
 }
 
 func (GHSA) Update(root string) error {
+	eb := oops.In("ghsa").With("root_dir", root)
 	dataSources := map[types.Ecosystem]types.DataSource{}
 	for ecosystem, ghsaEcosystem := range ecosystems {
 		src := types.DataSource{
@@ -80,7 +81,7 @@ func (GHSA) Update(root string) error {
 
 	t, err := newTransformer(root)
 	if err != nil {
-		return xerrors.Errorf("transformer error: %w", err)
+		return eb.Wrapf(err, "transformer error")
 	}
 
 	return osv.New(ghsaDir, sourceID, dataSources, t).Update(root)
@@ -94,7 +95,7 @@ type transformer struct {
 func newTransformer(root string) (*transformer, error) {
 	cocoaPodsSpecs, err := walkCocoaPodsSpecs(root)
 	if err != nil {
-		return nil, xerrors.Errorf("CocoaPods spec error: %w", err)
+		return nil, oops.Wrapf(err, "CocoaPods spec error")
 	}
 	return &transformer{
 		cocoaPodsSpecs: cocoaPodsSpecs,
@@ -104,14 +105,15 @@ func newTransformer(root string) (*transformer, error) {
 func (t *transformer) TransformAdvisories(advisories []osv.Advisory, entry osv.Entry) ([]osv.Advisory, error) {
 	var specific DatabaseSpecific
 	if err := json.Unmarshal(entry.DatabaseSpecific, &specific); err != nil {
-		return nil, xerrors.Errorf("JSON decode error: %w", err)
+		return nil, oops.Wrapf(err, "JSON decode error")
 	}
 
 	severity := convertSeverity(specific.Severity)
 	for i, adv := range advisories {
+		eb := oops.With("ecosystem", adv.Ecosystem).With("pkg_name", adv.PkgName).With("vuln_id", adv.VulnerabilityID).With("aliases", adv.Aliases)
 		// Parse database_specific
 		if err := parseDatabaseSpecific(adv); err != nil {
-			return nil, xerrors.Errorf("failed to parse database specific: %w", err)
+			return nil, eb.Wrapf(err, "failed to parse database specific")
 		}
 
 		// Fill severity from GHSA
@@ -149,7 +151,7 @@ func parseDatabaseSpecific(advisory osv.Advisory) error {
 
 	var affectedSpecific DatabaseSpecific
 	if err := json.Unmarshal(advisory.DatabaseSpecific, &affectedSpecific); err != nil {
-		return xerrors.Errorf("JSON decode error: %w", err)
+		return oops.Wrapf(err, "JSON decode error")
 	}
 
 	for i, vulnVersion := range advisory.VulnerableVersions {

--- a/pkg/vulnsrc/ghsa/ghsa.go
+++ b/pkg/vulnsrc/ghsa/ghsa.go
@@ -105,12 +105,12 @@ func newTransformer(root string) (*transformer, error) {
 func (t *transformer) TransformAdvisories(advisories []osv.Advisory, entry osv.Entry) ([]osv.Advisory, error) {
 	var specific DatabaseSpecific
 	if err := json.Unmarshal(entry.DatabaseSpecific, &specific); err != nil {
-		return nil, oops.Wrapf(err, "JSON decode error")
+		return nil, oops.Wrapf(err, "json unmarshal error")
 	}
 
 	severity := convertSeverity(specific.Severity)
 	for i, adv := range advisories {
-		eb := oops.With("ecosystem", adv.Ecosystem).With("pkg_name", adv.PkgName).With("vuln_id", adv.VulnerabilityID).With("aliases", adv.Aliases)
+		eb := oops.With("ecosystem", adv.Ecosystem).With("package_name", adv.PkgName).With("vuln_id", adv.VulnerabilityID).With("aliases", adv.Aliases)
 		// Parse database_specific
 		if err := parseDatabaseSpecific(adv); err != nil {
 			return nil, eb.Wrapf(err, "failed to parse database specific")
@@ -151,7 +151,7 @@ func parseDatabaseSpecific(advisory osv.Advisory) error {
 
 	var affectedSpecific DatabaseSpecific
 	if err := json.Unmarshal(advisory.DatabaseSpecific, &affectedSpecific); err != nil {
-		return oops.Wrapf(err, "JSON decode error")
+		return oops.Wrapf(err, "json unmarshal error")
 	}
 
 	for i, vulnVersion := range advisory.VulnerableVersions {

--- a/pkg/vulnsrc/ghsa/ghsa_test.go
+++ b/pkg/vulnsrc/ghsa/ghsa_test.go
@@ -395,7 +395,7 @@ func TestVulnSrc_Update(t *testing.T) {
 		{
 			name:    "sad path (failed to decode)",
 			dir:     filepath.Join("testdata", "sad"),
-			wantErr: "JSON decode error",
+			wantErr: "json decode error",
 		},
 		{
 			name:    "sad path (cocoapods-specs doesn't exist)",

--- a/pkg/vulnsrc/glad/glad.go
+++ b/pkg/vulnsrc/glad/glad.go
@@ -138,7 +138,7 @@ func (vs VulnSrc) commit(tx *bolt.Tx, pkgType packageType, glads []Advisory) err
 			return eb.Errorf("failed to get ecosystem: %s", pkgType)
 		}
 		bucketName := bucket.Name(ecosystem, source.Name)
-		eb = eb.With("package_name", pkgName).With("ecosystem", ecosystem).With("bucket_name", bucketName)
+		eb = eb.With("ecosystem", ecosystem)
 
 		if err := vs.dbc.PutDataSource(tx, bucketName, source); err != nil {
 			return eb.Wrapf(err, "failed to put data source")

--- a/pkg/vulnsrc/glad/glad.go
+++ b/pkg/vulnsrc/glad/glad.go
@@ -71,7 +71,7 @@ func (vs VulnSrc) Update(dir string) error {
 			log.String("type", cases.Title(language.English).String(string(t))))
 
 		rootDir := filepath.Join(dir, "vuln-list", gladDir, string(t))
-		eb = eb.With("root_dir", rootDir)
+		eb := eb.With("root_dir", rootDir)
 
 		if err := vs.update(t, rootDir); err != nil {
 			return eb.Wrapf(err, "update error")
@@ -138,7 +138,7 @@ func (vs VulnSrc) commit(tx *bolt.Tx, pkgType packageType, glads []Advisory) err
 			return eb.Errorf("failed to get ecosystem: %s", pkgType)
 		}
 		bucketName := bucket.Name(ecosystem, source.Name)
-		eb = eb.With("package_name", pkgName).With("ecosystem", ecosystem).With("bucket", bucketName)
+		eb = eb.With("package_name", pkgName).With("ecosystem", ecosystem).With("bucket_name", bucketName)
 
 		if err := vs.dbc.PutDataSource(tx, bucketName, source); err != nil {
 			return eb.Wrapf(err, "failed to put data source")

--- a/pkg/vulnsrc/glad/glad.go
+++ b/pkg/vulnsrc/glad/glad.go
@@ -6,10 +6,10 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/samber/oops"
 	bolt "go.etcd.io/bbolt"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy-db/pkg/db"
 	"github.com/aquasecurity/trivy-db/pkg/log"
@@ -65,38 +65,44 @@ func (vs VulnSrc) Name() types.SourceID {
 }
 
 func (vs VulnSrc) Update(dir string) error {
+	eb := oops.In("glad")
 	for t := range ecosystems {
 		vs.logger.Info("Updating GitLab Advisory Database",
 			log.String("type", cases.Title(language.English).String(string(t))))
+
 		rootDir := filepath.Join(dir, "vuln-list", gladDir, string(t))
+		eb = eb.With("root_dir", rootDir)
+
 		if err := vs.update(t, rootDir); err != nil {
-			return xerrors.Errorf("update error: %w", err)
+			return eb.Wrapf(err, "update error")
 		}
 	}
 	return nil
 }
 
 func (vs VulnSrc) update(pkgType packageType, rootDir string) error {
+	eb := oops.With("package_type", pkgType)
 	var glads []Advisory
 	err := utils.FileWalk(rootDir, func(r io.Reader, path string) error {
 		if !supportedIDs(filepath.Base(path)) {
 			return nil
 		}
+		eb := eb.With("file_path", path)
 
 		var glad Advisory
 		if err := json.NewDecoder(r).Decode(&glad); err != nil {
-			return xerrors.Errorf("failed to decode GitLab Advisory Database: %w", err)
+			return eb.Wrapf(err, "json decode error")
 		}
 
 		glads = append(glads, glad)
 		return nil
 	})
 	if err != nil {
-		return xerrors.Errorf("walk error: %w", err)
+		return eb.Wrapf(err, "walk error")
 	}
 
 	if err = vs.save(pkgType, glads); err != nil {
-		return xerrors.Errorf("save error: %w", err)
+		return eb.Wrapf(err, "save error")
 	}
 
 	return nil
@@ -107,7 +113,7 @@ func (vs VulnSrc) save(pkgType packageType, glads []Advisory) error {
 		return vs.commit(tx, pkgType, glads)
 	})
 	if err != nil {
-		return xerrors.Errorf("batch update error: %w", err)
+		return oops.Wrapf(err, "batch update error")
 	}
 	return nil
 }
@@ -118,25 +124,28 @@ func (vs VulnSrc) commit(tx *bolt.Tx, pkgType packageType, glads []Advisory) err
 			VulnerableVersions: []string{glad.AffectedRange},
 			PatchedVersions:    glad.FixedVersions,
 		}
+		eb := oops.With("vuln_id", glad.Identifier).With("slug", glad.PackageSlug)
 
 		// e.g. "go/github.com/go-ldap/ldap" => "go", "github.com/go-ldap/ldap"
 		ss := strings.SplitN(glad.PackageSlug, "/", 2)
 		if len(ss) < 2 {
-			return xerrors.Errorf("failed to parse package slug: %s", glad.PackageSlug)
+			return eb.Errorf("failed to parse package slug")
 		}
 
 		pkgName := ss[1]
 		ecosystem, ok := ecosystems[pkgType]
 		if !ok {
-			return xerrors.Errorf("failed to get ecosystem: %s", pkgType)
+			return eb.Errorf("failed to get ecosystem: %s", pkgType)
 		}
 		bucketName := bucket.Name(ecosystem, source.Name)
+		eb = eb.With("package_name", pkgName).With("ecosystem", ecosystem).With("bucket", bucketName)
+
 		if err := vs.dbc.PutDataSource(tx, bucketName, source); err != nil {
-			return xerrors.Errorf("failed to put data source: %w", err)
+			return eb.Wrapf(err, "failed to put data source")
 		}
 
 		if err := vs.dbc.PutAdvisoryDetail(tx, glad.Identifier, pkgName, []string{bucketName}, a); err != nil {
-			return xerrors.Errorf("failed to save GLAD advisory detail: %w", err)
+			return eb.Wrapf(err, "failed to save advisory")
 		}
 
 		// glad's cvss score is taken from NVD
@@ -149,12 +158,12 @@ func (vs VulnSrc) commit(tx *bolt.Tx, pkgType packageType, glads []Advisory) err
 		}
 
 		if err := vs.dbc.PutVulnerabilityDetail(tx, glad.Identifier, source.ID, vuln); err != nil {
-			return xerrors.Errorf("failed to save GLAD vulnerability detail: %w", err)
+			return eb.Wrapf(err, "failed to save vulnerability detail")
 		}
 
 		// for optimization
 		if err := vs.dbc.PutVulnerabilityID(tx, glad.Identifier); err != nil {
-			return xerrors.Errorf("failed to save the vulnerability ID: %w", err)
+			return eb.Wrapf(err, "failed to save vulnerability ID")
 		}
 	}
 

--- a/pkg/vulnsrc/glad/glad_test.go
+++ b/pkg/vulnsrc/glad/glad_test.go
@@ -49,7 +49,7 @@ func TestVulnSrc_Update(t *testing.T) {
 		{
 			name:    "sad path",
 			dir:     filepath.Join("testdata", "sad"),
-			wantErr: "failed to decode GitLab Advisory Database",
+			wantErr: "json decode error",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/vulnsrc/govulndb/govulndb.go
+++ b/pkg/vulnsrc/govulndb/govulndb.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"path/filepath"
 
-	"golang.org/x/xerrors"
+	"github.com/samber/oops"
 
 	"github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/osv"
@@ -46,7 +46,7 @@ type transformer struct{}
 func (t *transformer) TransformAdvisories(advisories []osv.Advisory, entry osv.Entry) ([]osv.Advisory, error) {
 	var specific DatabaseSpecific
 	if err := json.Unmarshal(entry.DatabaseSpecific, &specific); err != nil {
-		return nil, xerrors.Errorf("JSON decode error: %w", err)
+		return nil, oops.With("vuln_id", entry.ID).With("aliases", entry.Aliases).Wrapf(err, "json decode error")
 	}
 
 	var filtered []osv.Advisory

--- a/pkg/vulnsrc/govulndb/govulndb_test.go
+++ b/pkg/vulnsrc/govulndb/govulndb_test.go
@@ -104,7 +104,7 @@ func TestVulnSrc_Update(t *testing.T) {
 		{
 			name:    "sad path (failed to decode)",
 			dir:     filepath.Join("testdata", "sad"),
-			wantErr: "JSON decode error",
+			wantErr: "json decode error",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/vulnsrc/k8svulndb/k8svulndb_test.go
+++ b/pkg/vulnsrc/k8svulndb/k8svulndb_test.go
@@ -69,7 +69,7 @@ func TestVulnSrc_Update(t *testing.T) {
 		{
 			name:    "sad path",
 			dir:     filepath.Join("testdata", "broken"),
-			wantErr: "JSON decode error",
+			wantErr: "json decode error",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/vulnsrc/node/node.go
+++ b/pkg/vulnsrc/node/node.go
@@ -119,7 +119,7 @@ func (vs VulnSrc) update(repoPath string) error {
 
 func (vs VulnSrc) walk(tx *bolt.Tx, root string) error {
 	return filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
-		eb := oops.With("path", path)
+		eb := oops.With("file_path", path)
 		if err != nil {
 			return eb.Wrapf(err, "failed to walk")
 		}

--- a/pkg/vulnsrc/node/node.go
+++ b/pkg/vulnsrc/node/node.go
@@ -90,7 +90,7 @@ func (vs VulnSrc) Name() types.SourceID {
 
 func (vs VulnSrc) Update(dir string) error {
 	repoPath := filepath.Join(dir, nodeDir)
-	eb := oops.In("node").With("root_dir", dir).With("repo_path", repoPath)
+	eb := oops.In("node").With("root_dir", dir)
 
 	if err := vs.update(repoPath); err != nil {
 		return eb.Wrapf(err, "failed to update vulnerabilities")

--- a/pkg/vulnsrc/node/node.go
+++ b/pkg/vulnsrc/node/node.go
@@ -157,12 +157,9 @@ func (vs VulnSrc) commit(tx *bolt.Tx, f *os.File) error {
 
 	adv := convertToGenericAdvisory(advisory)
 	for _, vulnID := range vulnerabilityIDs {
-		eb := oops.With("vuln_id", vulnID).With("package_name", advisory.ModuleName)
-
 		// for detecting vulnerabilities
-		err = vs.dbc.PutAdvisoryDetail(tx, vulnID, advisory.ModuleName, []string{bucketName}, adv)
-		if err != nil {
-			return eb.Wrapf(err, "failed to save advisory")
+		if err = vs.dbc.PutAdvisoryDetail(tx, vulnID, advisory.ModuleName, []string{bucketName}, adv); err != nil {
+			return oops.Wrapf(err, "failed to save advisory")
 		}
 
 		// If an advisory is 0 override with -1
@@ -180,12 +177,12 @@ func (vs VulnSrc) commit(tx *bolt.Tx, f *os.File) error {
 			Description: advisory.Overview,
 		}
 		if err = vs.dbc.PutVulnerabilityDetail(tx, vulnID, source.ID, vuln); err != nil {
-			return eb.Wrapf(err, "failed to save vulnerability detail")
+			return oops.Wrapf(err, "failed to save vulnerability detail")
 		}
 
 		// for optimization
 		if err = vs.dbc.PutVulnerabilityID(tx, vulnID); err != nil {
-			return eb.Wrapf(err, "failed to save vulnerability ID")
+			return oops.Wrapf(err, "failed to save vulnerability ID")
 		}
 	}
 

--- a/pkg/vulnsrc/node/node.go
+++ b/pkg/vulnsrc/node/node.go
@@ -8,8 +8,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/samber/oops"
 	bolt "go.etcd.io/bbolt"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy-db/pkg/db"
 	"github.com/aquasecurity/trivy-db/pkg/types"
@@ -90,34 +90,38 @@ func (vs VulnSrc) Name() types.SourceID {
 
 func (vs VulnSrc) Update(dir string) error {
 	repoPath := filepath.Join(dir, nodeDir)
+	eb := oops.In("node").With("root_dir", dir).With("repo_path", repoPath)
+
 	if err := vs.update(repoPath); err != nil {
-		return xerrors.Errorf("failed to update node vulnerabilities: %w", err)
+		return eb.Wrapf(err, "failed to update vulnerabilities")
 	}
 	return nil
 }
 
 func (vs VulnSrc) update(repoPath string) error {
 	root := filepath.Join(repoPath, "vuln")
+	eb := oops.With("repo_path", repoPath)
 
 	err := vs.dbc.BatchUpdate(func(tx *bolt.Tx) error {
 		if err := vs.dbc.PutDataSource(tx, bucketName, source); err != nil {
-			return xerrors.Errorf("failed to put data source: %w", err)
+			return eb.Wrapf(err, "failed to put data source")
 		}
 		if err := vs.walk(tx, root); err != nil {
-			return xerrors.Errorf("failed to walk node advisories: %w", err)
+			return eb.Wrapf(err, "failed to walk advisories")
 		}
 		return nil
 	})
 	if err != nil {
-		return xerrors.Errorf("batch update failed: %w", err)
+		return eb.Wrapf(err, "batch update failed")
 	}
 	return nil
 }
 
 func (vs VulnSrc) walk(tx *bolt.Tx, root string) error {
 	return filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		eb := oops.With("path", path)
 		if err != nil {
-			return err
+			return eb.Wrapf(err, "failed to walk")
 		}
 		if info.IsDir() || !strings.HasSuffix(info.Name(), ".json") {
 			return nil
@@ -125,7 +129,7 @@ func (vs VulnSrc) walk(tx *bolt.Tx, root string) error {
 
 		f, err := os.Open(path)
 		if err != nil {
-			return err
+			return eb.Wrapf(err, "file open error")
 		}
 		defer f.Close()
 
@@ -137,7 +141,7 @@ func (vs VulnSrc) commit(tx *bolt.Tx, f *os.File) error {
 	advisory := RawAdvisory{}
 	var err error
 	if err = json.NewDecoder(f).Decode(&advisory); err != nil {
-		return err
+		return oops.Wrapf(err, "json decode error")
 	}
 
 	// Node.js itself
@@ -153,10 +157,12 @@ func (vs VulnSrc) commit(tx *bolt.Tx, f *os.File) error {
 
 	adv := convertToGenericAdvisory(advisory)
 	for _, vulnID := range vulnerabilityIDs {
+		eb := oops.With("vuln_id", vulnID).With("package_name", advisory.ModuleName)
+
 		// for detecting vulnerabilities
 		err = vs.dbc.PutAdvisoryDetail(tx, vulnID, advisory.ModuleName, []string{bucketName}, adv)
 		if err != nil {
-			return xerrors.Errorf("failed to save node advisory: %w", err)
+			return eb.Wrapf(err, "failed to save advisory")
 		}
 
 		// If an advisory is 0 override with -1
@@ -174,12 +180,12 @@ func (vs VulnSrc) commit(tx *bolt.Tx, f *os.File) error {
 			Description: advisory.Overview,
 		}
 		if err = vs.dbc.PutVulnerabilityDetail(tx, vulnID, source.ID, vuln); err != nil {
-			return xerrors.Errorf("failed to save node vulnerability detail: %w", err)
+			return eb.Wrapf(err, "failed to save vulnerability detail")
 		}
 
 		// for optimization
 		if err = vs.dbc.PutVulnerabilityID(tx, vulnID); err != nil {
-			return xerrors.Errorf("failed to save the vulnerability ID: %w", err)
+			return eb.Wrapf(err, "failed to save vulnerability ID")
 		}
 	}
 

--- a/pkg/vulnsrc/nvd/nvd.go
+++ b/pkg/vulnsrc/nvd/nvd.go
@@ -58,10 +58,10 @@ func (vs *VulnSrc) Update(dir string) error {
 	var cves []Cve
 	buffer := &bytes.Buffer{}
 	err := utils.FileWalk(rootDir, func(r io.Reader, filePath string) error {
-		eb = eb.With("file_path", filePath)
+		eb := eb.With("file_path", filePath)
 		cve := Cve{}
 		if _, err := buffer.ReadFrom(r); err != nil {
-			return eb.Wrapf(err, "read file error")
+			return eb.Wrapf(err, "file read error")
 		}
 		if err := json.Unmarshal(buffer.Bytes(), &cve); err != nil {
 			return eb.Wrapf(err, "json unmarshal error")

--- a/pkg/vulnsrc/nvd/nvd_test.go
+++ b/pkg/vulnsrc/nvd/nvd_test.go
@@ -82,7 +82,7 @@ func TestVulnSrc_Update(t *testing.T) {
 		{
 			name:    "sad path (failed to decode)",
 			dir:     filepath.Join("testdata", "sad"),
-			wantErr: "failed to decode NVD JSON",
+			wantErr: "json unmarshal error",
 		},
 	}
 

--- a/pkg/vulnsrc/oracle-oval/oracle-oval.go
+++ b/pkg/vulnsrc/oracle-oval/oracle-oval.go
@@ -70,7 +70,7 @@ func (vs *VulnSrc) Name() types.SourceID {
 
 func (vs *VulnSrc) Update(dir string) error {
 	rootDir := filepath.Join(dir, "vuln-list", oracleDir)
-	eb := oops.In("oracle-oval").With("root_dir", rootDir)
+	eb := oops.In("oracle").Tags("oval").With("root_dir", rootDir)
 
 	ovals, err := vs.parse(rootDir)
 	if err != nil {
@@ -328,7 +328,7 @@ func (o *Oracle) Put(tx *bolt.Tx, input PutInput) error {
 
 	for pkg, advisory := range input.Advisories {
 		platformName := pkg.PlatformName()
-		eb = eb.With("pkg_name", pkg.Name).With("platform", platformName)
+		eb := eb.With("package_name", pkg.Name).With("platform", platformName)
 
 		if err := o.PutAdvisoryDetail(tx, input.VulnID, pkg.Name, []string{platformName}, advisory); err != nil {
 			return eb.Wrapf(err, "failed to save advisory")
@@ -338,7 +338,7 @@ func (o *Oracle) Put(tx *bolt.Tx, input PutInput) error {
 }
 
 func (o *Oracle) Get(release, pkgName, arch string) ([]types.Advisory, error) {
-	eb := oops.In("oracle-oval").With("release", release).With("pkg_name", pkgName).With("arch", arch)
+	eb := oops.In("oracle").Tags("oval").With("release", release).With("package_name", pkgName).With("arch", arch)
 	bucket := fmt.Sprintf(platformFormat, release)
 	rawAdvisories, err := o.ForEachAdvisory([]string{bucket}, pkgName)
 	if err != nil {

--- a/pkg/vulnsrc/oracle-oval/oracle-oval.go
+++ b/pkg/vulnsrc/oracle-oval/oracle-oval.go
@@ -328,10 +328,8 @@ func (o *Oracle) Put(tx *bolt.Tx, input PutInput) error {
 
 	for pkg, advisory := range input.Advisories {
 		platformName := pkg.PlatformName()
-		eb := eb.With("package_name", pkg.Name).With("platform", platformName)
-
 		if err := o.PutAdvisoryDetail(tx, input.VulnID, pkg.Name, []string{platformName}, advisory); err != nil {
-			return eb.Wrapf(err, "failed to save advisory")
+			return eb.With("package_name", pkg.Name).With("bucket_name", platformName).Wrapf(err, "failed to save advisory")
 		}
 	}
 	return nil

--- a/pkg/vulnsrc/oracle-oval/oracle-oval_test.go
+++ b/pkg/vulnsrc/oracle-oval/oracle-oval_test.go
@@ -546,7 +546,7 @@ func TestVulnSrc_Update(t *testing.T) {
 		{
 			name:    "sad path (failed to decode)",
 			dir:     filepath.Join("testdata", "sad"),
-			wantErr: "failed to decode Oracle Linux OVAL JSON",
+			wantErr: "json decode error",
 		},
 	}
 	for _, tt := range tests {
@@ -693,7 +693,7 @@ func TestVulnSrc_Get(t *testing.T) {
 			},
 			version: "8",
 			pkgName: "bind",
-			wantErr: "failed to unmarshal advisory JSON",
+			wantErr: "json unmarshal error",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/vulnsrc/osv/osv.go
+++ b/pkg/vulnsrc/osv/osv.go
@@ -91,7 +91,7 @@ func (o OSV) Update(root string) error {
 		}
 		var entry Entry
 		if err := json.NewDecoder(r).Decode(&entry); err != nil {
-			return oops.With("path", path).Wrapf(err, "JSON decode error")
+			return oops.With("file_path", path).Wrapf(err, "json decode error")
 		}
 		entries = append(entries, entry)
 		return nil

--- a/pkg/vulnsrc/osv/osv.go
+++ b/pkg/vulnsrc/osv/osv.go
@@ -152,10 +152,8 @@ func (o OSV) commit(tx *bolt.Tx, entry Entry) error {
 			continue
 		}
 		bktName := bucket.Name(adv.Ecosystem, dataSource.Name)
-		eb := oops.With("bucket_name", bktName)
-
 		if err = o.dbc.PutDataSource(tx, bktName, dataSource); err != nil {
-			return eb.Wrapf(err, "failed to put data source")
+			return oops.Wrapf(err, "failed to put data source")
 		}
 
 		// Store advisories
@@ -164,9 +162,8 @@ func (o OSV) commit(tx *bolt.Tx, entry Entry) error {
 			VulnerableVersions: adv.VulnerableVersions,
 			PatchedVersions:    adv.PatchedVersions,
 		}
-		eb = eb.With("vuln_id", adv.VulnerabilityID).With("package_name", adv.PkgName).With("aliases", adv.Aliases)
 		if err = o.dbc.PutAdvisoryDetail(tx, adv.VulnerabilityID, adv.PkgName, []string{bktName}, advisory); err != nil {
-			return eb.Wrapf(err, "failed to save advisory")
+			return oops.Wrapf(err, "failed to save advisory")
 		}
 
 		// Store vulnerability details
@@ -180,11 +177,11 @@ func (o OSV) commit(tx *bolt.Tx, entry Entry) error {
 		}
 
 		if err = o.dbc.PutVulnerabilityDetail(tx, adv.VulnerabilityID, o.sourceID, vuln); err != nil {
-			return eb.Wrapf(err, "failed to put vulnerability detail")
+			return oops.Wrapf(err, "failed to put vulnerability detail")
 		}
 
 		if err = o.dbc.PutVulnerabilityID(tx, adv.VulnerabilityID); err != nil {
-			return eb.Wrapf(err, "failed to put vulnerability id")
+			return oops.Wrapf(err, "failed to put vulnerability id")
 		}
 	}
 	return nil

--- a/pkg/vulnsrc/osv/osv.go
+++ b/pkg/vulnsrc/osv/osv.go
@@ -152,7 +152,7 @@ func (o OSV) commit(tx *bolt.Tx, entry Entry) error {
 			continue
 		}
 		bktName := bucket.Name(adv.Ecosystem, dataSource.Name)
-		eb := oops.In(string(o.sourceID)).With("bkt_name", bktName)
+		eb := oops.With("bucket_name", bktName)
 
 		if err = o.dbc.PutDataSource(tx, bktName, dataSource); err != nil {
 			return eb.Wrapf(err, "failed to put data source")
@@ -164,7 +164,7 @@ func (o OSV) commit(tx *bolt.Tx, entry Entry) error {
 			VulnerableVersions: adv.VulnerableVersions,
 			PatchedVersions:    adv.PatchedVersions,
 		}
-		eb = eb.With("vuln_id", adv.VulnerabilityID).With("pkg_name", adv.PkgName).With("vendor_ids", adv.Aliases)
+		eb = eb.With("vuln_id", adv.VulnerabilityID).With("package_name", adv.PkgName).With("aliases", adv.Aliases)
 		if err = o.dbc.PutAdvisoryDetail(tx, adv.VulnerabilityID, adv.PkgName, []string{bktName}, advisory); err != nil {
 			return eb.Wrapf(err, "failed to save advisory")
 		}
@@ -225,7 +225,7 @@ func parseAffected(entry Entry, vulnIDs, aliases, references []string) ([]Adviso
 			continue
 		}
 		pkgName := vulnerability.NormalizePkgName(ecosystem, affected.Package.Name)
-		eb = eb.With("ecosystem", ecosystem).With("pkg_name", pkgName)
+		eb := eb.With("ecosystem", ecosystem).With("package_name", pkgName)
 
 		vulnerableVersions, patchedVersions, err := parseAffectedVersions(affected)
 		if err != nil {

--- a/pkg/vulnsrc/osv/osv.go
+++ b/pkg/vulnsrc/osv/osv.go
@@ -11,9 +11,9 @@ import (
 	gocvss30 "github.com/pandatix/go-cvss/30"
 	gocvss31 "github.com/pandatix/go-cvss/31"
 	"github.com/samber/lo"
+	"github.com/samber/oops"
 	bolt "go.etcd.io/bbolt"
 	"golang.org/x/exp/maps"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy-db/pkg/db"
 	"github.com/aquasecurity/trivy-db/pkg/log"
@@ -82,6 +82,7 @@ func (o OSV) Name() types.SourceID {
 
 func (o OSV) Update(root string) error {
 	rootDir := filepath.Join(root, o.dir)
+	eb := oops.In(string(o.sourceID)).With("root_dir", rootDir)
 
 	var entries []Entry
 	err := utils.FileWalk(rootDir, func(r io.Reader, path string) error {
@@ -90,17 +91,17 @@ func (o OSV) Update(root string) error {
 		}
 		var entry Entry
 		if err := json.NewDecoder(r).Decode(&entry); err != nil {
-			return xerrors.Errorf("JSON decode error (%s): %w", path, err)
+			return oops.With("path", path).Wrapf(err, "JSON decode error")
 		}
 		entries = append(entries, entry)
 		return nil
 	})
 	if err != nil {
-		return xerrors.Errorf("walk error: %w", err)
+		return eb.Wrapf(err, "walk error")
 	}
 
 	if err = o.save(entries); err != nil {
-		return xerrors.Errorf("save error: %w", err)
+		return eb.Wrapf(err, "save error")
 	}
 
 	return nil
@@ -116,7 +117,7 @@ func (o OSV) save(entries []Entry) error {
 		return nil
 	})
 	if err != nil {
-		return xerrors.Errorf("batch update error: %w", err)
+		return oops.Wrapf(err, "batch update error")
 	}
 	return nil
 }
@@ -136,13 +137,13 @@ func (o OSV) commit(tx *bolt.Tx, entry Entry) error {
 	// Parse []affected
 	advisories, err := parseAffected(entry, vulnIDs, aliases, references)
 	if err != nil {
-		return xerrors.Errorf("failed to parse affected: %w", err)
+		return oops.Wrapf(err, "failed to parse affected")
 	}
 
 	// Transform advisories
 	advisories, err = o.transformer.TransformAdvisories(advisories, entry)
 	if err != nil {
-		return xerrors.Errorf("failed to transform advisories: %w", err)
+		return oops.Wrapf(err, "failed to transform advisories")
 	}
 
 	for _, adv := range advisories {
@@ -151,9 +152,10 @@ func (o OSV) commit(tx *bolt.Tx, entry Entry) error {
 			continue
 		}
 		bktName := bucket.Name(adv.Ecosystem, dataSource.Name)
+		eb := oops.In(string(o.sourceID)).With("bkt_name", bktName)
 
 		if err = o.dbc.PutDataSource(tx, bktName, dataSource); err != nil {
-			return xerrors.Errorf("failed to put data source: %w", err)
+			return eb.Wrapf(err, "failed to put data source")
 		}
 
 		// Store advisories
@@ -162,8 +164,9 @@ func (o OSV) commit(tx *bolt.Tx, entry Entry) error {
 			VulnerableVersions: adv.VulnerableVersions,
 			PatchedVersions:    adv.PatchedVersions,
 		}
+		eb = eb.With("vuln_id", adv.VulnerabilityID).With("pkg_name", adv.PkgName).With("vendor_ids", adv.Aliases)
 		if err = o.dbc.PutAdvisoryDetail(tx, adv.VulnerabilityID, adv.PkgName, []string{bktName}, advisory); err != nil {
-			return xerrors.Errorf("failed to save OSV advisory: %w", err)
+			return eb.Wrapf(err, "failed to save advisory")
 		}
 
 		// Store vulnerability details
@@ -177,11 +180,11 @@ func (o OSV) commit(tx *bolt.Tx, entry Entry) error {
 		}
 
 		if err = o.dbc.PutVulnerabilityDetail(tx, adv.VulnerabilityID, o.sourceID, vuln); err != nil {
-			return xerrors.Errorf("failed to put vulnerability detail (%s): %w", adv.VulnerabilityID, err)
+			return eb.Wrapf(err, "failed to put vulnerability detail")
 		}
 
 		if err = o.dbc.PutVulnerabilityID(tx, adv.VulnerabilityID); err != nil {
-			return xerrors.Errorf("failed to put vulnerability id (%s): %w", adv.VulnerabilityID, err)
+			return eb.Wrapf(err, "failed to put vulnerability id")
 		}
 	}
 	return nil
@@ -207,10 +210,12 @@ func groupVulnIDs(id string, aliases []string) ([]string, []string) {
 // parseAffected parses the affected fields
 // cf. https://ossf.github.io/osv-schema/#affected-fields
 func parseAffected(entry Entry, vulnIDs, aliases, references []string) ([]Advisory, error) {
+	eb := oops.With("entry_id", entry.ID).With("vuln_ids", vulnIDs).With("aliases", aliases)
+
 	// Severities can be found both in severity and affected[].severity fields.
 	cvssVectorV3, cvssScoreV3, err := parseSeverity(entry.Severities)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to decode CVSS vector (%s): %w", entry.ID, err)
+		return nil, eb.Wrapf(err, "failed to decode CVSS vector")
 	}
 
 	uniqAdvisories := map[string]Advisory{}
@@ -220,15 +225,16 @@ func parseAffected(entry Entry, vulnIDs, aliases, references []string) ([]Adviso
 			continue
 		}
 		pkgName := vulnerability.NormalizePkgName(ecosystem, affected.Package.Name)
+		eb = eb.With("ecosystem", ecosystem).With("pkg_name", pkgName)
 
 		vulnerableVersions, patchedVersions, err := parseAffectedVersions(affected)
 		if err != nil {
-			return nil, xerrors.Errorf("failed to parse affected: %w", err)
+			return nil, eb.Wrapf(err, "failed to parse affected")
 		}
 
 		// Parse affected[].severity
 		if vecV3, scoreV3, err := parseSeverity(affected.Severities); err != nil {
-			return nil, xerrors.Errorf("failed to decode CVSS vector (%s): %w", entry.ID, err)
+			return nil, eb.Wrapf(err, "failed to decode CVSS vector")
 		} else if vecV3 != "" {
 			// Overwrite the CVSS vector and score if affected[].severity is set
 			cvssVectorV3, cvssScoreV3 = vecV3, scoreV3
@@ -327,11 +333,12 @@ func parseSeverity(severities []Severity) (string, float64, error) {
 			// e.g. https://github.com/github/advisory-database/blob/2d3bc73d2117893b217233aeb95b9236c7b93761/advisories/github-reviewed/2019/05/GHSA-j59f-6m4q-62h6/GHSA-j59f-6m4q-62h6.json#L14
 			// Trim the suffix to avoid errors
 			cvssVectorV3 := strings.TrimSuffix(s.Score, "/")
+			eb := oops.With("cvss_vector_v3", cvssVectorV3)
 			switch {
 			case strings.HasPrefix(cvssVectorV3, "CVSS:3.0"):
 				cvss, err := gocvss30.ParseVector(cvssVectorV3)
 				if err != nil {
-					return "", 0, xerrors.Errorf("failed to parse CVSSv3.0 vector: %w", err)
+					return "", 0, eb.Wrapf(err, "failed to parse CVSSv3.0 vector")
 				}
 				// cvss.EnvironmentalScore() returns the optimal score required from Vector.
 				// If the Environmental Metrics is not set, it will be the same value as TemporalScore(),
@@ -340,14 +347,14 @@ func parseSeverity(severities []Severity) (string, float64, error) {
 			case strings.HasPrefix(s.Score, "CVSS:3.1"):
 				cvss, err := gocvss31.ParseVector(cvssVectorV3)
 				if err != nil {
-					return "", 0, xerrors.Errorf("failed to parse CVSSv3.1 vector: %w", err)
+					return "", 0, oops.Wrapf(err, "failed to parse CVSSv3.1 vector")
 				}
 				// cvss.EnvironmentalScore() returns the optimal score required from Vector.
 				// If the Environmental Metrics is not set, it will be the same value as TemporalScore(),
 				// and if Temporal Metrics is not set, it will be the same value as Basescore().
 				return cvssVectorV3, cvss.EnvironmentalScore(), nil
 			default:
-				return "", 0, xerrors.Errorf("vector:%s does not have CVSS v3 prefix: \"CVSS:3.0\" or \"CVSS:3.1\"", s.Score)
+				return "", 0, eb.Errorf("vector does not have CVSS v3 prefix: \"CVSS:3.0\" or \"CVSS:3.1\"")
 			}
 		}
 	}

--- a/pkg/vulnsrc/osv/osv_test.go
+++ b/pkg/vulnsrc/osv/osv_test.go
@@ -117,7 +117,7 @@ func TestVulnSrc_Update(t *testing.T) {
 		{
 			name:    "sad path",
 			dir:     filepath.Join("testdata", "sad"),
-			wantErr: "JSON decode error",
+			wantErr: "json decode error",
 		},
 	}
 

--- a/pkg/vulnsrc/osv/range.go
+++ b/pkg/vulnsrc/osv/range.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 
 	mvn "github.com/masahiro331/go-mvn-version"
-	"golang.org/x/xerrors"
+	"github.com/samber/oops"
 
 	"github.com/aquasecurity/go-gem-version"
-	"github.com/aquasecurity/go-npm-version/pkg"
+	npm "github.com/aquasecurity/go-npm-version/pkg"
 	pep440 "github.com/aquasecurity/go-pep440-version"
 	"github.com/aquasecurity/go-version/pkg/semver"
 	"github.com/aquasecurity/go-version/pkg/version"
@@ -91,14 +91,16 @@ type DefaultVersionRange struct {
 }
 
 func (r *DefaultVersionRange) Contains(ver string) (bool, error) {
+	eb := oops.With("version_range", r.String()).With("version", ver)
+
 	c, err := version.NewConstraints(r.String())
 	if err != nil {
-		return false, xerrors.Errorf("failed to parse version constraint: %w", err)
+		return false, eb.Wrapf(err, "failed to parse version constraint")
 	}
 
 	v, err := version.Parse(ver)
 	if err != nil {
-		return false, xerrors.Errorf("failed to parse version: %w", err)
+		return false, eb.Wrapf(err, "failed to parse version")
 	}
 
 	return c.Check(v), nil
@@ -109,14 +111,16 @@ type SemVerRange struct {
 }
 
 func (r *SemVerRange) Contains(ver string) (bool, error) {
+	eb := oops.Tags("semver").With("version_range", r.String()).With("version", ver)
+
 	c, err := semver.NewConstraints(r.String())
 	if err != nil {
-		return false, xerrors.Errorf("failed to parse version constraint: %w", err)
+		return false, eb.Wrapf(err, "failed to parse version constraint")
 	}
 
 	v, err := semver.Parse(ver)
 	if err != nil {
-		return false, xerrors.Errorf("failed to parse version: %w", err)
+		return false, eb.Wrapf(err, "failed to parse version")
 	}
 
 	return c.Check(v), nil
@@ -127,14 +131,16 @@ type NpmVersionRange struct {
 }
 
 func (r *NpmVersionRange) Contains(ver string) (bool, error) {
+	eb := oops.Tags("npm").With("version_range", r.String()).With("version", ver)
+
 	c, err := npm.NewConstraints(r.String())
 	if err != nil {
-		return false, xerrors.Errorf("failed to parse version constraint: %w", err)
+		return false, eb.Wrapf(err, "failed to parse version constraint")
 	}
 
 	v, err := npm.NewVersion(ver)
 	if err != nil {
-		return false, xerrors.Errorf("failed to parse version: %w", err)
+		return false, eb.Wrapf(err, "failed to parse version")
 	}
 
 	return c.Check(v), nil
@@ -145,14 +151,16 @@ type RubyGemsVersionRange struct {
 }
 
 func (r *RubyGemsVersionRange) Contains(ver string) (bool, error) {
+	eb := oops.Tags("rubygems").With("version_range", r.String()).With("version", ver)
+
 	c, err := gem.NewConstraints(r.String())
 	if err != nil {
-		return false, xerrors.Errorf("failed to parse version constraint: %w", err)
+		return false, eb.Wrapf(err, "failed to parse version constraint")
 	}
 
 	v, err := gem.NewVersion(ver)
 	if err != nil {
-		return false, xerrors.Errorf("failed to parse version: %w", err)
+		return false, eb.Wrapf(err, "failed to parse version")
 	}
 
 	return c.Check(v), nil
@@ -163,14 +171,16 @@ type PyPIVersionRange struct {
 }
 
 func (r *PyPIVersionRange) Contains(ver string) (bool, error) {
+	eb := oops.Tags("pypi").With("version_range", r.String()).With("version", ver)
+
 	c, err := pep440.NewSpecifiers(r.String())
 	if err != nil {
-		return false, xerrors.Errorf("failed to parse version constraint: %w", err)
+		return false, eb.Wrapf(err, "failed to parse version constraint")
 	}
 
 	v, err := pep440.Parse(ver)
 	if err != nil {
-		return false, xerrors.Errorf("failed to parse version: %w", err)
+		return false, eb.Wrapf(err, "failed to parse version")
 	}
 
 	return c.Check(v), nil
@@ -181,14 +191,16 @@ type MavenVersionRange struct {
 }
 
 func (r *MavenVersionRange) Contains(ver string) (bool, error) {
+	eb := oops.Tags("maven").With("version_range", r.String()).With("version", ver)
+
 	c, err := mvn.NewConstraints(r.String())
 	if err != nil {
-		return false, xerrors.Errorf("failed to parse version constraint: %w", err)
+		return false, eb.Wrapf(err, "failed to parse version constraint")
 	}
 
 	v, err := mvn.NewVersion(ver)
 	if err != nil {
-		return false, xerrors.Errorf("failed to parse version: %w", err)
+		return false, eb.Wrapf(err, "failed to parse version")
 	}
 
 	return c.Check(v), nil

--- a/pkg/vulnsrc/photon/photon.go
+++ b/pkg/vulnsrc/photon/photon.go
@@ -6,8 +6,8 @@ import (
 	"io"
 	"path/filepath"
 
+	"github.com/samber/oops"
 	bolt "go.etcd.io/bbolt"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy-db/pkg/db"
 	"github.com/aquasecurity/trivy-db/pkg/log"
@@ -45,23 +45,26 @@ func (vs VulnSrc) Name() types.SourceID {
 
 func (vs VulnSrc) Update(dir string) error {
 	rootDir := filepath.Join(dir, "vuln-list", photonDir)
+	eb := oops.In("photon").With("root_dir", rootDir)
 
 	var cves []PhotonCVE
 	err := utils.FileWalk(rootDir, func(r io.Reader, path string) error {
+		eb := eb.With("file_path", path)
+
 		var cve PhotonCVE
 		if err := json.NewDecoder(r).Decode(&cve); err != nil {
-			return xerrors.Errorf("failed to decode Photon JSON: %w", err)
+			return eb.Wrapf(err, "json decode error")
 		}
 		cves = append(cves, cve)
 
 		return nil
 	})
 	if err != nil {
-		return xerrors.Errorf("error in Photon walk: %w", err)
+		return eb.Wrapf(err, "walk error")
 	}
 
 	if err = vs.save(cves); err != nil {
-		return xerrors.Errorf("unable to save Photon advisories: %w", err)
+		return eb.Wrapf(err, "save error")
 	}
 
 	return nil
@@ -73,7 +76,7 @@ func (vs VulnSrc) save(cves []PhotonCVE) error {
 		return vs.commit(tx, cves)
 	})
 	if err != nil {
-		return xerrors.Errorf("error in batch update: %w", err)
+		return oops.Wrapf(err, "batch update error")
 	}
 	return nil
 }
@@ -81,15 +84,17 @@ func (vs VulnSrc) save(cves []PhotonCVE) error {
 func (vs VulnSrc) commit(tx *bolt.Tx, cves []PhotonCVE) error {
 	for _, cve := range cves {
 		platformName := fmt.Sprintf(platformFormat, cve.OSVersion)
+		eb := oops.With("platform", platformName).With("cve_id", cve.CveID).With("package_name", cve.Pkg)
+
 		if err := vs.dbc.PutDataSource(tx, platformName, source); err != nil {
-			return xerrors.Errorf("failed to put data source: %w", err)
+			return eb.Wrapf(err, "failed to put data source")
 		}
 
 		advisory := types.Advisory{
 			FixedVersion: cve.ResVer,
 		}
 		if err := vs.dbc.PutAdvisoryDetail(tx, cve.CveID, cve.Pkg, []string{platformName}, advisory); err != nil {
-			return xerrors.Errorf("failed to save Photon advisory: %w", err)
+			return eb.Wrapf(err, "failed to save advisory")
 		}
 
 		vuln := types.VulnerabilityDetail{
@@ -97,22 +102,23 @@ func (vs VulnSrc) commit(tx *bolt.Tx, cves []PhotonCVE) error {
 			CvssScoreV3: cve.CveScore,
 		}
 		if err := vs.dbc.PutVulnerabilityDetail(tx, cve.CveID, source.ID, vuln); err != nil {
-			return xerrors.Errorf("failed to save Photon vulnerability detail: %w", err)
+			return eb.Wrapf(err, "failed to save vulnerability detail")
 		}
 
 		// for optimization
 		if err := vs.dbc.PutVulnerabilityID(tx, cve.CveID); err != nil {
-			return xerrors.Errorf("failed to save the vulnerability ID: %w", err)
+			return eb.Wrapf(err, "failed to save vulnerability ID")
 		}
 	}
 	return nil
 }
 
 func (vs VulnSrc) Get(release string, pkgName string) ([]types.Advisory, error) {
+	eb := oops.In("photon").With("release", release).With("pkg_name", pkgName)
 	bucket := fmt.Sprintf(platformFormat, release)
 	advisories, err := vs.dbc.GetAdvisories(bucket, pkgName)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to get Photon advisories: %w", err)
+		return nil, eb.Wrapf(err, "failed to get advisories")
 	}
 	return advisories, nil
 }

--- a/pkg/vulnsrc/photon/photon.go
+++ b/pkg/vulnsrc/photon/photon.go
@@ -84,7 +84,7 @@ func (vs VulnSrc) save(cves []PhotonCVE) error {
 func (vs VulnSrc) commit(tx *bolt.Tx, cves []PhotonCVE) error {
 	for _, cve := range cves {
 		platformName := fmt.Sprintf(platformFormat, cve.OSVersion)
-		eb := oops.With("platform", platformName).With("cve_id", cve.CveID).With("package_name", cve.Pkg)
+		eb := oops.With("platform", platformName).With("vuln_id", cve.CveID).With("package_name", cve.Pkg)
 
 		if err := vs.dbc.PutDataSource(tx, platformName, source); err != nil {
 			return eb.Wrapf(err, "failed to put data source")
@@ -114,7 +114,7 @@ func (vs VulnSrc) commit(tx *bolt.Tx, cves []PhotonCVE) error {
 }
 
 func (vs VulnSrc) Get(release string, pkgName string) ([]types.Advisory, error) {
-	eb := oops.In("photon").With("release", release).With("pkg_name", pkgName)
+	eb := oops.In("photon").With("release", release).With("package_name", pkgName)
 	bucket := fmt.Sprintf(platformFormat, release)
 	advisories, err := vs.dbc.GetAdvisories(bucket, pkgName)
 	if err != nil {

--- a/pkg/vulnsrc/photon/photon.go
+++ b/pkg/vulnsrc/photon/photon.go
@@ -53,7 +53,7 @@ func (vs VulnSrc) Update(dir string) error {
 
 		var cve PhotonCVE
 		if err := json.NewDecoder(r).Decode(&cve); err != nil {
-			return eb.Wrapf(err, "json decode error")
+			return eb.With("file_path", path).Wrapf(err, "json decode error")
 		}
 		cves = append(cves, cve)
 

--- a/pkg/vulnsrc/photon/photon_test.go
+++ b/pkg/vulnsrc/photon/photon_test.go
@@ -54,7 +54,7 @@ func TestVulnSrc_Update(t *testing.T) {
 		{
 			name:    "sad path (failed to decode)",
 			dir:     filepath.Join("testdata", "sad"),
-			wantErr: "failed to decode Photon JSON",
+			wantErr: "json decode error",
 		},
 	}
 	for _, tt := range tests {
@@ -102,7 +102,7 @@ func TestVulnSrc_Get(t *testing.T) {
 			fixtures: []string{"testdata/fixtures/sad.yaml"},
 			release:  "1.0",
 			pkgName:  "ansible",
-			wantErr:  "failed to unmarshal advisory JSON",
+			wantErr:  "json unmarshal error",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/vulnsrc/redhat-oval/parse.go
+++ b/pkg/vulnsrc/redhat-oval/parse.go
@@ -25,7 +25,7 @@ func unmarshalJSONFile(v interface{}, fileName string) error {
 	defer f.Close()
 
 	if err = json.NewDecoder(f).Decode(v); err != nil {
-		return eb.Wrapf(err, "decode error")
+		return eb.Wrapf(err, "json decode error")
 	}
 	return nil
 }

--- a/pkg/vulnsrc/redhat-oval/parse.go
+++ b/pkg/vulnsrc/redhat-oval/parse.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"golang.org/x/xerrors"
+	"github.com/samber/oops"
 )
 
 type rpmInfoTest struct {
@@ -16,22 +16,27 @@ type rpmInfoTest struct {
 }
 
 func unmarshalJSONFile(v interface{}, fileName string) error {
+	eb := oops.With("file_name", fileName)
+
 	f, err := os.Open(fileName)
 	if err != nil {
-		return xerrors.Errorf("unable to open a file (%s): %w", fileName, err)
+		return eb.Wrapf(err, "unable to open a file")
 	}
 	defer f.Close()
 
 	if err = json.NewDecoder(f).Decode(v); err != nil {
-		return xerrors.Errorf("failed to decode Red Hat OVAL JSON: %w", err)
+		return eb.Wrapf(err, "decode error")
 	}
 	return nil
 }
 
 func parseObjects(dir string) (map[string]string, error) {
+	filePath := filepath.Join(dir, "objects", "objects.json")
+	eb := oops.With("file_path", filePath)
+
 	var objects ovalObjects
-	if err := unmarshalJSONFile(&objects, filepath.Join(dir, "objects", "objects.json")); err != nil {
-		return nil, xerrors.Errorf("failed to unmarshal objects: %w", err)
+	if err := unmarshalJSONFile(&objects, filePath); err != nil {
+		return nil, eb.Wrapf(err, "failed to unmarshal objects")
 	}
 	objs := map[string]string{}
 	for _, obj := range objects.RpminfoObjects {
@@ -41,9 +46,12 @@ func parseObjects(dir string) (map[string]string, error) {
 }
 
 func parseStates(dir string) (map[string]rpminfoState, error) {
+	filePath := filepath.Join(dir, "states", "states.json")
+	eb := oops.With("file_path", filePath)
+
 	var ss ovalStates
-	if err := unmarshalJSONFile(&ss, filepath.Join(dir, "states", "states.json")); err != nil {
-		return nil, xerrors.Errorf("failed to unmarshal states: %w", err)
+	if err := unmarshalJSONFile(&ss, filePath); err != nil {
+		return nil, eb.Wrapf(err, "failed to unmarshal states")
 	}
 
 	states := map[string]rpminfoState{}
@@ -56,17 +64,17 @@ func parseStates(dir string) (map[string]rpminfoState, error) {
 func parseTests(dir string) (map[string]rpmInfoTest, error) {
 	objects, err := parseObjects(dir)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to parse objects: %w", err)
+		return nil, oops.Wrapf(err, "failed to parse objects")
 	}
 
 	states, err := parseStates(dir)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to parse states: %w", err)
+		return nil, oops.Wrapf(err, "failed to parse states")
 	}
 
 	var tt ovalTests
 	if err := unmarshalJSONFile(&tt, filepath.Join(dir, "tests", "tests.json")); err != nil {
-		return nil, xerrors.Errorf("failed to unmarshal states: %w", err)
+		return nil, oops.Wrapf(err, "failed to unmarshal states")
 	}
 
 	tests := map[string]rpmInfoTest{}
@@ -78,7 +86,7 @@ func parseTests(dir string) (map[string]rpmInfoTest, error) {
 
 		t, err := followTestRefs(test, objects, states)
 		if err != nil {
-			return nil, xerrors.Errorf("unable to follow test refs: %w", err)
+			return nil, oops.Wrapf(err, "unable to follow test refs")
 		}
 		tests[test.ID] = t
 	}
@@ -87,6 +95,7 @@ func parseTests(dir string) (map[string]rpmInfoTest, error) {
 
 func followTestRefs(test rpminfoTest, objects map[string]string, states map[string]rpminfoState) (rpmInfoTest, error) {
 	var t rpmInfoTest
+	eb := oops.With("object_ref", test.Object.ObjectRef).With("test_ref", test.ID).With("state_ref", test.State.StateRef)
 
 	// Follow object ref
 	if test.Object.ObjectRef == "" {
@@ -95,8 +104,7 @@ func followTestRefs(test rpminfoTest, objects map[string]string, states map[stri
 
 	pkgName, ok := objects[test.Object.ObjectRef]
 	if !ok {
-		return t, xerrors.Errorf("invalid tests data, can't find object ref: %s, test ref: %s",
-			test.Object.ObjectRef, test.ID)
+		return t, eb.Errorf("invalid tests data, can't find object ref")
 	}
 	t.Name = pkgName
 
@@ -107,8 +115,7 @@ func followTestRefs(test rpminfoTest, objects map[string]string, states map[stri
 
 	state, ok := states[test.State.StateRef]
 	if !ok {
-		return t, xerrors.Errorf("invalid tests data, can't find ovalstate ref %s, test ref: %s",
-			test.State.StateRef, test.ID)
+		return t, eb.Errorf("invalid tests data, can't find ovalstate ref")
 	}
 
 	t.SignatureKeyID = state.SignatureKeyID

--- a/pkg/vulnsrc/redhat-oval/parse.go
+++ b/pkg/vulnsrc/redhat-oval/parse.go
@@ -16,7 +16,7 @@ type rpmInfoTest struct {
 }
 
 func unmarshalJSONFile(v interface{}, fileName string) error {
-	eb := oops.With("file_name", fileName)
+	eb := oops.With("file_path", fileName)
 
 	f, err := os.Open(fileName)
 	if err != nil {
@@ -31,12 +31,9 @@ func unmarshalJSONFile(v interface{}, fileName string) error {
 }
 
 func parseObjects(dir string) (map[string]string, error) {
-	filePath := filepath.Join(dir, "objects", "objects.json")
-	eb := oops.With("file_path", filePath)
-
 	var objects ovalObjects
-	if err := unmarshalJSONFile(&objects, filePath); err != nil {
-		return nil, eb.Wrapf(err, "failed to unmarshal objects")
+	if err := unmarshalJSONFile(&objects, filepath.Join(dir, "objects", "objects.json")); err != nil {
+		return nil, oops.Wrapf(err, "failed to unmarshal objects")
 	}
 	objs := map[string]string{}
 	for _, obj := range objects.RpminfoObjects {
@@ -46,12 +43,9 @@ func parseObjects(dir string) (map[string]string, error) {
 }
 
 func parseStates(dir string) (map[string]rpminfoState, error) {
-	filePath := filepath.Join(dir, "states", "states.json")
-	eb := oops.With("file_path", filePath)
-
 	var ss ovalStates
-	if err := unmarshalJSONFile(&ss, filePath); err != nil {
-		return nil, eb.Wrapf(err, "failed to unmarshal states")
+	if err := unmarshalJSONFile(&ss, filepath.Join(dir, "states", "states.json")); err != nil {
+		return nil, oops.Wrapf(err, "failed to unmarshal states")
 	}
 
 	states := map[string]rpminfoState{}

--- a/pkg/vulnsrc/redhat-oval/redhat-oval.go
+++ b/pkg/vulnsrc/redhat-oval/redhat-oval.go
@@ -209,13 +209,12 @@ func (vs VulnSrc) save(repoToCpe, nvrToCpe map[string][]string, advisories map[b
 				advisory.Entries[i].AffectedCPEIndices = cpeList.Indices(advisory.Entries[i].AffectedCPEList)
 			}
 
-			eb := oops.With("vuln_id", bkt.vulnID).With("package_name", bkt.pkgName)
 			if err := vs.dbc.PutAdvisoryDetail(tx, bkt.vulnID, bkt.pkgName, []string{rootBucket}, advisory); err != nil {
-				return eb.Wrapf(err, "failed to save Red Hat OVAL advisory")
+				return oops.Wrapf(err, "failed to save Red Hat OVAL advisory")
 			}
 
 			if err := vs.dbc.PutVulnerabilityID(tx, bkt.vulnID); err != nil {
-				return eb.Wrapf(err, "failed to put vulnerability ID")
+				return oops.Wrapf(err, "failed to put vulnerability ID")
 			}
 		}
 
@@ -273,8 +272,6 @@ func (vs VulnSrc) Get(pkgName string, repositories, nvrs []string) ([]types.Advi
 
 	var advisories []types.Advisory
 	for vulnID, v := range rawAdvisories {
-		eb := eb.With("vuln_id", vulnID)
-
 		var adv Advisory
 		if err = json.Unmarshal(v.Content, &adv); err != nil {
 			return nil, eb.Wrapf(err, "failed to unmarshal advisory JSON")

--- a/pkg/vulnsrc/redhat-oval/redhat-oval.go
+++ b/pkg/vulnsrc/redhat-oval/redhat-oval.go
@@ -10,9 +10,9 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/samber/oops"
 	bolt "go.etcd.io/bbolt"
 	"golang.org/x/exp/slices"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy-db/pkg/db"
 	"github.com/aquasecurity/trivy-db/pkg/log"
@@ -58,41 +58,47 @@ func (vs VulnSrc) Name() types.SourceID {
 }
 
 func (vs VulnSrc) Update(dir string) error {
+	eb := oops.In("redhat-oval")
 	uniqCPEs := CPEMap{}
 
 	repoToCPE, err := vs.parseRepositoryCpeMapping(dir, uniqCPEs)
 	if err != nil {
-		return xerrors.Errorf("unable to store the mapping between repositories and CPE names: %w", err)
+		return eb.Wrapf(err, "unable to store the mapping between repositories and CPE names")
 	}
 
 	nvrToCPE, err := vs.parseNvrCpeMapping(dir, uniqCPEs)
 	if err != nil {
-		return xerrors.Errorf("unable to store the mapping between NVR and CPE names: %w", err)
+		return eb.Wrapf(err, "unable to store the mapping between NVR and CPE names")
 	}
 
 	// List version directories
 	rootDir := filepath.Join(dir, vulnListDir, ovalDir)
+	eb = eb.With("root_dir", rootDir)
+
 	versions, err := os.ReadDir(rootDir)
 	if err != nil {
-		return xerrors.Errorf("unable to list directory entries (%s): %w", rootDir, err)
+		return eb.Wrapf(err, "unable to list directory entries")
 	}
 
 	advisories := map[bucket]Advisory{}
 	for _, ver := range versions {
 		versionDir := filepath.Join(rootDir, ver.Name())
+		eb = eb.With("version_dir", versionDir)
+
 		streams, err := os.ReadDir(versionDir)
 		if err != nil {
-			return xerrors.Errorf("unable to get a list of directory entries (%s): %w", versionDir, err)
+			return eb.Wrapf(err, "unable to get a list of directory entries")
 		}
 
 		for _, f := range streams {
 			if !f.IsDir() {
 				continue
 			}
+			eb = eb.With("stream_dir", f.Name())
 
 			definitions, err := vs.parseOVALStream(filepath.Join(versionDir, f.Name()), uniqCPEs)
 			if err != nil {
-				return xerrors.Errorf("failed to parse OVAL stream: %w", err)
+				return eb.Wrapf(err, "failed to parse OVAL stream")
 			}
 
 			advisories = vs.mergeAdvisories(advisories, definitions)
@@ -100,7 +106,7 @@ func (vs VulnSrc) Update(dir string) error {
 	}
 
 	if err = vs.save(repoToCPE, nvrToCPE, advisories, uniqCPEs); err != nil {
-		return xerrors.Errorf("save error: %w", err)
+		return eb.Wrapf(err, "save error")
 	}
 
 	return nil
@@ -108,15 +114,17 @@ func (vs VulnSrc) Update(dir string) error {
 
 func (vs VulnSrc) parseRepositoryCpeMapping(dir string, uniqCPEs CPEMap) (map[string][]string, error) {
 	filePath := filepath.Join(dir, vulnListDir, cpeDir, "repository-to-cpe.json")
+	eb := oops.With("file_path", filePath)
+
 	f, err := os.Open(filePath)
 	if err != nil {
-		return nil, xerrors.Errorf("file open error: %w", err)
+		return nil, eb.Wrapf(err, "file open error")
 	}
 	defer f.Close()
 
 	var repoToCPE map[string][]string
 	if err = json.NewDecoder(f).Decode(&repoToCPE); err != nil {
-		return nil, xerrors.Errorf("JSON parse error: %w", err)
+		return nil, eb.Wrapf(err, "JSON parse error")
 	}
 
 	for _, cpes := range repoToCPE {
@@ -128,15 +136,17 @@ func (vs VulnSrc) parseRepositoryCpeMapping(dir string, uniqCPEs CPEMap) (map[st
 
 func (vs VulnSrc) parseNvrCpeMapping(dir string, uniqCPEs CPEMap) (map[string][]string, error) {
 	filePath := filepath.Join(dir, vulnListDir, cpeDir, "nvr-to-cpe.json")
+	eb := oops.With("file_path", filePath)
+
 	f, err := os.Open(filePath)
 	if err != nil {
-		return nil, xerrors.Errorf("file open error: %w", err)
+		return nil, eb.Wrapf(err, "file open error")
 	}
 	defer f.Close()
 
 	nvrToCpe := map[string][]string{}
 	if err = json.NewDecoder(f).Decode(&nvrToCpe); err != nil {
-		return nil, xerrors.Errorf("JSON parse error: %w", err)
+		return nil, eb.Wrapf(err, "JSON parse error")
 	}
 
 	for _, cpes := range nvrToCpe {
@@ -175,20 +185,20 @@ func (vs VulnSrc) save(repoToCpe, nvrToCpe map[string][]string, advisories map[b
 	cpeList := uniqCPEs.List()
 	err := vs.dbc.BatchUpdate(func(tx *bolt.Tx) error {
 		if err := vs.dbc.PutDataSource(tx, rootBucket, source); err != nil {
-			return xerrors.Errorf("failed to put data source: %w", err)
+			return oops.Wrapf(err, "failed to put data source")
 		}
 
 		// Store the mapping between repository and CPE names
 		for repo, cpes := range repoToCpe {
 			if err := vs.dbc.PutRedHatRepositories(tx, repo, cpeList.Indices(cpes)); err != nil {
-				return xerrors.Errorf("repository put error: %w", err)
+				return oops.With("repo", repo).Wrapf(err, "repository put error")
 			}
 		}
 
 		// Store the mapping between NVR and CPE names
 		for nvr, cpes := range nvrToCpe {
 			if err := vs.dbc.PutRedHatNVRs(tx, nvr, cpeList.Indices(cpes)); err != nil {
-				return xerrors.Errorf("NVR put error: %w", err)
+				return oops.With("nvr", nvr).Wrapf(err, "NVR put error")
 			}
 		}
 
@@ -199,26 +209,27 @@ func (vs VulnSrc) save(repoToCpe, nvrToCpe map[string][]string, advisories map[b
 				advisory.Entries[i].AffectedCPEIndices = cpeList.Indices(advisory.Entries[i].AffectedCPEList)
 			}
 
+			eb := oops.With("vuln_id", bkt.vulnID).With("pkg_name", bkt.pkgName)
 			if err := vs.dbc.PutAdvisoryDetail(tx, bkt.vulnID, bkt.pkgName, []string{rootBucket}, advisory); err != nil {
-				return xerrors.Errorf("failed to save Red Hat OVAL advisory: %w", err)
+				return eb.Wrapf(err, "failed to save Red Hat OVAL advisory")
 			}
 
 			if err := vs.dbc.PutVulnerabilityID(tx, bkt.vulnID); err != nil {
-				return xerrors.Errorf("failed to put severity: %w", err)
+				return eb.Wrapf(err, "failed to put vulnerability ID")
 			}
 		}
 
 		// Store CPE indices for debug information
 		for i, cpe := range cpeList {
 			if err := vs.dbc.PutRedHatCPEs(tx, i, cpe); err != nil {
-				return xerrors.Errorf("CPE put error: %w", err)
+				return oops.With("cpe", cpe).Wrapf(err, "cpe put error")
 			}
 		}
 
 		return nil
 	})
 	if err != nil {
-		return xerrors.Errorf("batch update error: %w", err)
+		return oops.Wrapf(err, "batch update error")
 	}
 	return nil
 }
@@ -228,7 +239,7 @@ func (vs VulnSrc) cpeIndices(repositories, nvrs []string) ([]int, error) {
 	for _, repo := range repositories {
 		results, err := vs.dbc.RedHatRepoToCPEs(repo)
 		if err != nil {
-			return nil, xerrors.Errorf("unable to convert repositories to CPEs: %w", err)
+			return nil, oops.With("repo", repo).Wrapf(err, "unable to convert repositories to CPEs")
 		}
 		cpeIndices = append(cpeIndices, results...)
 	}
@@ -236,7 +247,7 @@ func (vs VulnSrc) cpeIndices(repositories, nvrs []string) ([]int, error) {
 	for _, nvr := range nvrs {
 		results, err := vs.dbc.RedHatNVRToCPEs(nvr)
 		if err != nil {
-			return nil, xerrors.Errorf("unable to convert repositories to CPEs: %w", err)
+			return nil, oops.With("nvr", nvr).Wrapf(err, "unable to convert repositories to CPEs")
 		}
 		cpeIndices = append(cpeIndices, results...)
 	}
@@ -245,25 +256,28 @@ func (vs VulnSrc) cpeIndices(repositories, nvrs []string) ([]int, error) {
 }
 
 func (vs VulnSrc) Get(pkgName string, repositories, nvrs []string) ([]types.Advisory, error) {
+	eb := oops.In("redhat-oval").With("pkg_name", pkgName).With("repositories", repositories).With("nvrs", nvrs)
 	cpeIndices, err := vs.cpeIndices(repositories, nvrs)
 	if err != nil {
-		return nil, xerrors.Errorf("CPE convert error: %w", err)
+		return nil, eb.Wrapf(err, "cpe convert error")
 	}
 
 	if len(cpeIndices) == 0 {
-		return nil, xerrors.Errorf("unable to find CPE indices. See https://github.com/aquasecurity/trivy-db/issues/435 for details")
+		return nil, eb.Errorf("unable to find CPE indices. See https://github.com/aquasecurity/trivy-db/issues/435 for details")
 	}
 
 	rawAdvisories, err := vs.dbc.ForEachAdvisory([]string{rootBucket}, pkgName)
 	if err != nil {
-		return nil, xerrors.Errorf("unable to iterate advisories: %w", err)
+		return nil, eb.Wrapf(err, "unable to iterate advisories")
 	}
 
 	var advisories []types.Advisory
 	for vulnID, v := range rawAdvisories {
+		eb = eb.With("vuln_id", vulnID)
+
 		var adv Advisory
 		if err = json.Unmarshal(v.Content, &adv); err != nil {
-			return nil, xerrors.Errorf("failed to unmarshal advisory JSON: %w", err)
+			return nil, eb.Wrapf(err, "failed to unmarshal advisory JSON")
 		}
 
 		for _, entry := range adv.Entries {
@@ -301,7 +315,7 @@ func (vs VulnSrc) parseOVALStream(dir string, uniqCPEs CPEMap) (map[bucket]Defin
 	// Parse tests
 	tests, err := parseTests(dir)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to parse ovalTests: %w", err)
+		return nil, oops.Wrapf(err, "failed to parse ovalTests")
 	}
 
 	var advisories []redhatOVAL
@@ -310,17 +324,18 @@ func (vs VulnSrc) parseOVALStream(dir string, uniqCPEs CPEMap) (map[bucket]Defin
 		return nil, nil
 	}
 
+	eb := oops.With("definitions_dir", definitionsDir)
 	err = utils.FileWalk(definitionsDir, func(r io.Reader, path string) error {
 		var definition redhatOVAL
 		if err := json.NewDecoder(r).Decode(&definition); err != nil {
-			return xerrors.Errorf("failed to decode %s: %w", path, err)
+			return eb.With("file_path", path).Wrapf(err, "json decode error")
 		}
 		advisories = append(advisories, definition)
 		return nil
 	})
 
 	if err != nil {
-		return nil, xerrors.Errorf("Red Hat OVAL walk error: %w", err)
+		return nil, eb.Wrapf(err, "oval walk error")
 	}
 
 	return parseDefinitions(advisories, tests, uniqCPEs), nil

--- a/pkg/vulnsrc/redhat-oval/redhat-oval_test.go
+++ b/pkg/vulnsrc/redhat-oval/redhat-oval_test.go
@@ -788,7 +788,7 @@ func TestVulnSrc_Update(t *testing.T) {
 		{
 			name:    "broken JSON",
 			dir:     filepath.Join("testdata", "sad"),
-			wantErr: "failed to decode",
+			wantErr: "failed to parse OVAL stream",
 		},
 	}
 

--- a/pkg/vulnsrc/redhat-oval/redhat-oval_test.go
+++ b/pkg/vulnsrc/redhat-oval/redhat-oval_test.go
@@ -783,7 +783,7 @@ func TestVulnSrc_Update(t *testing.T) {
 		{
 			name:    "broken repo-to-cpe",
 			dir:     filepath.Join("testdata", "broken-repo-to-cpe"),
-			wantErr: "JSON parse error",
+			wantErr: "json parse error",
 		},
 		{
 			name:    "broken JSON",

--- a/pkg/vulnsrc/redhat/redhat.go
+++ b/pkg/vulnsrc/redhat/redhat.go
@@ -8,10 +8,10 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/samber/oops"
 	bolt "go.etcd.io/bbolt"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy-db/pkg/db"
 	"github.com/aquasecurity/trivy-db/pkg/log"
@@ -45,61 +45,66 @@ func (vs VulnSrc) Name() types.SourceID {
 
 func (vs VulnSrc) Update(dir string) error {
 	rootDir := filepath.Join(dir, vulnListDir, apiDir)
+	eb := oops.In("redhat").With("root_dir", rootDir)
 
 	var cves []RedhatCVE
-	err := utils.FileWalk(rootDir, func(r io.Reader, _ string) error {
+	err := utils.FileWalk(rootDir, func(r io.Reader, path string) error {
+		eb := eb.With("file_path", path)
+
 		content, err := io.ReadAll(r)
 		if err != nil {
-			return err
+			return eb.Wrap(err)
 		}
 		cve := RedhatCVE{}
 		if err = json.Unmarshal(content, &cve); err != nil {
-			return xerrors.Errorf("failed to decode RedHat JSON: %w", err)
+			return eb.Wrapf(err, "json decode error")
 		}
+
 		switch cve.TempAffectedRelease.(type) {
 		case []interface{}:
 			var ar RedhatCVEAffectedReleaseArray
 			if err = json.Unmarshal(content, &ar); err != nil {
-				return xerrors.Errorf("unknown affected_release type: %w", err)
+				return eb.Wrapf(err, "unknown affected_release type")
 			}
 			cve.AffectedRelease = ar.AffectedRelease
 		case map[string]interface{}:
 			var ar RedhatCVEAffectedReleaseObject
 			if err = json.Unmarshal(content, &ar); err != nil {
-				return xerrors.Errorf("unknown affected_release type: %w", err)
+				return eb.Wrapf(err, "unknown affected_release type")
 			}
 			cve.AffectedRelease = []RedhatAffectedRelease{ar.AffectedRelease}
 		case nil:
 		default:
-			return xerrors.New("unknown affected_release type")
+			return eb.Errorf("unknown affected_release type")
 		}
 
 		switch cve.TempPackageState.(type) {
 		case []interface{}:
 			var ps RedhatCVEPackageStateArray
 			if err = json.Unmarshal(content, &ps); err != nil {
-				return xerrors.Errorf("unknown package_state type: %w", err)
+				return eb.Wrapf(err, "unknown package_state type")
 			}
 			cve.PackageState = ps.PackageState
 		case map[string]interface{}:
 			var ps RedhatCVEPackageStateObject
 			if err = json.Unmarshal(content, &ps); err != nil {
-				return xerrors.Errorf("unknown package_state type: %w", err)
+				return eb.Wrapf(err, "unknown package_state type")
 			}
 			cve.PackageState = []RedhatPackageState{ps.PackageState}
 		case nil:
 		default:
-			return xerrors.New("unknown package_state type")
+			return eb.Errorf("unknown package_state type")
 		}
+
 		cves = append(cves, cve)
 		return nil
 	})
 	if err != nil {
-		return xerrors.Errorf("error in Red Hat walk: %w", err)
+		return eb.Wrapf(err, "walk error")
 	}
 
 	if err = vs.save(cves); err != nil {
-		return xerrors.Errorf("error in Red Hat save: %w", err)
+		return eb.Wrapf(err, "save error")
 	}
 
 	return nil
@@ -111,7 +116,7 @@ func (vs VulnSrc) save(cves []RedhatCVE) error {
 		return vs.commit(tx, cves)
 	})
 	if err != nil {
-		return xerrors.Errorf("failed batch update: %w", err)
+		return oops.Wrapf(err, "batch update error")
 	}
 	return nil
 }
@@ -142,13 +147,14 @@ func (vs VulnSrc) putVulnerabilityDetail(tx *bolt.Tx, cve RedhatCVE) error {
 		Title:        strings.TrimSpace(title),
 		Description:  strings.TrimSpace(strings.Join(cve.Details, "")),
 	}
+	eb := oops.With("cve_id", cve.Name)
 	if err := vs.dbc.PutVulnerabilityDetail(tx, cve.Name, vulnerability.RedHat, vuln); err != nil {
-		return xerrors.Errorf("failed to save Red Hat vulnerability: %w", err)
+		return eb.Wrapf(err, "failed to save vulnerability detail")
 	}
 
 	// for optimization
 	if err := vs.dbc.PutVulnerabilityID(tx, cve.Name); err != nil {
-		return xerrors.Errorf("failed to save the vulnerability ID: %w", err)
+		return eb.Wrapf(err, "failed to save the vulnerability ID")
 	}
 	return nil
 }

--- a/pkg/vulnsrc/redhat/redhat.go
+++ b/pkg/vulnsrc/redhat/redhat.go
@@ -147,7 +147,7 @@ func (vs VulnSrc) putVulnerabilityDetail(tx *bolt.Tx, cve RedhatCVE) error {
 		Title:        strings.TrimSpace(title),
 		Description:  strings.TrimSpace(strings.Join(cve.Details, "")),
 	}
-	eb := oops.With("cve_id", cve.Name)
+	eb := oops.With("vuln_id", cve.Name)
 	if err := vs.dbc.PutVulnerabilityDetail(tx, cve.Name, vulnerability.RedHat, vuln); err != nil {
 		return eb.Wrapf(err, "failed to save vulnerability detail")
 	}

--- a/pkg/vulnsrc/redhat/redhat.go
+++ b/pkg/vulnsrc/redhat/redhat.go
@@ -147,14 +147,13 @@ func (vs VulnSrc) putVulnerabilityDetail(tx *bolt.Tx, cve RedhatCVE) error {
 		Title:        strings.TrimSpace(title),
 		Description:  strings.TrimSpace(strings.Join(cve.Details, "")),
 	}
-	eb := oops.With("vuln_id", cve.Name)
 	if err := vs.dbc.PutVulnerabilityDetail(tx, cve.Name, vulnerability.RedHat, vuln); err != nil {
-		return eb.Wrapf(err, "failed to save vulnerability detail")
+		return oops.Wrapf(err, "failed to save vulnerability detail")
 	}
 
 	// for optimization
 	if err := vs.dbc.PutVulnerabilityID(tx, cve.Name); err != nil {
-		return eb.Wrapf(err, "failed to save the vulnerability ID")
+		return oops.Wrapf(err, "failed to save the vulnerability ID")
 	}
 	return nil
 }

--- a/pkg/vulnsrc/redhat/redhat_test.go
+++ b/pkg/vulnsrc/redhat/redhat_test.go
@@ -220,7 +220,7 @@ func TestVulnSrc_Update(t *testing.T) {
 		{
 			name:    "sad8: failed to decode",
 			dir:     filepath.Join("testdata", "sad8"),
-			wantErr: "failed to decode RedHat JSON",
+			wantErr: "json decode error",
 		},
 		{
 			name:    "sad9: dir doesn't exist",

--- a/pkg/vulnsrc/rocky/rocky.go
+++ b/pkg/vulnsrc/rocky/rocky.go
@@ -9,9 +9,9 @@ import (
 	"strings"
 
 	"github.com/samber/lo"
+	"github.com/samber/oops"
 	bolt "go.etcd.io/bbolt"
 	"golang.org/x/exp/slices"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy-db/pkg/db"
 	"github.com/aquasecurity/trivy-db/pkg/log"
@@ -78,12 +78,14 @@ func (vs *VulnSrc) Name() types.SourceID {
 
 func (vs *VulnSrc) Update(dir string) error {
 	rootDir := filepath.Join(dir, "vuln-list", rockyDir)
+	eb := oops.In("rocky").With("root_dir", rootDir)
+
 	errata, err := vs.parse(rootDir)
 	if err != nil {
-		return err
+		return eb.Wrap(err)
 	}
 	if err = vs.put(errata); err != nil {
-		return xerrors.Errorf("error in Rocky save: %w", err)
+		return eb.Wrapf(err, "save error")
 	}
 
 	return nil
@@ -94,9 +96,11 @@ func (vs *VulnSrc) Update(dir string) error {
 func (vs *VulnSrc) parse(rootDir string) (map[string][]RLSA, error) {
 	errata := map[string][]RLSA{}
 	err := utils.FileWalk(rootDir, func(r io.Reader, path string) error {
+		eb := oops.With("file_path", path)
+
 		var erratum RLSA
 		if err := json.NewDecoder(r).Decode(&erratum); err != nil {
-			return xerrors.Errorf("failed to decode Rocky erratum: %w", err)
+			return eb.Wrapf(err, "json decode error")
 		}
 
 		dirs := strings.Split(strings.TrimPrefix(path, rootDir), string(filepath.Separator))[1:]
@@ -125,7 +129,7 @@ func (vs *VulnSrc) parse(rootDir string) (map[string][]RLSA, error) {
 		return nil
 	})
 	if err != nil {
-		return nil, xerrors.Errorf("error in Rocky walk: %w", err)
+		return nil, oops.Wrapf(err, "walk error")
 	}
 	return errata, nil
 }
@@ -134,17 +138,18 @@ func (vs *VulnSrc) put(errataVer map[string][]RLSA) error {
 	err := vs.BatchUpdate(func(tx *bolt.Tx) error {
 		for majorVer, errata := range errataVer {
 			platformName := fmt.Sprintf(platformFormat, majorVer)
+			eb := oops.With("platform", platformName).With("major_version", majorVer)
 			if err := vs.PutDataSource(tx, platformName, source); err != nil {
-				return xerrors.Errorf("failed to put data source: %w", err)
+				return eb.Wrapf(err, "failed to put data source")
 			}
 			if err := vs.commit(tx, platformName, errata); err != nil {
-				return xerrors.Errorf("error in save Rocky %s: %w", majorVer, err)
+				return eb.Wrapf(err, "save error")
 			}
 		}
 		return nil
 	})
 	if err != nil {
-		return xerrors.Errorf("error in db batch update: %w", err)
+		return oops.Wrapf(err, "batch update error")
 	}
 	return nil
 }
@@ -232,20 +237,21 @@ func (vs *VulnSrc) commit(tx *bolt.Tx, platformName string, errata []RLSA) error
 	for _, input := range savedInputs {
 		err := vs.Put(tx, input)
 		if err != nil {
-			return xerrors.Errorf("db put error: %w", err)
+			return oops.Wrapf(err, "db put error")
 		}
 	}
 	return nil
 }
 
 func (r *Rocky) Put(tx *bolt.Tx, input PutInput) error {
+	eb := oops.With("platform", input.PlatformName).With("cve_id", input.CveID)
 	if err := r.PutVulnerabilityDetail(tx, input.CveID, source.ID, input.Vuln); err != nil {
-		return xerrors.Errorf("failed to save Rocky vulnerability: %w", err)
+		return eb.Wrapf(err, "failed to save vulnerability detail")
 	}
 
 	// for optimization
 	if err := r.PutVulnerabilityID(tx, input.CveID); err != nil {
-		return xerrors.Errorf("failed to save the vulnerability ID: %w", err)
+		return eb.Wrapf(err, "failed to save vulnerability ID")
 	}
 
 	for pkgName, advisory := range input.Advisories {
@@ -254,23 +260,25 @@ func (r *Rocky) Put(tx *bolt.Tx, input PutInput) error {
 			sort.Strings(entry.VendorIDs)
 		}
 		if err := r.PutAdvisoryDetail(tx, input.CveID, pkgName, []string{input.PlatformName}, advisory); err != nil {
-			return xerrors.Errorf("failed to save Rocky advisory: %w", err)
+			return eb.With("pkg_name", pkgName).Wrapf(err, "failed to save advisory")
 		}
 	}
 	return nil
 }
 
 func (r *Rocky) Get(release, pkgName, arch string) ([]types.Advisory, error) {
+	eb := oops.In("rocky").With("release", release).With("pkg_name", pkgName).With("arch", arch)
 	bucket := fmt.Sprintf(platformFormat, release)
 	rawAdvisories, err := r.ForEachAdvisory([]string{bucket}, pkgName)
 	if err != nil {
-		return nil, xerrors.Errorf("unable to iterate advisories: %w", err)
+		return nil, eb.Wrapf(err, "unable to iterate advisories")
 	}
+
 	var advisories []types.Advisory
 	for vulnID, v := range rawAdvisories {
 		var adv types.Advisories
 		if err = json.Unmarshal(v.Content, &adv); err != nil {
-			return nil, xerrors.Errorf("failed to unmarshal advisory JSON: %w", err)
+			return nil, eb.With("vuln_id", vulnID).Wrapf(err, "json unmarshal error")
 		}
 
 		// For backward compatibility

--- a/pkg/vulnsrc/rocky/rocky.go
+++ b/pkg/vulnsrc/rocky/rocky.go
@@ -138,7 +138,7 @@ func (vs *VulnSrc) put(errataVer map[string][]RLSA) error {
 	err := vs.BatchUpdate(func(tx *bolt.Tx) error {
 		for majorVer, errata := range errataVer {
 			platformName := fmt.Sprintf(platformFormat, majorVer)
-			eb := oops.With("platform", platformName).With("major_version", majorVer)
+			eb := oops.With("major_version", majorVer)
 			if err := vs.PutDataSource(tx, platformName, source); err != nil {
 				return eb.Wrapf(err, "failed to put data source")
 			}
@@ -244,14 +244,13 @@ func (vs *VulnSrc) commit(tx *bolt.Tx, platformName string, errata []RLSA) error
 }
 
 func (r *Rocky) Put(tx *bolt.Tx, input PutInput) error {
-	eb := oops.With("platform", input.PlatformName).With("vuln_id", input.CveID)
 	if err := r.PutVulnerabilityDetail(tx, input.CveID, source.ID, input.Vuln); err != nil {
-		return eb.Wrapf(err, "failed to save vulnerability detail")
+		return oops.Wrapf(err, "failed to save vulnerability detail")
 	}
 
 	// for optimization
 	if err := r.PutVulnerabilityID(tx, input.CveID); err != nil {
-		return eb.Wrapf(err, "failed to save vulnerability ID")
+		return oops.Wrapf(err, "failed to save vulnerability ID")
 	}
 
 	for pkgName, advisory := range input.Advisories {
@@ -260,7 +259,7 @@ func (r *Rocky) Put(tx *bolt.Tx, input PutInput) error {
 			sort.Strings(entry.VendorIDs)
 		}
 		if err := r.PutAdvisoryDetail(tx, input.CveID, pkgName, []string{input.PlatformName}, advisory); err != nil {
-			return eb.With("pkg_name", pkgName).Wrapf(err, "failed to save advisory")
+			return oops.Wrapf(err, "failed to save advisory")
 		}
 	}
 	return nil

--- a/pkg/vulnsrc/rocky/rocky.go
+++ b/pkg/vulnsrc/rocky/rocky.go
@@ -82,7 +82,7 @@ func (vs *VulnSrc) Update(dir string) error {
 
 	errata, err := vs.parse(rootDir)
 	if err != nil {
-		return eb.Wrap(err)
+		return eb.Wrapf(err, "parse error")
 	}
 	if err = vs.put(errata); err != nil {
 		return eb.Wrapf(err, "save error")
@@ -244,7 +244,7 @@ func (vs *VulnSrc) commit(tx *bolt.Tx, platformName string, errata []RLSA) error
 }
 
 func (r *Rocky) Put(tx *bolt.Tx, input PutInput) error {
-	eb := oops.With("platform", input.PlatformName).With("cve_id", input.CveID)
+	eb := oops.With("platform", input.PlatformName).With("vuln_id", input.CveID)
 	if err := r.PutVulnerabilityDetail(tx, input.CveID, source.ID, input.Vuln); err != nil {
 		return eb.Wrapf(err, "failed to save vulnerability detail")
 	}
@@ -267,7 +267,7 @@ func (r *Rocky) Put(tx *bolt.Tx, input PutInput) error {
 }
 
 func (r *Rocky) Get(release, pkgName, arch string) ([]types.Advisory, error) {
-	eb := oops.In("rocky").With("release", release).With("pkg_name", pkgName).With("arch", arch)
+	eb := oops.In("rocky").With("release", release).With("package_name", pkgName).With("arch", arch)
 	bucket := fmt.Sprintf(platformFormat, release)
 	rawAdvisories, err := r.ForEachAdvisory([]string{bucket}, pkgName)
 	if err != nil {

--- a/pkg/vulnsrc/rocky/rocky_test.go
+++ b/pkg/vulnsrc/rocky/rocky_test.go
@@ -368,7 +368,7 @@ func TestVulnSrc_Update(t *testing.T) {
 		{
 			name:    "sad path",
 			dir:     filepath.Join("testdata", "sad"),
-			wantErr: "failed to decode Rocky erratum",
+			wantErr: "json decode error",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/vulnsrc/suse-cvrf/suse-cvrf.go
+++ b/pkg/vulnsrc/suse-cvrf/suse-cvrf.go
@@ -83,7 +83,6 @@ func (vs VulnSrc) Update(dir string) error {
 
 	var cvrfs []SuseCvrf
 	err := utils.FileWalk(rootDir, func(r io.Reader, path string) error {
-		eb := eb.With("file_path", path)
 		var cvrf SuseCvrf
 		if err := json.NewDecoder(r).Decode(&cvrf); err != nil {
 			return eb.With("file_path", path).Wrapf(err, "json decode error")
@@ -123,15 +122,14 @@ func (vs VulnSrc) commit(tx *bolt.Tx, cvrfs []SuseCvrf) error {
 			advisory := types.Advisory{
 				FixedVersion: affectedPkg.Package.FixedVersion,
 			}
-			eb := oops.With("os_ver", affectedPkg.OSVer).With("package_name", affectedPkg.Package.Name).With("fixed_version", affectedPkg.Package.FixedVersion)
 
 			if err := vs.dbc.PutDataSource(tx, affectedPkg.OSVer, source); err != nil {
-				return eb.Wrapf(err, "failed to put data source")
+				return oops.Wrapf(err, "failed to put data source")
 			}
 
 			if err := vs.dbc.PutAdvisoryDetail(tx, cvrf.Tracking.ID, affectedPkg.Package.Name,
 				[]string{affectedPkg.OSVer}, advisory); err != nil {
-				return eb.Wrapf(err, "unable to save CVRF")
+				return oops.Wrapf(err, "unable to save CVRF")
 			}
 		}
 

--- a/pkg/vulnsrc/suse-cvrf/suse-cvrf.go
+++ b/pkg/vulnsrc/suse-cvrf/suse-cvrf.go
@@ -86,7 +86,7 @@ func (vs VulnSrc) Update(dir string) error {
 		eb := eb.With("file_path", path)
 		var cvrf SuseCvrf
 		if err := json.NewDecoder(r).Decode(&cvrf); err != nil {
-			return eb.Wrapf(err, "json decode error")
+			return eb.With("file_path", path).Wrapf(err, "json decode error")
 		}
 		cvrfs = append(cvrfs, cvrf)
 		return nil

--- a/pkg/vulnsrc/suse-cvrf/suse-cvrf_test.go
+++ b/pkg/vulnsrc/suse-cvrf/suse-cvrf_test.go
@@ -253,7 +253,7 @@ func TestVulnSrc_Update(t *testing.T) {
 			name:    "sad path (failed to decode)",
 			dir:     filepath.Join("testdata", "sad"),
 			dist:    OpenSUSE,
-			wantErr: "failed to decode SUSE CVRF JSON",
+			wantErr: "json decode error",
 		},
 	}
 	for _, tt := range tests {
@@ -305,7 +305,7 @@ func TestVulnSrc_Get(t *testing.T) {
 			version:  "13.1",
 			pkgName:  "bind",
 			dist:     OpenSUSE,
-			wantErr:  "failed to unmarshal advisory JSON",
+			wantErr:  "json unmarshal error",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/vulnsrc/ubuntu/ubuntu.go
+++ b/pkg/vulnsrc/ubuntu/ubuntu.go
@@ -144,7 +144,7 @@ func (vs VulnSrc) commit(tx *bolt.Tx, cves []UbuntuCVE) error {
 }
 
 func (vs VulnSrc) Get(release string, pkgName string) ([]types.Advisory, error) {
-	eb := oops.In("ubuntu").With("release", release).With("pkg_name", pkgName)
+	eb := oops.In("ubuntu").With("release", release).With("package_name", pkgName)
 	bucket := fmt.Sprintf(platformFormat, release)
 	advisories, err := vs.dbc.GetAdvisories(bucket, pkgName)
 	if err != nil {
@@ -159,10 +159,10 @@ func defaultPut(dbc db.Operation, tx *bolt.Tx, advisory interface{}) error {
 		return oops.Errorf("unknown type")
 	}
 
-	eb := oops.With("cve_id", cve.Candidate)
+	eb := oops.With("vuln_id", cve.Candidate)
 	for packageName, patch := range cve.Patches {
 		pkgName := string(packageName)
-		eb := eb.With("pkg_name", pkgName)
+		eb := eb.With("package_name", pkgName)
 		for release, status := range patch {
 			if !slices.Contains(targetStatuses, status.Status) {
 				continue

--- a/pkg/vulnsrc/ubuntu/ubuntu.go
+++ b/pkg/vulnsrc/ubuntu/ubuntu.go
@@ -7,8 +7,8 @@ import (
 	"path/filepath"
 	"slices"
 
+	"github.com/samber/oops"
 	bolt "go.etcd.io/bbolt"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy-db/pkg/db"
 	"github.com/aquasecurity/trivy-db/pkg/log"
@@ -98,21 +98,22 @@ func (vs VulnSrc) Name() types.SourceID {
 
 func (vs VulnSrc) Update(dir string) error {
 	rootDir := filepath.Join(dir, "vuln-list", ubuntuDir)
+	eb := oops.In("ubuntu").With("root_dir", rootDir)
 	var cves []UbuntuCVE
 	err := utils.FileWalk(rootDir, func(r io.Reader, path string) error {
 		var cve UbuntuCVE
 		if err := json.NewDecoder(r).Decode(&cve); err != nil {
-			return xerrors.Errorf("failed to decode Ubuntu JSON: %w", err)
+			return eb.With("file_path", path).Wrapf(err, "json decode error")
 		}
 		cves = append(cves, cve)
 		return nil
 	})
 	if err != nil {
-		return xerrors.Errorf("error in Ubuntu walk: %w", err)
+		return eb.Wrapf(err, "walk error")
 	}
 
 	if err = vs.save(cves); err != nil {
-		return xerrors.Errorf("error in Ubuntu save: %w", err)
+		return eb.Wrapf(err, "save error")
 	}
 
 	return nil
@@ -128,7 +129,7 @@ func (vs VulnSrc) save(cves []UbuntuCVE) error {
 		return nil
 	})
 	if err != nil {
-		return xerrors.Errorf("error in batch update: %w", err)
+		return oops.Wrapf(err, "batch update error")
 	}
 	return nil
 }
@@ -136,17 +137,18 @@ func (vs VulnSrc) save(cves []UbuntuCVE) error {
 func (vs VulnSrc) commit(tx *bolt.Tx, cves []UbuntuCVE) error {
 	for _, cve := range cves {
 		if err := vs.put(vs.dbc, tx, cve); err != nil {
-			return xerrors.Errorf("put error: %w", err)
+			return oops.Wrapf(err, "put error")
 		}
 	}
 	return nil
 }
 
 func (vs VulnSrc) Get(release string, pkgName string) ([]types.Advisory, error) {
+	eb := oops.In("ubuntu").With("release", release).With("pkg_name", pkgName)
 	bucket := fmt.Sprintf(platformFormat, release)
 	advisories, err := vs.dbc.GetAdvisories(bucket, pkgName)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to get Ubuntu advisories: %w", err)
+		return nil, eb.Wrapf(err, "failed to get advisories")
 	}
 	return advisories, nil
 }
@@ -154,11 +156,13 @@ func (vs VulnSrc) Get(release string, pkgName string) ([]types.Advisory, error) 
 func defaultPut(dbc db.Operation, tx *bolt.Tx, advisory interface{}) error {
 	cve, ok := advisory.(UbuntuCVE)
 	if !ok {
-		return xerrors.New("unknown type")
+		return oops.Errorf("unknown type")
 	}
 
+	eb := oops.With("cve_id", cve.Candidate)
 	for packageName, patch := range cve.Patches {
 		pkgName := string(packageName)
+		eb := eb.With("pkg_name", pkgName)
 		for release, status := range patch {
 			if !slices.Contains(targetStatuses, status.Status) {
 				continue
@@ -168,8 +172,9 @@ func defaultPut(dbc db.Operation, tx *bolt.Tx, advisory interface{}) error {
 				continue
 			}
 			platformName := fmt.Sprintf(platformFormat, osVersion)
+			eb := eb.With("platform", platformName)
 			if err := dbc.PutDataSource(tx, platformName, source); err != nil {
-				return xerrors.Errorf("failed to put data source: %w", err)
+				return eb.Wrapf(err, "failed to put data source")
 			}
 
 			adv := types.Advisory{}
@@ -177,7 +182,7 @@ func defaultPut(dbc db.Operation, tx *bolt.Tx, advisory interface{}) error {
 				adv.FixedVersion = status.Note
 			}
 			if err := dbc.PutAdvisoryDetail(tx, cve.Candidate, pkgName, []string{platformName}, adv); err != nil {
-				return xerrors.Errorf("failed to save Ubuntu advisory: %w", err)
+				return eb.Wrapf(err, "failed to save advisory")
 			}
 
 			vuln := types.VulnerabilityDetail{
@@ -186,12 +191,12 @@ func defaultPut(dbc db.Operation, tx *bolt.Tx, advisory interface{}) error {
 				Description: cve.Description,
 			}
 			if err := dbc.PutVulnerabilityDetail(tx, cve.Candidate, source.ID, vuln); err != nil {
-				return xerrors.Errorf("failed to save Ubuntu vulnerability: %w", err)
+				return eb.Wrapf(err, "failed to save vulnerability")
 			}
 
 			// for optimization
 			if err := dbc.PutVulnerabilityID(tx, cve.Candidate); err != nil {
-				return xerrors.Errorf("failed to save the vulnerability ID: %w", err)
+				return eb.Wrapf(err, "failed to save the vulnerability ID")
 			}
 		}
 	}

--- a/pkg/vulnsrc/ubuntu/ubuntu.go
+++ b/pkg/vulnsrc/ubuntu/ubuntu.go
@@ -159,10 +159,8 @@ func defaultPut(dbc db.Operation, tx *bolt.Tx, advisory interface{}) error {
 		return oops.Errorf("unknown type")
 	}
 
-	eb := oops.With("vuln_id", cve.Candidate)
 	for packageName, patch := range cve.Patches {
 		pkgName := string(packageName)
-		eb := eb.With("package_name", pkgName)
 		for release, status := range patch {
 			if !slices.Contains(targetStatuses, status.Status) {
 				continue
@@ -172,9 +170,8 @@ func defaultPut(dbc db.Operation, tx *bolt.Tx, advisory interface{}) error {
 				continue
 			}
 			platformName := fmt.Sprintf(platformFormat, osVersion)
-			eb := eb.With("platform", platformName)
 			if err := dbc.PutDataSource(tx, platformName, source); err != nil {
-				return eb.Wrapf(err, "failed to put data source")
+				return oops.Wrapf(err, "failed to put data source")
 			}
 
 			adv := types.Advisory{}
@@ -182,7 +179,7 @@ func defaultPut(dbc db.Operation, tx *bolt.Tx, advisory interface{}) error {
 				adv.FixedVersion = status.Note
 			}
 			if err := dbc.PutAdvisoryDetail(tx, cve.Candidate, pkgName, []string{platformName}, adv); err != nil {
-				return eb.Wrapf(err, "failed to save advisory")
+				return oops.Wrapf(err, "failed to save advisory")
 			}
 
 			vuln := types.VulnerabilityDetail{
@@ -191,12 +188,12 @@ func defaultPut(dbc db.Operation, tx *bolt.Tx, advisory interface{}) error {
 				Description: cve.Description,
 			}
 			if err := dbc.PutVulnerabilityDetail(tx, cve.Candidate, source.ID, vuln); err != nil {
-				return eb.Wrapf(err, "failed to save vulnerability")
+				return oops.Wrapf(err, "failed to save vulnerability")
 			}
 
 			// for optimization
 			if err := dbc.PutVulnerabilityID(tx, cve.Candidate); err != nil {
-				return eb.Wrapf(err, "failed to save the vulnerability ID")
+				return oops.Wrapf(err, "failed to save the vulnerability ID")
 			}
 		}
 	}

--- a/pkg/vulnsrc/wolfi/wolfi.go
+++ b/pkg/vulnsrc/wolfi/wolfi.go
@@ -86,8 +86,6 @@ func (vs VulnSrc) save(advisories []advisory) error {
 }
 
 func (vs VulnSrc) saveSecFixes(tx *bolt.Tx, platform, pkgName string, secfixes map[string][]string) error {
-	eb := oops.With("platform", platform).With("package_name", pkgName)
-
 	for fixedVersion, vulnIDs := range secfixes {
 		advisory := types.Advisory{
 			FixedVersion: fixedVersion,
@@ -101,14 +99,13 @@ func (vs VulnSrc) saveSecFixes(tx *bolt.Tx, platform, pkgName string, secfixes m
 				if !strings.HasPrefix(cveID, "CVE-") {
 					continue
 				}
-				eb := eb.With("vuln_id", cveID)
 				if err := vs.dbc.PutAdvisoryDetail(tx, cveID, pkgName, []string{platform}, advisory); err != nil {
-					return eb.Wrapf(err, "failed to save advisory detail")
+					return oops.Wrapf(err, "failed to save advisory detail")
 				}
 
 				// for optimization
 				if err := vs.dbc.PutVulnerabilityID(tx, cveID); err != nil {
-					return eb.Wrapf(err, "failed to save the vulnerability ID")
+					return oops.Wrapf(err, "failed to save the vulnerability ID")
 				}
 			}
 		}
@@ -117,7 +114,7 @@ func (vs VulnSrc) saveSecFixes(tx *bolt.Tx, platform, pkgName string, secfixes m
 }
 
 func (vs VulnSrc) Get(_, pkgName string) ([]types.Advisory, error) {
-	eb := oops.In(string(source.ID)).With("package_name", pkgName)
+	eb := oops.In(string(source.ID))
 	bucket := distroName
 	advisories, err := vs.dbc.GetAdvisories(bucket, pkgName)
 	if err != nil {

--- a/pkg/vulnsrc/wolfi/wolfi.go
+++ b/pkg/vulnsrc/wolfi/wolfi.go
@@ -50,7 +50,7 @@ func (vs VulnSrc) Update(dir string) error {
 	err := utils.FileWalk(rootDir, func(r io.Reader, path string) error {
 		var advisory advisory
 		if err := json.NewDecoder(r).Decode(&advisory); err != nil {
-			return eb.With("path", path).Wrapf(err, "json decode error")
+			return eb.With("file_path", path).Wrapf(err, "json decode error")
 		}
 		advisories = append(advisories, advisory)
 		return nil
@@ -101,7 +101,7 @@ func (vs VulnSrc) saveSecFixes(tx *bolt.Tx, platform, pkgName string, secfixes m
 				if !strings.HasPrefix(cveID, "CVE-") {
 					continue
 				}
-				eb := eb.With("cve_id", cveID)
+				eb := eb.With("vuln_id", cveID)
 				if err := vs.dbc.PutAdvisoryDetail(tx, cveID, pkgName, []string{platform}, advisory); err != nil {
 					return eb.Wrapf(err, "failed to save advisory detail")
 				}

--- a/pkg/vulnsrc/wolfi/wolfi.go
+++ b/pkg/vulnsrc/wolfi/wolfi.go
@@ -6,8 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/samber/oops"
 	bolt "go.etcd.io/bbolt"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy-db/pkg/db"
 	"github.com/aquasecurity/trivy-db/pkg/types"
@@ -44,21 +44,23 @@ func (vs VulnSrc) Name() types.SourceID {
 
 func (vs VulnSrc) Update(dir string) error {
 	rootDir := filepath.Join(dir, "vuln-list", wolfiDir)
+	eb := oops.In(string(source.ID)).With("root_dir", rootDir)
+
 	var advisories []advisory
 	err := utils.FileWalk(rootDir, func(r io.Reader, path string) error {
 		var advisory advisory
 		if err := json.NewDecoder(r).Decode(&advisory); err != nil {
-			return xerrors.Errorf("failed to decode Wolfi advisory: %w", err)
+			return eb.With("path", path).Wrapf(err, "json decode error")
 		}
 		advisories = append(advisories, advisory)
 		return nil
 	})
 	if err != nil {
-		return xerrors.Errorf("error in Wolfi walk: %w", err)
+		return eb.Wrapf(err, "walk error")
 	}
 
 	if err = vs.save(advisories); err != nil {
-		return xerrors.Errorf("error in Wolfi save: %w", err)
+		return eb.Wrapf(err, "save error")
 	}
 
 	return nil
@@ -69,21 +71,23 @@ func (vs VulnSrc) save(advisories []advisory) error {
 		for _, adv := range advisories {
 			bucket := distroName
 			if err := vs.dbc.PutDataSource(tx, bucket, source); err != nil {
-				return xerrors.Errorf("failed to put data source: %w", err)
+				return oops.Wrapf(err, "failed to put data source")
 			}
 			if err := vs.saveSecFixes(tx, distroName, adv.PkgName, adv.Secfixes); err != nil {
-				return err
+				return oops.Wrapf(err, "failed to save sec fixes")
 			}
 		}
 		return nil
 	})
 	if err != nil {
-		return xerrors.Errorf("error in db batch update: %w", err)
+		return oops.Wrapf(err, "batch update failed")
 	}
 	return nil
 }
 
 func (vs VulnSrc) saveSecFixes(tx *bolt.Tx, platform, pkgName string, secfixes map[string][]string) error {
+	eb := oops.With("platform", platform).With("package_name", pkgName)
+
 	for fixedVersion, vulnIDs := range secfixes {
 		advisory := types.Advisory{
 			FixedVersion: fixedVersion,
@@ -97,13 +101,14 @@ func (vs VulnSrc) saveSecFixes(tx *bolt.Tx, platform, pkgName string, secfixes m
 				if !strings.HasPrefix(cveID, "CVE-") {
 					continue
 				}
+				eb := eb.With("cve_id", cveID)
 				if err := vs.dbc.PutAdvisoryDetail(tx, cveID, pkgName, []string{platform}, advisory); err != nil {
-					return xerrors.Errorf("failed to save Wolfi advisory: %w", err)
+					return eb.Wrapf(err, "failed to save advisory detail")
 				}
 
 				// for optimization
 				if err := vs.dbc.PutVulnerabilityID(tx, cveID); err != nil {
-					return xerrors.Errorf("failed to save the vulnerability ID: %w", err)
+					return eb.Wrapf(err, "failed to save the vulnerability ID")
 				}
 			}
 		}
@@ -112,10 +117,11 @@ func (vs VulnSrc) saveSecFixes(tx *bolt.Tx, platform, pkgName string, secfixes m
 }
 
 func (vs VulnSrc) Get(_, pkgName string) ([]types.Advisory, error) {
+	eb := oops.In(string(source.ID)).With("package_name", pkgName)
 	bucket := distroName
 	advisories, err := vs.dbc.GetAdvisories(bucket, pkgName)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to get Wolfi advisories: %w", err)
+		return nil, eb.Wrapf(err, "failed to get advisories")
 	}
 	return advisories, nil
 }

--- a/pkg/vulnsrc/wolfi/wolfi_test.go
+++ b/pkg/vulnsrc/wolfi/wolfi_test.go
@@ -46,7 +46,7 @@ func TestVulnSrc_Update(t *testing.T) {
 		{
 			name:    "sad path",
 			dir:     filepath.Join("testdata", "sad"),
-			wantErr: "failed to decode Wolfi advisory",
+			wantErr: "json decode error",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
This PR proposes migrating our error handling from xerrors to [github.com/samber/oops](https://github.com/samber/oops).

## Background
- We've been using xerrors primarily because the standard `errors` package doesn't support stack traces
- However, adding context to errors has been cumbersome with xerrors

## Benefits of oops
Please refer to [the oops README](https://github.com/samber/oops) for comprehensive features, but here are the key benefits for our use case:

1. Provides a slog-like interface
   - Easy to add contextual attributes using `oops.With()`, similar to `slog.With()`
   - As we recently migrated to slog (#486), this aligned interface will improve the development experience

2. Enhanced error output
   - Better visualization of error context and domains
   - Makes debugging easier by providing more structured and readable error information

![image](https://github.com/user-attachments/assets/44df0b84-7d02-4afb-8707-2c42f4ab83b7)

This change will make our error handling more maintainable and debugging more effective while maintaining all the benefits we had with xerrors (like stack traces).

## Real-world validation:
We've successfully tested oops in [another project](https://github.com/aquasecurity/vexhub-crawler) where its improved error output [helped us](https://github.com/aquasecurity/vexhub-crawler/actions/runs/12891691388/job/35944215335) identify issues more efficiently.

## Implementation Guidelines

1. Domain Definition (oops.In)
   - Define `oops.In` at the top of each exported (public) function
   - Rationale: Private functions don't need domain definition as they are called within the context of public functions

2. OopsErrorBuilder Usage
   - Use `OopsErrorBuilder` when the same contextual attributes are reused multiple times
   - Direct error creation is preferred for one-off errors
   - Exception: OopsErrorBuilder can be used when there are many attributes, even for one-off errors

3. OopsErrorBuilder Scope Management
   When creating a new `OopsErrorBuilder` from an existing one:
   - Be careful with variable scope
   - Avoid overwriting existing builder variables as attributes will persist after leaving the scope
   - Correct usage: `eb := eb.With()` to create a new variable
   - Incorrect usage: `eb = eb.With()` (overwrites existing variable)


Example:

```go
// Good
func PublicFunction() error {
    // Define domain at the top
    eb := oops.In("domain")
    
    // Reusable builder for common attributes
    eb = eb.With("common_attr", "value").With("other_attr", "value")

    for _, value := range values {
        // Create a new error builder fothe r specific scope
        eb := eb.With("specific", value)
        return eb.Wrapf(err, "error")
    }
    
    // Use directly for one-off errors
    if err != nil {
        return oops.Wrap(err, "failed to do something").With("simple_attr", "value")
    }
}
```

4. Context Attribution Responsibility
   Internal Package Calls:
   - Caller: Generally avoid adding context attributes unless necessary
   - Callee: Responsible for adding appropriate context attributes
   - Rationale: Prevents duplicate attribute attribution at both caller and callee levels

   External Package Calls:
   - Caller: Must add project-specific context attributes
   - Rationale: External packages won't add project-specific context, so it's our responsibility

```go
// Good - Internal package calls
func CallerFunction() error {
    in := oops.In("caller")
    
    // Let the callee handle the context
    if err := internalPkg.DoSomething(); err != nil {
        return oops.Wrapf(err, "internal calls")
    }
    
    // Add context only when needed
    if err := internalPkg.DoSomethingSpecial(); err != nil {
        return oops.Wrap(err, "special case").
            With("special_context", "value")
    }
}

// Good - External package calls
func ExternalCall() error {
    in := oops.In("external")
    
    // Add our context for external calls
    if err := externalPkg.DoSomething(); err != nil {
        return oops.Wrap(err, "external operation failed").
            With("operation", "something").
            With("external_context", "value")
    }
}
```