### PR TITLE
fix(db): return error if panic occurs when opening database

### DIFF
--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -87,7 +87,7 @@ func Init(dbDir string, opts ...Option) (err error) {
 			if err = os.Remove(dbPath); err != nil {
 				return
 			}
-			err = eb.Errorf("failed to open db: %s", r)
+			err = eb.Errorf("db corrupted: %s", r)
 		}
 		debug.SetPanicOnFault(false)
 	}()

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -8,10 +8,11 @@ import (
 	"runtime/debug"
 	"strings"
 
-	"github.com/aquasecurity/trivy-db/pkg/log"
-	"github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/samber/oops"
 	bolt "go.etcd.io/bbolt"
+
+	"github.com/aquasecurity/trivy-db/pkg/log"
+	"github.com/aquasecurity/trivy-db/pkg/types"
 )
 
 type CustomPut func(dbc Operation, tx *bolt.Tx, adv interface{}) error

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -80,10 +80,13 @@ func Init(dbDir string, opts ...Option) (err error) {
 	eb = eb.With("db_path", dbPath)
 
 	// bbolt sometimes occurs the fatal error of "unexpected fault address".
-	// In that case, the local DB should be broken and we need to return error.
+	// In that case, the local DB should be broken and needs to be removed.
 	debug.SetPanicOnFault(true)
 	defer func() {
 		if r := recover(); r != nil {
+			if err = os.Remove(dbPath); err != nil {
+				return
+			}
 			err = eb.Errorf("failed to open db: %s", r)
 		}
 		debug.SetPanicOnFault(false)

--- a/pkg/db/db_test.go
+++ b/pkg/db/db_test.go
@@ -6,25 +6,26 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/aquasecurity/trivy-db/pkg/db"
 	"github.com/stretchr/testify/require"
 	"go.etcd.io/bbolt"
-
-	"github.com/aquasecurity/trivy-db/pkg/db"
 )
 
 func TestInit(t *testing.T) {
 	tests := []struct {
-		name   string
-		dbPath string
-		dbOpts *bbolt.Options
+		name    string
+		dbPath  string
+		wantErr string
+		dbOpts  *bbolt.Options
 	}{
 		{
 			name:   "normal db",
 			dbPath: "testdata/normal.db",
 		},
 		{
-			name:   "broken db",
-			dbPath: "testdata/broken.db",
+			name:    "broken db",
+			dbPath:  "testdata/broken.db",
+			wantErr: "invalid memory address or nil pointer dereference",
 		},
 		{
 			name:   "no db",
@@ -46,6 +47,11 @@ func TestInit(t *testing.T) {
 			}
 
 			err := db.Init(tmpDir, db.WithBoltOptions(tt.dbOpts))
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+
 			require.NoError(t, err)
 		})
 	}

--- a/pkg/db/db_test.go
+++ b/pkg/db/db_test.go
@@ -6,9 +6,10 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/aquasecurity/trivy-db/pkg/db"
 	"github.com/stretchr/testify/require"
 	"go.etcd.io/bbolt"
+
+	"github.com/aquasecurity/trivy-db/pkg/db"
 )
 
 func TestInit(t *testing.T) {


### PR DESCRIPTION
## Description
if `bbolt` returned panic when initializing db we just create new empty database.

This results in Trivy doesn't show vulnerabilities.
See https://github.com/aquasecurity/trivy/discussions/7758#discussioncomment-12309744

we should return error if we couldn't open trivy-db

example (https://gist.github.com/knqyf263/7ce8e504b6d1f9867e6898f83c89acba is used to reproduce error):

before:
```
Testing race condition with downloader.Download
Starting concurrent downloads to the same destination file...
Download 1: Adding fixed delay of 100 ms
Download 0: Starting
Download 1: Starting
Download 0: Completed
Download 1: Completed

Checking the destination file:
File: /var/folders/8m/p1341n2941jbyc5gm7357x5c0000gn/T/trivy-poc-1180293935/dst/trivy.db, Size: 65536 bytes
WARNING - DB is EMPTY!

Result: Empty file detected! Race condition successfully reproduced.

```

after:
```
Testing race condition with downloader.Download
Starting concurrent downloads to the same destination file...
Download 1: Adding fixed delay of 100 ms
Download 0: Starting
Download 1: Starting
Download 0: Completed
2025/02/25 15:27:54 got error initializing db: failed to open db: runtime error: invalid memory address or nil pointer dereference

```