### PR TITLE
feat(ubuntu): add ubuntu 18 ESM support

### DIFF
--- a/pkg/vulnsrc/ubuntu/ubuntu.go
+++ b/pkg/vulnsrc/ubuntu/ubuntu.go
@@ -55,6 +55,7 @@ var (
 		"precise/esm":      "12.04-ESM",
 		"trusty/esm":       "14.04-ESM",
 		"esm-infra/xenial": "16.04-ESM",
+		"esm-infra/bionic": "18.04-ESM",
 	}
 
 	source = types.DataSource{


### PR DESCRIPTION
## Description
Add ubuntu 18.04 ESM into trivy-db

`ubuntu` uses `esm-infra/bionic` name - https://github.com/aquasecurity/vuln-list/blob/e7622a9b8f3ff5c1c958f4846173c64aed270340/ubuntu/2023/CVE-2023-2953.json#L35-L38

EXample:
Actual DB:
```
➜  trivy -q image ubuntu:18.04-esm -f json | grep Results -A 5
  "Results": [
    {
      "Target": "ubuntu:18.04-esm (ubuntu 18.04-ESM)",
      "Class": "os-pkgs",
      "Type": "ubuntu"
    }
```

New DB:
```bash
➜  trivy -q image ubuntu:18.04-esm -f json | grep Results -A 5
  "Results": [
    {
      "Target": "ubuntu:18.04-esm (ubuntu 18.04-ESM)",
      "Class": "os-pkgs",
      "Type": "ubuntu",
      "Vulnerabilities": [
```