### PR TITLE
ci: use `Skitionek/notify-microsoft-teams` instead of aquasecurity fork

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -120,10 +120,7 @@ jobs:
           echo "Artifact upload process completed."
 
       - name: Microsoft Teams Notification
-        ## Until the PR with the fix for the AdaptivCard version is merged yet
-        ## https://github.com/Skitionek/notify-microsoft-teams/pull/96
-        ## Use the aquasecurity fork
-        uses: aquasecurity/notify-microsoft-teams@master
+        uses: Skitionek/notify-microsoft-teams@e7a2493ac87dad8aa7a62f079f295e54ff511d88
         if: failure()
         with:
           webhook_url: ${{ secrets.TRIVY_MSTEAMS_WEBHOOK }}


### PR DESCRIPTION
## Description
`Skitionek/notify-microsoft-teams` fixed the issue and now we can use it instead of the fork
See - https://github.com/aquasecurity/notify-microsoft-teams/pull/1

test run - https://github.com/DmitriyLewen/trivy-db/actions/runs/14485778659/job/40630965075