### PR TITLE
Parse openSUSE Leap Micro versions

### DIFF
--- a/pkg/vulnsrc/suse-cvrf/suse-cvrf.go
+++ b/pkg/vulnsrc/suse-cvrf/suse-cvrf.go
@@ -28,6 +28,7 @@ const (
 	OpenSUSETumbleweed
 
 	platformOpenSUSELeapFormat             = "openSUSE Leap %s"
+	platformOpenSUSELeapMicroFormat        = "openSUSE Leap Micro %s"
 	platformOpenSUSETumbleweedFormat       = "openSUSE Tumbleweed"
 	platformSUSELinuxFormat                = "SUSE Linux Enterprise %s"
 	platformSUSELinuxEnterpriseMicroFormat = "SUSE Linux Enterprise Micro %s"
@@ -199,6 +200,20 @@ func (vs VulnSrc) getOSVersion(platformName string) string {
 		// Tumbleweed has no version, it is a rolling release
 		return platformOpenSUSETumbleweedFormat
 	}
+	if strings.HasPrefix(platformName, "openSUSE Leap Micro") {
+		ss := strings.Fields(platformName)
+		if len(ss) < 4 {
+			vs.logger.Warn("Invalid version", log.String("platform", platformName))
+			return ""
+		}
+
+		if _, err := version.Parse(ss[3]); err != nil {
+			vs.logger.Warn("Invalid version", log.String("platform", platformName), log.Err(err))
+			return ""
+		}
+
+		return fmt.Sprintf(platformOpenSUSELeapMicroFormat, ss[3])
+	}
 	if strings.HasPrefix(platformName, "openSUSE Leap") {
 		// openSUSE Leap 15.0
 		ss := strings.Split(platformName, " ")
@@ -323,6 +338,7 @@ func (vs VulnSrc) Get(version string, pkgName string) ([]types.Advisory, error) 
 	}
 	return advisories, nil
 }
+
 func severityFromThreat(sev string) types.Severity {
 	switch sev {
 	case "low":

--- a/pkg/vulnsrc/suse-cvrf/suse-cvrf_test.go
+++ b/pkg/vulnsrc/suse-cvrf/suse-cvrf_test.go
@@ -562,6 +562,14 @@ func TestGetOSVersion(t *testing.T) {
 			expectedPlatformName: "openSUSE Leap 15.1",
 		},
 		{
+			inputPlatformName:    "openSUSE Leap Micro 15.1 NonFree",
+			expectedPlatformName: "openSUSE Leap Micro 15.1",
+		},
+		{
+			inputPlatformName:    "openSUSE Leap Micro 15.1",
+			expectedPlatformName: "openSUSE Leap Micro 15.1",
+		},
+		{
 			inputPlatformName:    "openSUSE Tumbleweed",
 			expectedPlatformName: "openSUSE Tumbleweed",
 		},


### PR DESCRIPTION
This PR adds a branch to the `getOSVersion` function that parses the openSUSE Leap Micro strings.

Fixes #367 