### PR TITLE
Add support for MinimOS

### DIFF
--- a/pkg/vulnsrc/minimos/minimos.go
+++ b/pkg/vulnsrc/minimos/minimos.go
@@ -1,0 +1,129 @@
+package minimos
+
+import (
+	"encoding/json"
+	"io"
+	"path/filepath"
+	"strings"
+
+	"github.com/samber/oops"
+	bolt "go.etcd.io/bbolt"
+
+	"github.com/aquasecurity/trivy-db/pkg/db"
+	"github.com/aquasecurity/trivy-db/pkg/types"
+	"github.com/aquasecurity/trivy-db/pkg/utils"
+	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/vulnerability"
+)
+
+const (
+	minimosDir = "minimos"
+	distroName = "minimos"
+)
+
+var (
+	source = types.DataSource{
+		ID:   vulnerability.MinimOS,
+		Name: "MinimOS Security Data",
+		URL:  "https://packages.mini.dev/advisories/secdb/security.json",
+	}
+)
+
+type advisory struct {
+	PkgName       string              `json:"name"`
+	Secfixes      map[string][]string `json:"secfixes"`
+	Apkurl        string              `json:"apkurl"`
+	Archs         []string            `json:"archs"`
+	Urlprefix     string              `json:"urlprefix"`
+	Reponame      string              `json:"reponame"`
+	Distroversion string              `json:"distroversion"`
+}
+
+type VulnSrc struct {
+	dbc db.Operation
+}
+
+func NewVulnSrc() VulnSrc {
+	return VulnSrc{
+		dbc: db.Config{},
+	}
+}
+
+func (vs VulnSrc) Name() types.SourceID {
+	return source.ID
+}
+
+func (vs VulnSrc) Update(dir string) error {
+	rootDir := filepath.Join(dir, "vuln-list", minimosDir)
+	eb := oops.In(string(source.ID)).With("root_dir", rootDir)
+
+	var advisories []advisory
+	err := utils.FileWalk(rootDir, func(r io.Reader, path string) error {
+		var advisory advisory
+		if err := json.NewDecoder(r).Decode(&advisory); err != nil {
+			return eb.With("file_path", path).Wrapf(err, "json decode error")
+		}
+		advisories = append(advisories, advisory)
+		return nil
+	})
+	if err != nil {
+		return eb.Wrapf(err, "walk error")
+	}
+
+	if err = vs.save(advisories); err != nil {
+		return eb.Wrapf(err, "save advisories error")
+	}
+
+	return nil
+}
+
+func (vs VulnSrc) save(advisories []advisory) error {
+	err := vs.dbc.BatchUpdate(func(tx *bolt.Tx) error {
+		for _, adv := range advisories {
+			bucket := distroName
+			if err := vs.dbc.PutDataSource(tx, bucket, source); err != nil {
+				return oops.Wrapf(err, "failed to put data source")
+			}
+			if err := vs.saveSecFixes(tx, distroName, adv.PkgName, adv.Secfixes); err != nil {
+				return oops.Wrapf(err, "failed to save sec fixes")
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return oops.Wrapf(err, "batch update failed")
+	}
+	return nil
+}
+
+func (vs VulnSrc) saveSecFixes(tx *bolt.Tx, platform, pkgName string, secfixes map[string][]string) error {
+	for fixedVersion, vulnIDs := range secfixes {
+		advisory := types.Advisory{
+			FixedVersion: fixedVersion,
+		}
+		for _, vulnID := range vulnIDs {
+			if !strings.HasPrefix(vulnID, "CVE-") {
+				continue
+			}
+
+			if err := vs.dbc.PutAdvisoryDetail(tx, vulnID, pkgName, []string{platform}, advisory); err != nil {
+				return oops.Wrapf(err, "failed to save advisory")
+			}
+
+			// for optimization
+			if err := vs.dbc.PutVulnerabilityID(tx, vulnID); err != nil {
+				return oops.Wrapf(err, "failed to save the vulnerability ID")
+			}
+		}
+	}
+	return nil
+}
+
+func (vs VulnSrc) Get(_, pkgName string) ([]types.Advisory, error) {
+	eb := oops.In(string(source.ID))
+	bucket := distroName
+	advisories, err := vs.dbc.GetAdvisories(bucket, pkgName)
+	if err != nil {
+		return nil, eb.Wrapf(err, "failed to get advisories")
+	}
+	return advisories, nil
+}

--- a/pkg/vulnsrc/minimos/minimos_test.go
+++ b/pkg/vulnsrc/minimos/minimos_test.go
@@ -1,0 +1,62 @@
+package minimos_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/aquasecurity/trivy-db/pkg/types"
+	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/minimos"
+	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/vulnerability"
+	"github.com/aquasecurity/trivy-db/pkg/vulnsrctest"
+)
+
+func TestVulnSrc_Update(t *testing.T) {
+	tests := []struct {
+		name       string
+		dir        string
+		wantValues []vulnsrctest.WantValues
+		wantErr    string
+	}{
+		{
+			name: "happy path",
+			dir:  filepath.Join("testdata", "happy"),
+			wantValues: []vulnsrctest.WantValues{
+				{
+					Key: []string{"data-source", "minimos"},
+					Value: types.DataSource{
+						ID:   vulnerability.MinimOS,
+						Name: "MinimOS Security Data",
+						URL:  "https://packages.mini.dev/advisories/secdb/security.json",
+					},
+				},
+				{
+					Key: []string{"advisory-detail", "CVE-2022-38126", "minimos", "binutils"},
+					Value: types.Advisory{
+						FixedVersion: "2.39-r1",
+					},
+				},
+				{
+					Key: []string{"advisory-detail", "CVE-2022-38533", "minimos", "binutils"},
+					Value: types.Advisory{
+						FixedVersion: "2.39-r2",
+					},
+				},
+			},
+		},
+		{
+			name:    "sad path",
+			dir:     filepath.Join("testdata", "sad"),
+			wantErr: "json decode error",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vs := minimos.NewVulnSrc()
+			vulnsrctest.TestUpdate(t, vs, vulnsrctest.TestUpdateArgs{
+				Dir:        tt.dir,
+				WantValues: tt.wantValues,
+				WantErr:    tt.wantErr,
+			})
+		})
+	}
+}

--- a/pkg/vulnsrc/minimos/testdata/happy/vuln-list/minimos/binutils.json
+++ b/pkg/vulnsrc/minimos/testdata/happy/vuln-list/minimos/binutils.json
@@ -1,0 +1,17 @@
+{
+  "name": "binutils",
+  "secfixes": {
+    "2.39-r1": [
+      "CVE-2022-38126"
+    ],
+    "2.39-r2": [
+      "CVE-2022-38533"
+    ]
+  },
+  "apkurl": "{{urlprefix}}/{{reponame}}/{{arch}}/{{pkg.name}}-{{pkg.ver}}.apk",
+  "archs": [
+    "x86_64"
+  ],
+  "urlprefix": "https://packages.mini.dev",
+  "reponame": "os"
+}

--- a/pkg/vulnsrc/minimos/testdata/sad/vuln-list/minimos/binutils.json
+++ b/pkg/vulnsrc/minimos/testdata/sad/vuln-list/minimos/binutils.json
@@ -1,0 +1,12 @@
+{
+  "name": "binutils",
+  "secfixes": {
+    "2.39-r1": {}
+  },
+  "apkurl": "{{urlprefix}}/{{reponame}}/{{arch}}/{{pkg.name}}-{{pkg.ver}}.apk",
+  "archs": [
+    "x86_64"
+  ],
+  "urlprefix": "https://packages.mini.dev",
+  "reponame": "os"
+}

--- a/pkg/vulnsrc/vulnerability/const.go
+++ b/pkg/vulnsrc/vulnerability/const.go
@@ -35,6 +35,7 @@ const (
 	K8sVulnDB             types.SourceID = "k8s"
 	GoVulnDB              types.SourceID = "govulndb"
 	Aqua                  types.SourceID = "aqua"
+	MinimOS               types.SourceID = "minimos"
 
 	// Ecosystem
 	Unknown    types.Ecosystem = "unknown"
@@ -106,4 +107,5 @@ var AllSourceIDs = []types.SourceID{
 	Chainguard,
 	BitnamiVulndb,
 	GoVulnDB,
+	MinimOS,
 }

--- a/pkg/vulnsrc/vulnsrc.go
+++ b/pkg/vulnsrc/vulnsrc.go
@@ -16,6 +16,7 @@ import (
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/glad"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/govulndb"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/k8svulndb"
+	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/minimos"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/node"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/nvd"
 	oracleoval "github.com/aquasecurity/trivy-db/pkg/vulnsrc/oracle-oval"
@@ -69,5 +70,6 @@ var (
 		govulndb.NewVulnSrc(), // For Go stdlib packages
 
 		aqua.NewVulnSrc(),
+		minimos.NewVulnSrc(),
 	}
 )


### PR DESCRIPTION
Hi,
I’m part of the [Minimus](https://minimus.io/) team. Minimus delivers secure, minimal container images with auto-generated SBOMs and real-time vulnerability threat intelligence to help reduce vulnerability risk.
We also maintain a minimal operating system called MinimOS. We’ve been publishing our security advisories in a secdb feed and would like to contribute it as a new security data source.

Details:
The feed URL: https://packages.mini.dev/advisories/secdb/security.json

The format closely mirrors Alpine's secdb, but it's unversioned—similar to Alpine's edge feed.

Discussion ref: https://github.com/aquasecurity/trivy/discussions/8666

Thanks for your consideration!