### PR TITLE
fix(ghsa): parse `last_known_affected_version_range` field for each affected entry

### DIFF
--- a/pkg/vulnsrc/ghsa/ghsa_test.go
+++ b/pkg/vulnsrc/ghsa/ghsa_test.go
@@ -381,6 +381,68 @@ func TestVulnSrc_Update(t *testing.T) {
 					},
 					Value: map[string]interface{}{},
 				},
+				{
+					Key: []string{
+						"data-source",
+						"npm::GitHub Security Advisory npm",
+					},
+					Value: types.DataSource{
+						ID:   vulnerability.GHSA,
+						Name: "GitHub Security Advisory npm",
+						URL:  "https://github.com/advisories?query=type%3Areviewed+ecosystem%3Anpm",
+					},
+				},
+				{
+					Key: []string{
+						"advisory-detail",
+						"CVE-2025-46653",
+						"npm::GitHub Security Advisory npm",
+						"formidable",
+					},
+					Value: types.Advisory{
+						VendorIDs: []string{
+							"GHSA-75v8-2h7p-7m2m",
+						},
+						PatchedVersions: []string{
+							"3.5.3",
+						},
+						VulnerableVersions: []string{
+							">=3.1.1-canary.20211030, <3.5.3",
+							">=2.1.0, <2.1.3",
+						},
+					},
+				},
+				{
+					Key: []string{
+						"vulnerability-detail",
+						"CVE-2025-46653",
+						"ghsa",
+					},
+					Value: types.VulnerabilityDetail{
+						Title:       "Formidable relies on hexoid to prevent guessing of filenames for untrusted executable content",
+						Description: "Formidable (aka node-formidable) 2.1.0 through 3.x before 3.5.3 relies on hexoid to prevent guessing of filenames for untrusted executable content; however, hexoid is documented as not \"cryptographically secure.\" (Also, there is a scenario in which only the last two characters of a hexoid string need to be guessed, but this is not often relevant.) NOTE: this does not imply that, in a typical use case, attackers will be able to exploit any hexoid behavior to upload and execute their own content.",
+						References: []string{
+							"https://nvd.nist.gov/vuln/detail/CVE-2025-46653",
+							"https://github.com/node-formidable/formidable/commit/022c2c5577dfe14d2947f10909d81b03b6070bf5",
+							"https://github.com/node-formidable/formidable/commit/37a3e89fca1ed68ec674a539f13aafd62221ddaa",
+							"https://github.com/node-formidable/formidable",
+							"https://github.com/node-formidable/formidable/blob/d0fbec13edc8add54a1afb9ce1a8d3db803f8d47/CHANGELOG.md?plain=1#L10",
+							"https://github.com/zast-ai/vulnerability-reports/blob/main/formidable/file_upload/report.md",
+						},
+						Severity:         types.SeverityLow,
+						CvssVectorV3:     "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:N/I:L/A:N",
+						CvssScoreV3:      3.1,
+						LastModifiedDate: utils.MustTimeParse("2025-04-30T21:07:20Z"),
+						PublishedDate:    utils.MustTimeParse("2025-04-26T21:31:26Z"),
+					},
+				},
+				{
+					Key: []string{
+						"vulnerability-id",
+						"CVE-2025-46653",
+					},
+					Value: map[string]interface{}{},
+				},
 			},
 			noBuckets: [][]string{
 				// We shouldn't save Go runtime vulnerabilities

--- a/pkg/vulnsrc/ghsa/testdata/happy/ghsa/advisories/github-reviewed/2025/04/GHSA-75v8-2h7p-7m2m/GHSA-75v8-2h7p-7m2m.json
+++ b/pkg/vulnsrc/ghsa/testdata/happy/ghsa/advisories/github-reviewed/2025/04/GHSA-75v8-2h7p-7m2m/GHSA-75v8-2h7p-7m2m.json
@@ -1,0 +1,92 @@
+{
+  "schema_version": "1.4.0",
+  "id": "GHSA-75v8-2h7p-7m2m",
+  "modified": "2025-04-30T21:07:20Z",
+  "published": "2025-04-26T21:31:26Z",
+  "aliases": [
+    "CVE-2025-46653"
+  ],
+  "summary": "Formidable relies on hexoid to prevent guessing of filenames for untrusted executable content",
+  "details": "Formidable (aka node-formidable) 2.1.0 through 3.x before 3.5.3 relies on hexoid to prevent guessing of filenames for untrusted executable content; however, hexoid is documented as not \"cryptographically secure.\" (Also, there is a scenario in which only the last two characters of a hexoid string need to be guessed, but this is not often relevant.) NOTE: this does not imply that, in a typical use case, attackers will be able to exploit any hexoid behavior to upload and execute their own content.",
+  "severity": [
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:N/I:L/A:N"
+    }
+  ],
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "formidable"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "3.1.1-canary.20211030"
+            },
+            {
+              "fixed": "3.5.3"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "formidable"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.1.0"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "< 2.1.3"
+      }
+    }
+  ],
+  "references": [
+    {
+      "type": "ADVISORY",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-46653"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/node-formidable/formidable/commit/022c2c5577dfe14d2947f10909d81b03b6070bf5"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/node-formidable/formidable/commit/37a3e89fca1ed68ec674a539f13aafd62221ddaa"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/node-formidable/formidable"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/node-formidable/formidable/blob/d0fbec13edc8add54a1afb9ce1a8d3db803f8d47/CHANGELOG.md?plain=1#L10"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/zast-ai/vulnerability-reports/blob/main/formidable/file_upload/report.md"
+    }
+  ],
+  "database_specific": {
+    "cwe_ids": [
+      "CWE-338"
+    ],
+    "severity": "LOW",
+    "github_reviewed": true,
+    "github_reviewed_at": "2025-04-29T14:07:17Z",
+    "nvd_published_at": "2025-04-26T21:15:14Z"
+  }
+}


### PR DESCRIPTION
## Description
We don't always add `last_known_affected_version_range` to `FixedVersions`.

### Current logic
We only keep the first `database_specific` field for each unique advisory found:
https://github.com/aquasecurity/trivy-db/blob/319ae10c5abfcdb1dbc4e208ef9079c830ba02e5/pkg/vulnsrc/osv/osv.go#L241-L264
So when the second (or later) affected entry contains a `last_known_affected_version_range` field, we don't check it.

### New logic
Update the `FixedVersions` array after each `Affected` record is parsed using `PostParseAffected`. In this case, we will add the range from `last_known_affected_version_range` for each advisory found (if necessary) and update `FixedVersion` range.

### Example
Test advisory - https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2025/04/GHSA-75v8-2h7p-7m2m/GHSA-75v8-2h7p-7m2m.json

Before:
![изображение](https://github.com/user-attachments/assets/a2264002-f726-4c48-a293-fd40078e018b)

After:
![изображение](https://github.com/user-attachments/assets/59cf7fd2-317a-4db6-bbf0-106cee6e60a4)

