### PR TITLE
fix(alpine): save not only CVE-IDs

### DIFF
--- a/pkg/vulnsrc/alpine/alpine.go
+++ b/pkg/vulnsrc/alpine/alpine.go
@@ -100,7 +100,10 @@ func (vs VulnSrc) saveSecFixes(tx *bolt.Tx, platform, pkgName string, secfixes m
 			ids := strings.Fields(vulnID)
 			for _, cveID := range ids {
 				cveID = strings.ReplaceAll(cveID, "CVE_", "CVE-")
-				if !strings.HasPrefix(cveID, "CVE-") {
+				// Possible cases when vulnID contains only one non-CVE-ID
+				// e.g. only GHSA-ID
+				// cf. https://github.com/aquasecurity/vuln-list/blob/a830a1cc031f51a29a1a6f1c28d8366bbb5e7b64/alpine/3.21/community/vaultwarden.json#L9-L13
+				if !strings.HasPrefix(cveID, "CVE-") && len(ids) > 1 {
 					continue
 				}
 				if err := vs.dbc.PutAdvisoryDetail(tx, cveID, pkgName, []string{platform}, advisory); err != nil {

--- a/pkg/vulnsrc/alpine/alpine_test.go
+++ b/pkg/vulnsrc/alpine/alpine_test.go
@@ -42,10 +42,70 @@ func TestVulnSrc_Update(t *testing.T) {
 					},
 				},
 				{
+					Key: []string{"advisory-detail", "CVE-2024-22195", "alpine 3.12", "ansible"},
+					Value: types.Advisory{
+						FixedVersion: "2.9.3-r0",
+					},
+				},
+				{
+					Key: []string{"advisory-detail", "CVE-2017-2616", "alpine 3.12", "ansible"},
+					Value: types.Advisory{
+						FixedVersion: "2.9.3-r0",
+					},
+				},
+				{
+					Key: []string{"advisory-detail", "GHSA-f7r5-w49x-gxm3", "alpine 3.12", "ansible"},
+					Value: types.Advisory{
+						FixedVersion: "2.9.3-r0",
+					},
+				},
+				{
 					Key: []string{"advisory-detail", "CVE-2020-1737", "alpine 3.12", "ansible"},
 					Value: types.Advisory{
 						FixedVersion: "2.9.6-r0",
 					},
+				},
+				{
+					Key: []string{
+						"vulnerability-id",
+						"CVE-2019-14904",
+					},
+					Value: map[string]interface{}{},
+				},
+				{
+					Key: []string{
+						"vulnerability-id",
+						"CVE-2019-14905",
+					},
+					Value: map[string]interface{}{},
+				},
+				{
+					Key: []string{
+						"vulnerability-id",
+						"CVE-2024-22195",
+					},
+					Value: map[string]interface{}{},
+				},
+				{
+					Key: []string{
+						"vulnerability-id",
+						"CVE-2017-2616",
+					},
+					Value: map[string]interface{}{},
+				},
+				{
+					Key: []string{
+						"vulnerability-id",
+						"GHSA-f7r5-w49x-gxm3",
+					},
+					Value: map[string]interface{}{},
+				},
+				{
+					Key: []string{
+						"vulnerability-id",
+						"CVE-2020-1737",
+					},
+					Value: map[string]interface{}{},
 				},
 			},
 		},

--- a/pkg/vulnsrc/alpine/alpine_test.go
+++ b/pkg/vulnsrc/alpine/alpine_test.go
@@ -60,6 +60,12 @@ func TestVulnSrc_Update(t *testing.T) {
 					},
 				},
 				{
+					Key: []string{"advisory-detail", "GHSA-h6cc-rc6q-23j4", "alpine 3.12", "ansible"},
+					Value: types.Advisory{
+						FixedVersion: "2.9.3-r0",
+					},
+				},
+				{
 					Key: []string{"advisory-detail", "CVE-2020-1737", "alpine 3.12", "ansible"},
 					Value: types.Advisory{
 						FixedVersion: "2.9.6-r0",
@@ -97,6 +103,13 @@ func TestVulnSrc_Update(t *testing.T) {
 					Key: []string{
 						"vulnerability-id",
 						"GHSA-f7r5-w49x-gxm3",
+					},
+					Value: map[string]interface{}{},
+				},
+				{
+					Key: []string{
+						"vulnerability-id",
+						"GHSA-h6cc-rc6q-23j4",
 					},
 					Value: map[string]interface{}{},
 				},

--- a/pkg/vulnsrc/alpine/testdata/happy/vuln-list/alpine/ansible.json
+++ b/pkg/vulnsrc/alpine/testdata/happy/vuln-list/alpine/ansible.json
@@ -6,7 +6,8 @@
       "CVE-2019-14905",
       "CVE-2024-22195 GHSA-h5c8-rqwp-cp95",
       "CVE-2017-2616 (+ regression fix)",
-      "GHSA-f7r5-w49x-gxm3"
+      "GHSA-f7r5-w49x-gxm3",
+      "GHSA-h6cc-rc6q-23j4 (+regression fix)"
     ],
     "2.9.6-r0": [
       "CVE-2020-1737"

--- a/pkg/vulnsrc/alpine/testdata/happy/vuln-list/alpine/ansible.json
+++ b/pkg/vulnsrc/alpine/testdata/happy/vuln-list/alpine/ansible.json
@@ -3,7 +3,10 @@
   "secfixes": {
     "2.9.3-r0": [
       "CVE-2019-14904",
-      "CVE-2019-14905"
+      "CVE-2019-14905",
+      "CVE-2024-22195 GHSA-h5c8-rqwp-cp95",
+      "CVE-2017-2616 (+ regression fix)",
+      "GHSA-f7r5-w49x-gxm3"
     ],
     "2.9.6-r0": [
       "CVE-2020-1737"


### PR DESCRIPTION
## Description
There are advisories with a vulnerability ID other than CVE-ID (e.g. GHSA-ID):
e.g. https://security.alpinelinux.org/srcpkg/vaultwarden
```
➜ grep -r "GHSA*" | grep -v CVE | sort -u
./3.10/main/squid.json:      "GHSA-572g-rvwr-6c7f"
./3.11/main/squid.json:      "GHSA-572g-rvwr-6c7f"
./3.12/main/squid.json:      "GHSA-572g-rvwr-6c7f"
./3.13/community/py3-bleach.json:      "GHSA-vv2x-vrpj-qqpq"
./3.13/main/glib.json:      "GHSL-2021-045",
./3.13/main/squid.json:      "GHSA-572g-rvwr-6c7f"
./3.14/community/py3-bleach.json:      "GHSA-vv2x-vrpj-qqpq"
./3.14/main/squid.json:      "GHSA-572g-rvwr-6c7f"
./3.15/community/py3-treq.json:      "GHSA-fhpf-pp6p-55qc"
./3.16/community/py3-treq.json:      "GHSA-fhpf-pp6p-55qc"
./3.17/community/py3-treq.json:      "GHSA-fhpf-pp6p-55qc"
./3.18/community/py3-treq.json:      "GHSA-fhpf-pp6p-55qc"
./3.19/community/py3-treq.json:      "GHSA-fhpf-pp6p-55qc"
./3.19/community/singularity.json:      "GHSA-77vh-xpmg-72qh"
./3.20/community/py3-treq.json:      "GHSA-fhpf-pp6p-55qc"
./3.20/community/singularity.json:      "GHSA-77vh-xpmg-72qh"
./3.21/community/py3-treq.json:      "GHSA-fhpf-pp6p-55qc"
./3.21/community/singularity.json:      "GHSA-77vh-xpmg-72qh"
./3.21/community/vaultwarden.json:      "GHSA-f7r5-w49x-gxm3",
./3.21/community/vaultwarden.json:      "GHSA-h6cc-rc6q-23j4",
./3.21/community/vaultwarden.json:      "GHSA-j4h8-vch3-f797"
./edge/community/py3-treq.json:      "GHSA-fhpf-pp6p-55qc"
./edge/community/singularity.json:      "GHSA-77vh-xpmg-72qh"
./edge/community/vaultwarden.json:      "GHSA-f7r5-w49x-gxm3",
./edge/community/vaultwarden.json:      "GHSA-h6cc-rc6q-23j4",
./edge/community/vaultwarden.json:      "GHSA-j4h8-vch3-f797"
```

So we don't need to save only `CVE-` advisories.
