### PR TITLE
docs(oras): #402 fix link oras install

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ make db-compact // Compact database (`./assets` dir by default)
 make db-compress // Compress database into `db.tar.gz` file
 ```
 
-To build trivy-db image and push into registry, you need to use [Oras CLI](https://oras.land/cli/).
+To build trivy-db image and push into registry, you need to use [Oras CLI](https://oras.land/docs/installation/).
 For example for `ghcr`:
 ```bash
 ./oras push --artifact-type application/vnd.aquasec.trivy.config.v1+json \


### PR DESCRIPTION
Hello,

The link oras cli is 404 like declared in the issue #402,

If we check an archived page we find the good page : https://web.archive.org/web/20230315183929/https://oras.land/cli/ 
after the page is always 404 ex: https://web.archive.org/web/20230829061007/https://oras.land/cli/


Thanks to apply this commit :) 

Have nice day
