### PR TITLE
feat(ubuntu): add support 20.04-ESM

### DIFF
--- a/pkg/vulnsrc/ubuntu/ubuntu.go
+++ b/pkg/vulnsrc/ubuntu/ubuntu.go
@@ -52,10 +52,15 @@ var (
 		"noble":    "24.04",
 		"oracular": "24.10",
 		// ESM versions:
-		"precise/esm":      "12.04-ESM",
-		"trusty/esm":       "14.04-ESM",
+		"precise/esm": "12.04-ESM",
+		"trusty/esm":  "14.04-ESM",
+		// Possible multiple values for one release:
+		//(release_list="trusty trusty/esm xenial esm-infra/xenial esm-apps/xenial bionic esm-infra/bionic esm-apps/bionic focal esm-apps/focal jammy esm-apps/jammy noble oracular plucky")
+		// cf. https://wiki.ubuntu.com/SecurityTeam/BuildEnvironment#line867
 		"esm-infra/xenial": "16.04-ESM",
+		"esm-apps/xenial":  "16.04-ESM",
 		"esm-infra/bionic": "18.04-ESM",
+		"esm-apps/bionic":  "18.04-ESM",
 		"esm-apps/focal":   "20.04-ESM",
 	}
 

--- a/pkg/vulnsrc/ubuntu/ubuntu.go
+++ b/pkg/vulnsrc/ubuntu/ubuntu.go
@@ -56,6 +56,7 @@ var (
 		"trusty/esm":       "14.04-ESM",
 		"esm-infra/xenial": "16.04-ESM",
 		"esm-infra/bionic": "18.04-ESM",
+		"esm-apps/focal":   "20.04-ESM",
 	}
 
 	source = types.DataSource{


### PR DESCRIPTION
## Description
Ubutnu now supports 20.04 only for Ubuntu pro (ESM).
So we need to add advisories for 20.04-ESM.

New name for 20.04-ESM is `esm-apps/focal`:
`(release_list="trusty trusty/esm xenial esm-infra/xenial esm-apps/xenial bionic esm-infra/bionic esm-apps/bionic focal esm-apps/focal jammy esm-apps/jammy noble oracular plucky"`
took from https://wiki.ubuntu.com/SecurityTeam/BuildEnvironment#line867

Same for files from `vuln-list`:
```
➜ grep -rh "focal" | sort -u | grep esm 
      "esm-apps/focal": {
```

## Test build
I confirm that trivy-db contains new advisories.
e.g.:
![изображение](https://github.com/user-attachments/assets/0df0e0f9-6f3d-4d6f-b9d0-e619130953b8)

