### PR TITLE
ci: use `AdityaGarg8/remove-unwanted-software` instead of `easimon/maximize-build-space`

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       # vuln-list dirs + language repositories use more than 31GB of storage
       - name: Maximize build space
-        uses: AdityaGarg8/remove-unwanted-software@v5
+        uses: AdityaGarg8/remove-unwanted-software@90e01b21170618765a73370fcc3abbd1684a7793
         with:
           remove-android: 'true'
           remove-dotnet: 'true'


### PR DESCRIPTION
## Description
We got space error - https://github.com/aquasecurity/trivy-db/actions/runs/15714756455/job/44281599307
`vuln-list` and language repos use 32GB space:
```
➜ du -shm ./trivy-db-cache 
31365 ./trivy-db-cache
```
`easimon/maximize-build-space` can't free more then 40GB space - https://github.com/DmitriyLewen/trivy-db/actions/runs/15725438939/job/44314263726#step:2:177
But `AdityaGarg8/remove-unwanted-software` frees 54 GB - https://github.com/DmitriyLewen/trivy-db/actions/runs/15731622643/job/44333867214#step:2:157

So we want to use `dityaGarg8/remove-unwanted-software@v5` to get more free space.

Test run - https://github.com/DmitriyLewen/trivy-db/actions/runs/15731622643/job/44333867214