### PR TITLE
feat(ubuntu): Add support for Ubuntu plucky (25.04)

### DIFF
--- a/pkg/vulnsrc/ubuntu/ubuntu.go
+++ b/pkg/vulnsrc/ubuntu/ubuntu.go
@@ -51,6 +51,7 @@ var (
 		"mantic":   "23.10",
 		"noble":    "24.04",
 		"oracular": "24.10",
+        "plucky":   "25.04",
 		// ESM versions:
 		"precise/esm": "12.04-ESM",
 		"trusty/esm":  "14.04-ESM",

--- a/pkg/vulnsrc/ubuntu/ubuntu.go
+++ b/pkg/vulnsrc/ubuntu/ubuntu.go
@@ -51,7 +51,7 @@ var (
 		"mantic":   "23.10",
 		"noble":    "24.04",
 		"oracular": "24.10",
-        "plucky":   "25.04",
+		"plucky":   "25.04",
 		// ESM versions:
 		"precise/esm": "12.04-ESM",
 		"trusty/esm":  "14.04-ESM",


### PR DESCRIPTION
This is to resolve first part of an issue here: <https://github.com/aquasecurity/trivy/issues/8980>

I tried for a while on my own, and looked through a few past PRs adding support for new OS/new versions, but couldn't figure out how to confirm that the new trivy-db contains advisories for Ubuntu 25.04.

I did find some 25.04 related CVEs in the cache, but I reckon that is just what's been downloaded from the online Ubuntu CVE database?
<img width="694" alt="Screenshot 2025-06-24 at 19 37 13" src="https://github.com/user-attachments/assets/187f1539-19e1-4aca-8e76-3800bfe0c716" />
