### PR TITLE
feat(db): add DataSource.BaseID field

### DIFF
--- a/pkg/db/advisory.go
+++ b/pkg/db/advisory.go
@@ -40,7 +40,12 @@ func (dbc Config) GetAdvisories(source, pkgName string) ([]types.Advisory, error
 
 		advisory.VulnerabilityID = vulnID
 		if !lo.IsEmpty(v.Source) {
-			advisory.DataSource = &v.Source
+			advisory.DataSource = &types.DataSource{
+				ID:     v.Source.ID,
+				Name:   v.Source.Name,
+				URL:    v.Source.URL,
+				BaseID: v.Source.BaseID,
+			}
 		}
 
 		results = append(results, advisory)

--- a/pkg/db/advisory.go
+++ b/pkg/db/advisory.go
@@ -3,6 +3,7 @@ package db
 import (
 	"encoding/json"
 
+	"github.com/samber/lo"
 	"github.com/samber/oops"
 	bolt "go.etcd.io/bbolt"
 
@@ -38,12 +39,8 @@ func (dbc Config) GetAdvisories(source, pkgName string) ([]types.Advisory, error
 		}
 
 		advisory.VulnerabilityID = vulnID
-		if v.Source != (types.DataSource{}) {
-			advisory.DataSource = &types.DataSource{
-				ID:   v.Source.ID,
-				Name: v.Source.Name,
-				URL:  v.Source.URL,
-			}
+		if !lo.IsEmpty(v.Source) {
+			advisory.DataSource = &v.Source
 		}
 
 		results = append(results, advisory)

--- a/pkg/db/advisory_test.go
+++ b/pkg/db/advisory_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aquasecurity/trivy-db/pkg/db"
 	"github.com/aquasecurity/trivy-db/pkg/dbtest"
 	"github.com/aquasecurity/trivy-db/pkg/types"
+	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/vulnerability"
 )
 
 func TestConfig_ForEachAdvisory(t *testing.T) {
@@ -169,16 +170,29 @@ func TestConfig_GetAdvisories(t *testing.T) {
 				source:  "composer::",
 				pkgName: "symfony/symfony",
 			},
-			fixtures: []string{"testdata/fixtures/multiple-buckets.yaml"},
+			fixtures: []string{
+				"testdata/fixtures/multiple-buckets.yaml",
+				"testdata/fixtures/data-source.yaml",
+			},
 			want: []types.Advisory{
 				{
 					VulnerabilityID:    "CVE-2019-10909",
 					PatchedVersions:    []string{"4.2.7"},
 					VulnerableVersions: []string{">= 4.2.0, < 4.2.7"},
+					DataSource: &types.DataSource{
+						ID:   vulnerability.GHSA,
+						Name: "GitHub Security Advisory Composer",
+						URL:  "https://github.com/advisories?query=type%%3Areviewed+ecosystem%%3Acomposer",
+					},
 				},
 				{
 					VulnerabilityID:    "CVE-2020-5275",
 					VulnerableVersions: []string{">= 4.4.0, < 4.4.7"},
+					DataSource: &types.DataSource{
+						ID:   vulnerability.PhpSecurityAdvisories,
+						Name: "PHP Security Advisories Database",
+						URL:  "https://github.com/FriendsOfPHP/security-advisories",
+					},
 				},
 			},
 		},

--- a/pkg/db/testdata/fixtures/data-source.yaml
+++ b/pkg/db/testdata/fixtures/data-source.yaml
@@ -1,0 +1,12 @@
+- bucket: data-source
+  pairs:
+    - key: composer::GitHub Security Advisory Composer
+      value:
+        ID: "ghsa"
+        Name: "GitHub Security Advisory Composer"
+        URL: "https://github.com/advisories?query=type%%3Areviewed+ecosystem%%3Acomposer"
+    - key: composer::php-security-advisories
+      value:
+        ID: "php-security-advisories"
+        Name: "PHP Security Advisories Database"
+        URL: "https://github.com/FriendsOfPHP/security-advisories"

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -102,7 +102,7 @@ type DataSource struct {
 
 	// BaseID shows Base source of advisories.
 	// e.g. `Root.io` based on Debian/Ubuntu/Alpine advisories.
-	BaseID SourceID `json:",omitempty"`
+	BaseID SourceID `json:",omitzero"`
 }
 
 type Advisory struct {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -99,6 +99,10 @@ type DataSource struct {
 	ID   SourceID `json:",omitempty"`
 	Name string   `json:",omitempty"`
 	URL  string   `json:",omitempty"`
+
+	// BaseID shows Base source of advisories.
+	// e.g. `Root.io` based on Debian/Ubuntu/Alpine advisories.
+	BaseID SourceID `json:",omitempty"`
 }
 
 type Advisory struct {

--- a/pkg/vulnsrc/rootio/rootio.go
+++ b/pkg/vulnsrc/rootio/rootio.go
@@ -27,8 +27,6 @@ const (
 	rootioDir      = "rootio"
 	feedFileName   = "cve_feed.json"
 	platformFormat = "root.io %s %s" // "root.io {baseOS} {version}"
-
-	sourceIDSeparator = "-for-"
 )
 
 var (
@@ -128,9 +126,10 @@ func (vs VulnSrc) save(baseOS string, feeds map[string][]Feed) error {
 	err := vs.dbc.BatchUpdate(func(tx *bolt.Tx) error {
 		for platform, platformFeeds := range feeds {
 			dataSource := types.DataSource{
-				ID:   source.ID + sourceIDSeparator + types.SourceID(baseOS),
-				Name: source.Name + fmt.Sprintf(" (%s)", baseOS),
-				URL:  source.URL,
+				ID:     source.ID,
+				Name:   source.Name + fmt.Sprintf(" (%s)", baseOS),
+				URL:    source.URL,
+				BaseID: types.SourceID(baseOS),
 			}
 			if err := vs.dbc.PutDataSource(tx, platform, dataSource); err != nil {
 				return oops.Wrapf(err, "failed to put data source")

--- a/pkg/vulnsrc/rootio/rootio_test.go
+++ b/pkg/vulnsrc/rootio/rootio_test.go
@@ -30,9 +30,10 @@ func TestVulnSrc_Update(t *testing.T) {
 						"root.io debian 12",
 					},
 					Value: types.DataSource{
-						ID:   vulnerability.RootIO + "-for-" + vulnerability.Debian,
-						Name: "Root.io Security Patches (debian)",
-						URL:  "https://api.root.io/external/patch_feed",
+						ID:     vulnerability.RootIO,
+						Name:   "Root.io Security Patches (debian)",
+						URL:    "https://api.root.io/external/patch_feed",
+						BaseID: vulnerability.Debian,
 					},
 				},
 				{
@@ -60,9 +61,10 @@ func TestVulnSrc_Update(t *testing.T) {
 						"root.io alpine 3.17",
 					},
 					Value: types.DataSource{
-						ID:   vulnerability.RootIO + "-for-" + vulnerability.Alpine,
-						Name: "Root.io Security Patches (alpine)",
-						URL:  "https://api.root.io/external/patch_feed",
+						ID:     vulnerability.RootIO,
+						Name:   "Root.io Security Patches (alpine)",
+						URL:    "https://api.root.io/external/patch_feed",
+						BaseID: vulnerability.Alpine,
 					},
 				},
 				{
@@ -90,9 +92,10 @@ func TestVulnSrc_Update(t *testing.T) {
 						"root.io ubuntu 22.04",
 					},
 					Value: types.DataSource{
-						ID:   vulnerability.RootIO + "-for-" + vulnerability.Ubuntu,
-						Name: "Root.io Security Patches (ubuntu)",
-						URL:  "https://api.root.io/external/patch_feed",
+						ID:     vulnerability.RootIO,
+						Name:   "Root.io Security Patches (ubuntu)",
+						URL:    "https://api.root.io/external/patch_feed",
+						BaseID: vulnerability.Ubuntu,
 					},
 				},
 				{

--- a/pkg/vulnsrc/rootio/rootio_test.go
+++ b/pkg/vulnsrc/rootio/rootio_test.go
@@ -162,9 +162,12 @@ func TestVulnSrc_Get(t *testing.T) {
 		wantErr  string
 	}{
 		{
-			name:     "only Root.io debian advisories",
-			baseOS:   vulnerability.Debian,
-			fixtures: []string{"testdata/fixtures/happy.yaml"},
+			name:   "only Root.io debian advisories",
+			baseOS: vulnerability.Debian,
+			fixtures: []string{
+				"testdata/fixtures/happy.yaml",
+				"testdata/fixtures/data-source.yaml",
+			},
 			args: args{
 				osVer:   "11",
 				pkgName: "openssl",
@@ -174,13 +177,22 @@ func TestVulnSrc_Get(t *testing.T) {
 					VulnerabilityID:    "CVE-2023-0464",
 					VulnerableVersions: []string{">=1.1.1, <1.1.1t"},
 					PatchedVersions:    []string{"1.1.1t-1+deb11u2"},
+					DataSource: &types.DataSource{
+						ID:     vulnerability.RootIO,
+						BaseID: vulnerability.Debian,
+						Name:   "Root.io Security Patches (debian)",
+						URL:    "https://api.root.io/external/patch_feed",
+					},
 				},
 			},
 		},
 		{
-			name:     "only Root.io debian advisories (with fixed version by Root.io and Debian)",
-			baseOS:   vulnerability.Debian,
-			fixtures: []string{"testdata/fixtures/happy.yaml"},
+			name:   "only Root.io debian advisories (with fixed version by Root.io and Debian)",
+			baseOS: vulnerability.Debian,
+			fixtures: []string{
+				"testdata/fixtures/happy.yaml",
+				"testdata/fixtures/data-source.yaml",
+			},
 			args: args{
 				osVer:   "12",
 				pkgName: "openssl",
@@ -192,18 +204,26 @@ func TestVulnSrc_Get(t *testing.T) {
 						"<3.0.15-1~deb12u1.root.io.1",
 						">3.0.15-1~deb12u1.root.io.1 <3.0.16-1~deb12u1",
 					},
-
 					PatchedVersions: []string{
 						"3.0.15-1~deb12u1.root.io.1",
 						"3.0.16-1~deb12u1",
+					},
+					DataSource: &types.DataSource{
+						ID:     vulnerability.RootIO,
+						BaseID: vulnerability.Debian,
+						Name:   "Root.io Security Patches (debian)",
+						URL:    "https://api.root.io/external/patch_feed",
 					},
 				},
 			},
 		},
 		{
-			name:     "only Root.io ubuntu advisories",
-			baseOS:   vulnerability.Ubuntu,
-			fixtures: []string{"testdata/fixtures/happy.yaml"},
+			name:   "only Root.io ubuntu advisories",
+			baseOS: vulnerability.Ubuntu,
+			fixtures: []string{
+				"testdata/fixtures/happy.yaml",
+				"testdata/fixtures/data-source.yaml",
+			},
 			args: args{
 				osVer:   "20.04",
 				pkgName: "nginx",
@@ -213,13 +233,22 @@ func TestVulnSrc_Get(t *testing.T) {
 					VulnerabilityID:    "CVE-2023-44487",
 					VulnerableVersions: []string{"<1.22.1-9+deb12u2.root.io.1"},
 					PatchedVersions:    []string{"1.22.1-9+deb12u2.root.io.1"},
+					DataSource: &types.DataSource{
+						ID:     vulnerability.RootIO,
+						BaseID: vulnerability.Ubuntu,
+						Name:   "Root.io Security Patches (ubuntu)",
+						URL:    "https://api.root.io/external/patch_feed",
+					},
 				},
 			},
 		},
 		{
-			name:     "only Root.io alpine advisories",
-			baseOS:   vulnerability.Alpine,
-			fixtures: []string{"testdata/fixtures/happy.yaml"},
+			name:   "only Root.io alpine advisories",
+			baseOS: vulnerability.Alpine,
+			fixtures: []string{
+				"testdata/fixtures/happy.yaml",
+				"testdata/fixtures/data-source.yaml",
+			},
 			args: args{
 				osVer:   "3.19",
 				pkgName: "less",
@@ -229,13 +258,22 @@ func TestVulnSrc_Get(t *testing.T) {
 					VulnerabilityID:    "CVE-2024-32487",
 					VulnerableVersions: []string{"<643-r00072"},
 					PatchedVersions:    []string{"643-r00072"},
+					DataSource: &types.DataSource{
+						ID:     vulnerability.RootIO,
+						BaseID: vulnerability.Alpine,
+						Name:   "Root.io Security Patches (alpine)",
+						URL:    "https://api.root.io/external/patch_feed",
+					},
 				},
 			},
 		},
 		{
-			name:     "Root.io and Debian have advisories",
-			baseOS:   vulnerability.Debian,
-			fixtures: []string{"testdata/fixtures/happy.yaml"},
+			name:   "Root.io and Debian have advisories",
+			baseOS: vulnerability.Debian,
+			fixtures: []string{
+				"testdata/fixtures/happy.yaml",
+				"testdata/fixtures/data-source.yaml",
+			},
 			args: args{
 				osVer:   "11",
 				pkgName: "pam",
@@ -247,19 +285,34 @@ func TestVulnSrc_Get(t *testing.T) {
 					VulnerableVersions: []string{"<1.5.2-6+deb12u1.root.io.3"},
 					PatchedVersions:    []string{"1.5.2-6+deb12u1.root.io.3"},
 					Severity:           types.SeverityMedium,
+					DataSource: &types.DataSource{
+						ID:     vulnerability.RootIO,
+						BaseID: vulnerability.Debian,
+						Name:   "Root.io Security Patches (debian)",
+						URL:    "https://api.root.io/external/patch_feed",
+					},
 				},
 				{
 					// Debian has fixed version
 					VulnerabilityID:    "CVE-2024-22365",
 					VulnerableVersions: []string{"<1.5.2-6+deb12u1.root.io.3"},
 					PatchedVersions:    []string{"1.5.2-6+deb12u1.root.io.3"},
+					DataSource: &types.DataSource{
+						ID:     vulnerability.RootIO,
+						BaseID: vulnerability.Debian,
+						Name:   "Root.io Security Patches (debian)",
+						URL:    "https://api.root.io/external/patch_feed",
+					},
 				},
 			},
 		},
 		{
-			name:     "only debian advisories",
-			baseOS:   vulnerability.Debian,
-			fixtures: []string{"testdata/fixtures/happy.yaml"},
+			name:   "only debian advisories",
+			baseOS: vulnerability.Debian,
+			fixtures: []string{
+				"testdata/fixtures/happy.yaml",
+				"testdata/fixtures/data-source.yaml",
+			},
 			args: args{
 				osVer:   "10",
 				pkgName: "pam",
@@ -269,11 +322,21 @@ func TestVulnSrc_Get(t *testing.T) {
 					VulnerabilityID: "CVE-2024-10041",
 					Status:          types.StatusAffected,
 					Severity:        types.SeverityLow,
+					DataSource: &types.DataSource{
+						ID:   vulnerability.Debian,
+						Name: "Debian Security Tracker",
+						URL:  "https://salsa.debian.org/security-tracker-team/security-tracker",
+					},
 				},
 				{
 					VulnerabilityID:    "CVE-2024-22365",
 					VulnerableVersions: []string{"<1.5.2-6+deb12u2"},
 					PatchedVersions:    []string{"1.5.2-6+deb12u2"},
+					DataSource: &types.DataSource{
+						ID:   vulnerability.Debian,
+						Name: "Debian Security Tracker",
+						URL:  "https://salsa.debian.org/security-tracker-team/security-tracker",
+					},
 				},
 			},
 		},

--- a/pkg/vulnsrc/rootio/testdata/fixtures/data-source.yaml
+++ b/pkg/vulnsrc/rootio/testdata/fixtures/data-source.yaml
@@ -1,0 +1,36 @@
+- bucket: data-source
+  pairs:
+    - key: debian 10
+      value:
+        ID: "debian"
+        Name: "Debian Security Tracker"
+        URL: "https://salsa.debian.org/security-tracker-team/security-tracker"
+    - key: debian 11
+      value:
+        ID: "debian"
+        Name: "Debian Security Tracker"
+        URL: "https://salsa.debian.org/security-tracker-team/security-tracker"
+    - key: root.io debian 11
+      value:
+        ID: "rootio"
+        BaseID: "debian"
+        Name: "Root.io Security Patches (debian)"
+        URL: "https://api.root.io/external/patch_feed"
+    - key: root.io debian 12
+      value:
+        ID: "rootio"
+        BaseID: "debian"
+        Name: "Root.io Security Patches (debian)"
+        URL: "https://api.root.io/external/patch_feed"
+    - key: root.io ubuntu 20.04
+      value:
+        ID: "rootio"
+        BaseID: "ubuntu"
+        Name: "Root.io Security Patches (ubuntu)"
+        URL: "https://api.root.io/external/patch_feed"
+    - key: root.io alpine 3.19
+      value:
+        ID: "rootio"
+        BaseID: "alpine"
+        Name: "Root.io Security Patches (alpine)"
+        URL: "https://api.root.io/external/patch_feed"


### PR DESCRIPTION
## Description
We added baseOS suffixes for `Root.io` advisories in #554.

But after [this discussion](https://github.com/aquasecurity/trivy/pull/9181#discussion_r2209370563) we understand that better and easier way: add `BaseID` field for `DataSource`.


- At the moment this field will be filled for `Root.io` advisories only:
  ```
  "DataSource": {
      "BaseID": "debian",
      "ID": "root.io",
      "Name": "Root.io Security Advisories (debian)",
      "URL": "https://api.root.io/external/patch_feed"
  }
  ```
  BaseOS suffix for Name ( e.g. (Debian) ) to make it clearer what BaseID means.

- The rest `DataSource` will remain unchanged.


## Related PRs
- [x] #554
