### PR TITLE
chore: update go version to 1.24.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aquasecurity/trivy-db
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986


### PR DESCRIPTION
## Summary
- Update Go version from 1.23.0 to 1.24.0 in go.mod
- Run go mod tidy to clean up dependencies

## Test plan
- [x] Tests pass with Go 1.24.0
- [x] Linter passes with no issues
- [x] go mod tidy executed successfully