### PR TITLE
feat(db): use GetParams (release, pkgName, arch) for `Getter` interface

### DIFF
--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -53,7 +53,9 @@ type Operation interface {
 }
 
 type Getter interface {
-	Get(string, string) ([]types.Advisory, error)
+	// Get uses the following parameters:
+	// `osVer`, `pkgName`, `arch`
+	Get(string, string, string) ([]types.Advisory, error)
 }
 
 type Config struct{}

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -53,9 +53,13 @@ type Operation interface {
 }
 
 type Getter interface {
-	// Get uses the following parameters:
-	// `osVer`, `pkgName`, `arch`
-	Get(string, string, string) ([]types.Advisory, error)
+	Get(GetParams) ([]types.Advisory, error)
+}
+
+type GetParams struct {
+	Release string
+	PkgName string
+	Arch    string
 }
 
 type Config struct{}

--- a/pkg/vulnsrc/alma/alma.go
+++ b/pkg/vulnsrc/alma/alma.go
@@ -42,8 +42,8 @@ type PutInput struct {
 
 type DB interface {
 	db.Operation
+	db.Getter
 	Put(*bolt.Tx, PutInput) error
-	Get(release, pkgName string) ([]types.Advisory, error)
 }
 
 type VulnSrc struct {
@@ -213,7 +213,7 @@ func (a *Alma) Put(tx *bolt.Tx, input PutInput) error {
 	return nil
 }
 
-func (a *Alma) Get(release, pkgName string) ([]types.Advisory, error) {
+func (a *Alma) Get(release, pkgName, _ string) ([]types.Advisory, error) {
 	bucket := fmt.Sprintf(platformFormat, release)
 	advisories, err := a.GetAdvisories(bucket, pkgName)
 	if err != nil {

--- a/pkg/vulnsrc/alma/alma.go
+++ b/pkg/vulnsrc/alma/alma.go
@@ -213,11 +213,11 @@ func (a *Alma) Put(tx *bolt.Tx, input PutInput) error {
 	return nil
 }
 
-func (a *Alma) Get(release, pkgName, _ string) ([]types.Advisory, error) {
-	bucket := fmt.Sprintf(platformFormat, release)
-	advisories, err := a.GetAdvisories(bucket, pkgName)
+func (a *Alma) Get(params db.GetParams) ([]types.Advisory, error) {
+	bucket := fmt.Sprintf(platformFormat, params.Release)
+	advisories, err := a.GetAdvisories(bucket, params.PkgName)
 	if err != nil {
-		return nil, oops.With("release", release).With("package_name", pkgName).Wrapf(err, "failed to get advisories")
+		return nil, oops.With("release", params.Release).With("package_name", params.PkgName).Wrapf(err, "failed to get advisories")
 	}
 	return advisories, nil
 }

--- a/pkg/vulnsrc/alpine/alpine.go
+++ b/pkg/vulnsrc/alpine/alpine.go
@@ -129,7 +129,7 @@ func (vs VulnSrc) saveSecFixes(tx *bolt.Tx, platform, pkgName string, secfixes m
 	return nil
 }
 
-func (vs VulnSrc) Get(release, pkgName string) ([]types.Advisory, error) {
+func (vs VulnSrc) Get(release, pkgName, _ string) ([]types.Advisory, error) {
 	eb := oops.In("alpine").With("release", release)
 	bucket := fmt.Sprintf(platformFormat, release)
 	advisories, err := vs.dbc.GetAdvisories(bucket, pkgName)

--- a/pkg/vulnsrc/alpine/alpine.go
+++ b/pkg/vulnsrc/alpine/alpine.go
@@ -129,10 +129,10 @@ func (vs VulnSrc) saveSecFixes(tx *bolt.Tx, platform, pkgName string, secfixes m
 	return nil
 }
 
-func (vs VulnSrc) Get(release, pkgName, _ string) ([]types.Advisory, error) {
-	eb := oops.In("alpine").With("release", release)
-	bucket := fmt.Sprintf(platformFormat, release)
-	advisories, err := vs.dbc.GetAdvisories(bucket, pkgName)
+func (vs VulnSrc) Get(params db.GetParams) ([]types.Advisory, error) {
+	eb := oops.In("alpine").With("release", params.Release)
+	bucket := fmt.Sprintf(platformFormat, params.Release)
+	advisories, err := vs.dbc.GetAdvisories(bucket, params.PkgName)
 	if err != nil {
 		return nil, eb.Wrapf(err, "failed to get Alpine advisories")
 	}

--- a/pkg/vulnsrc/amazon/amazon.go
+++ b/pkg/vulnsrc/amazon/amazon.go
@@ -165,10 +165,10 @@ func (vs VulnSrc) commit(tx *bolt.Tx) error {
 }
 
 // Get returns a security advisory
-func (vs VulnSrc) Get(version, pkgName, _ string) ([]types.Advisory, error) {
-	eb := oops.In("amazon").With("version", version)
-	bucket := fmt.Sprintf(platformFormat, version)
-	advisories, err := vs.dbc.GetAdvisories(bucket, pkgName)
+func (vs VulnSrc) Get(params db.GetParams) ([]types.Advisory, error) {
+	eb := oops.In("amazon").With("release", params.Release)
+	bucket := fmt.Sprintf(platformFormat, params.Release)
+	advisories, err := vs.dbc.GetAdvisories(bucket, params.PkgName)
 	if err != nil {
 		return nil, eb.Wrapf(err, "failed to get advisories")
 	}

--- a/pkg/vulnsrc/amazon/amazon.go
+++ b/pkg/vulnsrc/amazon/amazon.go
@@ -165,7 +165,7 @@ func (vs VulnSrc) commit(tx *bolt.Tx) error {
 }
 
 // Get returns a security advisory
-func (vs VulnSrc) Get(version, pkgName string) ([]types.Advisory, error) {
+func (vs VulnSrc) Get(version, pkgName, _ string) ([]types.Advisory, error) {
 	eb := oops.In("amazon").With("version", version)
 	bucket := fmt.Sprintf(platformFormat, version)
 	advisories, err := vs.dbc.GetAdvisories(bucket, pkgName)

--- a/pkg/vulnsrc/amazon/amazon_test.go
+++ b/pkg/vulnsrc/amazon/amazon_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/aquasecurity/trivy-db/pkg/db"
 	"github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy-db/pkg/utils"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/amazon"
@@ -152,9 +153,11 @@ func TestVulnSrc_Get(t *testing.T) {
 			vulnsrctest.TestGet(t, vs, vulnsrctest.TestGetArgs{
 				Fixtures:   tt.fixtures,
 				WantValues: tt.want,
-				Release:    tt.version,
-				PkgName:    tt.pkgName,
-				WantErr:    tt.wantErr,
+				GetParams: db.GetParams{
+					Release: tt.version,
+					PkgName: tt.pkgName,
+				},
+				WantErr: tt.wantErr,
 			})
 		})
 	}

--- a/pkg/vulnsrc/azure/azure.go
+++ b/pkg/vulnsrc/azure/azure.go
@@ -300,7 +300,7 @@ func (vs VulnSrc) commit(tx *bolt.Tx, platformName string, entries []Entry) erro
 	return nil
 }
 
-func (vs VulnSrc) Get(release, pkgName string) ([]types.Advisory, error) {
+func (vs VulnSrc) Get(release, pkgName, _ string) ([]types.Advisory, error) {
 	eb := oops.In(string(vs.source.ID)).With("release", release).With("package_name", pkgName)
 	bucket := fmt.Sprintf(vs.platformFormat, release)
 	advisories, err := vs.dbc.GetAdvisories(bucket, pkgName)

--- a/pkg/vulnsrc/azure/azure.go
+++ b/pkg/vulnsrc/azure/azure.go
@@ -300,10 +300,10 @@ func (vs VulnSrc) commit(tx *bolt.Tx, platformName string, entries []Entry) erro
 	return nil
 }
 
-func (vs VulnSrc) Get(release, pkgName, _ string) ([]types.Advisory, error) {
-	eb := oops.In(string(vs.source.ID)).With("release", release).With("package_name", pkgName)
-	bucket := fmt.Sprintf(vs.platformFormat, release)
-	advisories, err := vs.dbc.GetAdvisories(bucket, pkgName)
+func (vs VulnSrc) Get(params db.GetParams) ([]types.Advisory, error) {
+	eb := oops.In(string(vs.source.ID)).With("release", params.Release).With("package_name", params.PkgName)
+	bucket := fmt.Sprintf(vs.platformFormat, params.Release)
+	advisories, err := vs.dbc.GetAdvisories(bucket, params.PkgName)
 	if err != nil {
 		return nil, eb.Wrapf(err, "failed to get advisories")
 	}

--- a/pkg/vulnsrc/azure/azure_test.go
+++ b/pkg/vulnsrc/azure/azure_test.go
@@ -4,6 +4,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/aquasecurity/trivy-db/pkg/db"
 	"github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/azure"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/vulnerability"
@@ -402,9 +403,11 @@ func TestVulnSrc_Get(t *testing.T) {
 			vulnsrctest.TestGet(t, vs, vulnsrctest.TestGetArgs{
 				Fixtures:   tt.fixtures,
 				WantValues: tt.want,
-				Release:    tt.release,
-				PkgName:    tt.pkgName,
-				WantErr:    tt.wantErr,
+				GetParams: db.GetParams{
+					Release: tt.release,
+					PkgName: tt.pkgName,
+				},
+				WantErr: tt.wantErr,
 			})
 		})
 	}

--- a/pkg/vulnsrc/chainguard/chainguard.go
+++ b/pkg/vulnsrc/chainguard/chainguard.go
@@ -112,10 +112,10 @@ func (vs VulnSrc) saveSecFixes(tx *bolt.Tx, platform, pkgName string, secfixes m
 	return nil
 }
 
-func (vs VulnSrc) Get(_, pkgName, _ string) ([]types.Advisory, error) {
+func (vs VulnSrc) Get(params db.GetParams) ([]types.Advisory, error) {
 	eb := oops.In("chainguard")
 	bucket := distroName
-	advisories, err := vs.dbc.GetAdvisories(bucket, pkgName)
+	advisories, err := vs.dbc.GetAdvisories(bucket, params.PkgName)
 	if err != nil {
 		return nil, eb.Wrapf(err, "failed to get advisories")
 	}

--- a/pkg/vulnsrc/chainguard/chainguard.go
+++ b/pkg/vulnsrc/chainguard/chainguard.go
@@ -112,7 +112,7 @@ func (vs VulnSrc) saveSecFixes(tx *bolt.Tx, platform, pkgName string, secfixes m
 	return nil
 }
 
-func (vs VulnSrc) Get(_, pkgName string) ([]types.Advisory, error) {
+func (vs VulnSrc) Get(_, pkgName, _ string) ([]types.Advisory, error) {
 	eb := oops.In("chainguard")
 	bucket := distroName
 	advisories, err := vs.dbc.GetAdvisories(bucket, pkgName)

--- a/pkg/vulnsrc/debian/debian.go
+++ b/pkg/vulnsrc/debian/debian.go
@@ -505,7 +505,7 @@ func defaultPut(dbc db.Operation, tx *bolt.Tx, advisory any) error {
 	return nil
 }
 
-func (vs VulnSrc) Get(release, pkgName string) ([]types.Advisory, error) {
+func (vs VulnSrc) Get(release, pkgName, _ string) ([]types.Advisory, error) {
 	eb := oops.In("debian").With("release", release).With("package_name", pkgName)
 	bkt := fmt.Sprintf(platformFormat, release)
 	advisories, err := vs.dbc.GetAdvisories(bkt, pkgName)

--- a/pkg/vulnsrc/debian/debian.go
+++ b/pkg/vulnsrc/debian/debian.go
@@ -505,10 +505,10 @@ func defaultPut(dbc db.Operation, tx *bolt.Tx, advisory any) error {
 	return nil
 }
 
-func (vs VulnSrc) Get(release, pkgName, _ string) ([]types.Advisory, error) {
-	eb := oops.In("debian").With("release", release).With("package_name", pkgName)
-	bkt := fmt.Sprintf(platformFormat, release)
-	advisories, err := vs.dbc.GetAdvisories(bkt, pkgName)
+func (vs VulnSrc) Get(params db.GetParams) ([]types.Advisory, error) {
+	eb := oops.In("debian").With("release", params.Release).With("package_name", params.PkgName)
+	bkt := fmt.Sprintf(platformFormat, params.Release)
+	advisories, err := vs.dbc.GetAdvisories(bkt, params.PkgName)
 	if err != nil {
 		return nil, eb.Wrapf(err, "failed to get advisories")
 	}

--- a/pkg/vulnsrc/debian/debian_test.go
+++ b/pkg/vulnsrc/debian/debian_test.go
@@ -4,6 +4,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/aquasecurity/trivy-db/pkg/db"
 	"github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/debian"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/vulnerability"
@@ -272,9 +273,11 @@ func TestVulnSrc_Get(t *testing.T) {
 			vulnsrctest.TestGet(t, vs, vulnsrctest.TestGetArgs{
 				Fixtures:   tt.fixtures,
 				WantValues: tt.want,
-				Release:    tt.args.release,
-				PkgName:    tt.args.pkgName,
-				WantErr:    tt.wantErr,
+				GetParams: db.GetParams{
+					Release: tt.args.release,
+					PkgName: tt.args.pkgName,
+				},
+				WantErr: tt.wantErr,
 			})
 		})
 	}

--- a/pkg/vulnsrc/echo/echo.go
+++ b/pkg/vulnsrc/echo/echo.go
@@ -119,7 +119,7 @@ func (vs VulnSrc) saveAdvisories(tx *bolt.Tx, pkgName string, advisories Advisor
 	return nil
 }
 
-func (vs VulnSrc) Get(_, pkgName string) ([]types.Advisory, error) {
+func (vs VulnSrc) Get(_, pkgName, _ string) ([]types.Advisory, error) {
 	eb := oops.In(string(source.ID))
 
 	advisories, err := vs.dbc.GetAdvisories(distroName, pkgName)

--- a/pkg/vulnsrc/echo/echo.go
+++ b/pkg/vulnsrc/echo/echo.go
@@ -119,10 +119,10 @@ func (vs VulnSrc) saveAdvisories(tx *bolt.Tx, pkgName string, advisories Advisor
 	return nil
 }
 
-func (vs VulnSrc) Get(_, pkgName, _ string) ([]types.Advisory, error) {
+func (vs VulnSrc) Get(params db.GetParams) ([]types.Advisory, error) {
 	eb := oops.In(string(source.ID))
 
-	advisories, err := vs.dbc.GetAdvisories(distroName, pkgName)
+	advisories, err := vs.dbc.GetAdvisories(distroName, params.PkgName)
 	if err != nil {
 		return nil, eb.With("bucket", distroName).Wrapf(err, "failed to get advisories")
 	}

--- a/pkg/vulnsrc/echo/echo_test.go
+++ b/pkg/vulnsrc/echo/echo_test.go
@@ -4,6 +4,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/aquasecurity/trivy-db/pkg/db"
 	"github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/vulnerability"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrctest"
@@ -99,8 +100,10 @@ func TestVulnSrc_Get(t *testing.T) {
 			vulnsrctest.TestGet(t, vs, vulnsrctest.TestGetArgs{
 				Fixtures:   tt.fixtures,
 				WantValues: tt.want,
-				PkgName:    tt.args.pkgName,
-				WantErr:    tt.wantErr,
+				GetParams: db.GetParams{
+					PkgName: tt.args.pkgName,
+				},
+				WantErr: tt.wantErr,
 			})
 		})
 	}

--- a/pkg/vulnsrc/minimos/minimos.go
+++ b/pkg/vulnsrc/minimos/minimos.go
@@ -117,7 +117,7 @@ func (vs VulnSrc) saveSecFixes(tx *bolt.Tx, platform, pkgName string, secfixes m
 	return nil
 }
 
-func (vs VulnSrc) Get(_, pkgName string) ([]types.Advisory, error) {
+func (vs VulnSrc) Get(_, pkgName, _ string) ([]types.Advisory, error) {
 	eb := oops.In(string(source.ID))
 	bucket := distroName
 	advisories, err := vs.dbc.GetAdvisories(bucket, pkgName)

--- a/pkg/vulnsrc/minimos/minimos.go
+++ b/pkg/vulnsrc/minimos/minimos.go
@@ -117,10 +117,10 @@ func (vs VulnSrc) saveSecFixes(tx *bolt.Tx, platform, pkgName string, secfixes m
 	return nil
 }
 
-func (vs VulnSrc) Get(_, pkgName, _ string) ([]types.Advisory, error) {
+func (vs VulnSrc) Get(params db.GetParams) ([]types.Advisory, error) {
 	eb := oops.In(string(source.ID))
 	bucket := distroName
-	advisories, err := vs.dbc.GetAdvisories(bucket, pkgName)
+	advisories, err := vs.dbc.GetAdvisories(bucket, params.PkgName)
 	if err != nil {
 		return nil, eb.Wrapf(err, "failed to get advisories")
 	}

--- a/pkg/vulnsrc/oracle-oval/oracle-oval_test.go
+++ b/pkg/vulnsrc/oracle-oval/oracle-oval_test.go
@@ -5,10 +5,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
-	"github.com/aquasecurity/trivy-db/pkg/db"
-	"github.com/aquasecurity/trivy-db/pkg/dbtest"
 	"github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy-db/pkg/utils"
 	oracleoval "github.com/aquasecurity/trivy-db/pkg/vulnsrc/oracle-oval"
@@ -742,19 +738,15 @@ func TestVulnSrc_Get(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_ = dbtest.InitDB(t, tt.fixtures)
-			defer db.Close()
-
 			vs := oracleoval.NewVulnSrc()
-			got, err := vs.Get(tt.version, tt.pkgName, tt.arch)
-
-			if tt.wantErr != "" {
-				require.ErrorContains(t, err, tt.wantErr)
-				return
-			}
-
-			require.NoError(t, err)
-			require.Equal(t, tt.want, got)
+			vulnsrctest.TestGet(t, vs, vulnsrctest.TestGetArgs{
+				Fixtures:   tt.fixtures,
+				WantValues: tt.want,
+				Release:    tt.version,
+				PkgName:    tt.pkgName,
+				Arch:       tt.arch,
+				WantErr:    tt.wantErr,
+			})
 		})
 	}
 }

--- a/pkg/vulnsrc/oracle-oval/oracle-oval_test.go
+++ b/pkg/vulnsrc/oracle-oval/oracle-oval_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/aquasecurity/trivy-db/pkg/db"
 	"github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy-db/pkg/utils"
 	oracleoval "github.com/aquasecurity/trivy-db/pkg/vulnsrc/oracle-oval"
@@ -742,10 +743,12 @@ func TestVulnSrc_Get(t *testing.T) {
 			vulnsrctest.TestGet(t, vs, vulnsrctest.TestGetArgs{
 				Fixtures:   tt.fixtures,
 				WantValues: tt.want,
-				Release:    tt.version,
-				PkgName:    tt.pkgName,
-				Arch:       tt.arch,
-				WantErr:    tt.wantErr,
+				GetParams: db.GetParams{
+					Release: tt.version,
+					PkgName: tt.pkgName,
+					Arch:    tt.arch,
+				},
+				WantErr: tt.wantErr,
 			})
 		})
 	}

--- a/pkg/vulnsrc/photon/photon.go
+++ b/pkg/vulnsrc/photon/photon.go
@@ -109,10 +109,10 @@ func (vs VulnSrc) commit(tx *bolt.Tx, cves []PhotonCVE) error {
 	return nil
 }
 
-func (vs VulnSrc) Get(release, pkgName, _ string) ([]types.Advisory, error) {
-	eb := oops.In("photon").With("release", release)
-	bucket := fmt.Sprintf(platformFormat, release)
-	advisories, err := vs.dbc.GetAdvisories(bucket, pkgName)
+func (vs VulnSrc) Get(params db.GetParams) ([]types.Advisory, error) {
+	eb := oops.In("photon").With("release", params.Release)
+	bucket := fmt.Sprintf(platformFormat, params.Release)
+	advisories, err := vs.dbc.GetAdvisories(bucket, params.PkgName)
 	if err != nil {
 		return nil, eb.Wrapf(err, "failed to get advisories")
 	}

--- a/pkg/vulnsrc/photon/photon.go
+++ b/pkg/vulnsrc/photon/photon.go
@@ -109,7 +109,7 @@ func (vs VulnSrc) commit(tx *bolt.Tx, cves []PhotonCVE) error {
 	return nil
 }
 
-func (vs VulnSrc) Get(release, pkgName string) ([]types.Advisory, error) {
+func (vs VulnSrc) Get(release, pkgName, _ string) ([]types.Advisory, error) {
 	eb := oops.In("photon").With("release", release)
 	bucket := fmt.Sprintf(platformFormat, release)
 	advisories, err := vs.dbc.GetAdvisories(bucket, pkgName)

--- a/pkg/vulnsrc/photon/photon_test.go
+++ b/pkg/vulnsrc/photon/photon_test.go
@@ -4,6 +4,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/aquasecurity/trivy-db/pkg/db"
 	"github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/vulnerability"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrctest"
@@ -111,9 +112,11 @@ func TestVulnSrc_Get(t *testing.T) {
 			vulnsrctest.TestGet(t, vs, vulnsrctest.TestGetArgs{
 				Fixtures:   tt.fixtures,
 				WantValues: tt.want,
-				Release:    tt.release,
-				PkgName:    tt.pkgName,
-				WantErr:    tt.wantErr,
+				GetParams: db.GetParams{
+					Release: tt.release,
+					PkgName: tt.pkgName,
+				},
+				WantErr: tt.wantErr,
 			})
 		})
 	}

--- a/pkg/vulnsrc/rocky/rocky_test.go
+++ b/pkg/vulnsrc/rocky/rocky_test.go
@@ -4,6 +4,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/aquasecurity/trivy-db/pkg/db"
 	"github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/rocky"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/vulnerability"
@@ -477,10 +478,12 @@ func TestRocky_Get(t *testing.T) {
 			vulnsrctest.TestGet(t, vs, vulnsrctest.TestGetArgs{
 				Fixtures:   tt.fixtures,
 				WantValues: tt.want,
-				Release:    tt.args.release,
-				PkgName:    tt.args.pkgName,
-				Arch:       tt.args.arch,
-				WantErr:    tt.wantErr,
+				GetParams: db.GetParams{
+					Release: tt.args.release,
+					PkgName: tt.args.pkgName,
+					Arch:    tt.args.arch,
+				},
+				WantErr: tt.wantErr,
 			})
 		})
 	}

--- a/pkg/vulnsrc/rootio/rootio.go
+++ b/pkg/vulnsrc/rootio/rootio.go
@@ -186,10 +186,10 @@ func NewVulnSrcGetter(baseOS types.SourceID) VulnSrcGetter {
 	}
 }
 
-func (vs VulnSrcGetter) Get(osVer, pkgName, _ string) ([]types.Advisory, error) {
-	eb := oops.In("rootio").With("base_os", vs.baseOS).With("os_version", osVer).With("package_name", pkgName)
+func (vs VulnSrcGetter) Get(params db.GetParams) ([]types.Advisory, error) {
+	eb := oops.In("rootio").With("base_os", vs.baseOS).With("os_version", params.Release).With("package_name", params.PkgName)
 	// Get advisories from the original distributors, like Debian or Alpine
-	advs, err := vs.baseOSGetter().Get(osVer, pkgName, "")
+	advs, err := vs.baseOSGetter().Get(params)
 	if err != nil {
 		return nil, eb.Wrapf(err, "failed to get advisories for base OS")
 	}
@@ -205,8 +205,8 @@ func (vs VulnSrcGetter) Get(osVer, pkgName, _ string) ([]types.Advisory, error) 
 		allAdvs[adv.VulnerabilityID] = adv
 	}
 
-	rootioOSVer := fmt.Sprintf(platformFormat, vs.baseOS, osVer)
-	advs, err = vs.dbc.GetAdvisories(rootioOSVer, pkgName)
+	rootioOSVer := fmt.Sprintf(platformFormat, vs.baseOS, params.Release)
+	advs, err = vs.dbc.GetAdvisories(rootioOSVer, params.PkgName)
 	if err != nil {
 		return nil, eb.Wrapf(err, "failed to get advisories")
 	}

--- a/pkg/vulnsrc/rootio/rootio.go
+++ b/pkg/vulnsrc/rootio/rootio.go
@@ -186,10 +186,10 @@ func NewVulnSrcGetter(baseOS types.SourceID) VulnSrcGetter {
 	}
 }
 
-func (vs VulnSrcGetter) Get(osVer, pkgName string) ([]types.Advisory, error) {
+func (vs VulnSrcGetter) Get(osVer, pkgName, _ string) ([]types.Advisory, error) {
 	eb := oops.In("rootio").With("base_os", vs.baseOS).With("os_version", osVer).With("package_name", pkgName)
 	// Get advisories from the original distributors, like Debian or Alpine
-	advs, err := vs.baseOSGetter().Get(osVer, pkgName)
+	advs, err := vs.baseOSGetter().Get(osVer, pkgName, "")
 	if err != nil {
 		return nil, eb.Wrapf(err, "failed to get advisories for base OS")
 	}

--- a/pkg/vulnsrc/rootio/rootio_test.go
+++ b/pkg/vulnsrc/rootio/rootio_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/aquasecurity/trivy-db/pkg/db"
 	"github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/rootio"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/vulnerability"
@@ -301,9 +302,11 @@ func TestVulnSrc_Get(t *testing.T) {
 			vulnsrctest.TestGet(t, vs, vulnsrctest.TestGetArgs{
 				Fixtures:   tt.fixtures,
 				WantValues: tt.want,
-				Release:    tt.args.osVer,
-				PkgName:    tt.args.pkgName,
-				WantErr:    tt.wantErr,
+				GetParams: db.GetParams{
+					Release: tt.args.osVer,
+					PkgName: tt.args.pkgName,
+				},
+				WantErr: tt.wantErr,
 			})
 		})
 	}

--- a/pkg/vulnsrc/suse-cvrf/suse-cvrf.go
+++ b/pkg/vulnsrc/suse-cvrf/suse-cvrf.go
@@ -350,7 +350,7 @@ func splitPkgName(pkgName string) (string, string) {
 	return pkgName, version
 }
 
-func (vs VulnSrc) Get(version, pkgName string) ([]types.Advisory, error) {
+func (vs VulnSrc) Get(version, pkgName, _ string) ([]types.Advisory, error) {
 	eb := oops.In("suse").Tags("cvrf").With("version", version).With("package_name", pkgName)
 	var bucket string
 	switch vs.dist {

--- a/pkg/vulnsrc/suse-cvrf/suse-cvrf.go
+++ b/pkg/vulnsrc/suse-cvrf/suse-cvrf.go
@@ -350,23 +350,23 @@ func splitPkgName(pkgName string) (string, string) {
 	return pkgName, version
 }
 
-func (vs VulnSrc) Get(version, pkgName, _ string) ([]types.Advisory, error) {
-	eb := oops.In("suse").Tags("cvrf").With("version", version).With("package_name", pkgName)
+func (vs VulnSrc) Get(params db.GetParams) ([]types.Advisory, error) {
+	eb := oops.In("suse").Tags("cvrf").With("release", params.Release).With("package_name", params.PkgName)
 	var bucket string
 	switch vs.dist {
 	case SUSEEnterpriseLinuxMicro:
-		bucket = fmt.Sprintf(platformSUSELinuxEnterpriseMicroFormat, version)
+		bucket = fmt.Sprintf(platformSUSELinuxEnterpriseMicroFormat, params.Release)
 	case SUSEEnterpriseLinux:
-		bucket = fmt.Sprintf(platformSUSELinuxFormat, version)
+		bucket = fmt.Sprintf(platformSUSELinuxFormat, params.Release)
 	case OpenSUSE:
-		bucket = fmt.Sprintf(platformOpenSUSELeapFormat, version)
+		bucket = fmt.Sprintf(platformOpenSUSELeapFormat, params.Release)
 	case OpenSUSETumbleweed:
 		bucket = platformOpenSUSETumbleweedFormat
 	default:
 		return nil, eb.Errorf("unknown distribution")
 	}
 
-	advisories, err := vs.GetAdvisories(bucket, pkgName)
+	advisories, err := vs.GetAdvisories(bucket, params.PkgName)
 	if err != nil {
 		return nil, eb.Wrapf(err, "failed to get advisories")
 	}

--- a/pkg/vulnsrc/suse-cvrf/suse-cvrf_test.go
+++ b/pkg/vulnsrc/suse-cvrf/suse-cvrf_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/aquasecurity/trivy-db/pkg/db"
 	"github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/vulnerability"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrctest"
@@ -44,7 +45,9 @@ func TestVulnSrc_Update(t *testing.T) {
 					},
 				},
 				{
-					Key: []string{"advisory-detail", "openSUSE-SU-2019:2598-1", "openSUSE Leap 15.1", "strongswan-sqlite"},
+					Key: []string{
+						"advisory-detail", "openSUSE-SU-2019:2598-1", "openSUSE Leap 15.1", "strongswan-sqlite",
+					},
 					Value: types.Advisory{
 						FixedVersion: "5.6.0-lp151.4.3.1",
 					},
@@ -81,13 +84,17 @@ func TestVulnSrc_Update(t *testing.T) {
 					},
 				},
 				{
-					Key: []string{"advisory-detail", "openSUSE-SU-2024:10400-1", "openSUSE Tumbleweed", "python3-logilab-common"},
+					Key: []string{
+						"advisory-detail", "openSUSE-SU-2024:10400-1", "openSUSE Tumbleweed", "python3-logilab-common",
+					},
 					Value: types.Advisory{
 						FixedVersion: "1.2.2-1.2",
 					},
 				},
 				{
-					Key: []string{"advisory-detail", "openSUSE-SU-2024:10400-1", "openSUSE Tumbleweed", "python-logilab-common"},
+					Key: []string{
+						"advisory-detail", "openSUSE-SU-2024:10400-1", "openSUSE Tumbleweed", "python-logilab-common",
+					},
 					Value: types.Advisory{
 						FixedVersion: "1.0.2-1.4",
 					},
@@ -125,7 +132,9 @@ func TestVulnSrc_Update(t *testing.T) {
 					},
 				},
 				{
-					Key: []string{"advisory-detail", "SUSE-SU-2019:0048-2", "SUSE Linux Enterprise 15.1", "helm-mirror"},
+					Key: []string{
+						"advisory-detail", "SUSE-SU-2019:0048-2", "SUSE Linux Enterprise 15.1", "helm-mirror",
+					},
 					Value: types.Advisory{
 						FixedVersion: "0.2.1-1.7.1",
 					},
@@ -163,13 +172,18 @@ func TestVulnSrc_Update(t *testing.T) {
 					},
 				},
 				{
-					Key: []string{"advisory-detail", "openSUSE-SU-2019:0003-1", "SUSE Linux Enterprise 15", "GraphicsMagick"},
+					Key: []string{
+						"advisory-detail", "openSUSE-SU-2019:0003-1", "SUSE Linux Enterprise 15", "GraphicsMagick",
+					},
 					Value: types.Advisory{
 						FixedVersion: "1.3.29-bp150.2.12.1",
 					},
 				},
 				{
-					Key: []string{"advisory-detail", "openSUSE-SU-2019:0003-1", "SUSE Linux Enterprise 15", "GraphicsMagick-devel"},
+					Key: []string{
+						"advisory-detail", "openSUSE-SU-2019:0003-1", "SUSE Linux Enterprise 15",
+						"GraphicsMagick-devel",
+					},
 					Value: types.Advisory{
 						FixedVersion: "1.3.29-bp150.2.12.1",
 					},
@@ -206,14 +220,18 @@ func TestVulnSrc_Update(t *testing.T) {
 					},
 				},
 				{
-					Key: []string{"advisory-detail", "SUSE-SU-2024:2546-1", "SUSE Linux Enterprise Micro 5.3", "gnutls"},
+					Key: []string{
+						"advisory-detail", "SUSE-SU-2024:2546-1", "SUSE Linux Enterprise Micro 5.3", "gnutls",
+					},
 
 					Value: types.Advisory{
 						FixedVersion: "3.7.3-150400.8.1",
 					},
 				},
 				{
-					Key: []string{"advisory-detail", "SUSE-SU-2024:2546-1", "SUSE Linux Enterprise Micro 5.3", "libgnutls30"},
+					Key: []string{
+						"advisory-detail", "SUSE-SU-2024:2546-1", "SUSE Linux Enterprise Micro 5.3", "libgnutls30",
+					},
 					Value: types.Advisory{
 						FixedVersion: "3.7.3-150400.8.1",
 					},
@@ -313,9 +331,11 @@ func TestVulnSrc_Get(t *testing.T) {
 			vulnsrctest.TestGet(t, vs, vulnsrctest.TestGetArgs{
 				Fixtures:   tt.fixtures,
 				WantValues: tt.want,
-				Release:    tt.version,
-				PkgName:    tt.pkgName,
-				WantErr:    tt.wantErr,
+				GetParams: db.GetParams{
+					Release: tt.version,
+					PkgName: tt.pkgName,
+				},
+				WantErr: tt.wantErr,
 			})
 		})
 	}

--- a/pkg/vulnsrc/ubuntu/ubuntu.go
+++ b/pkg/vulnsrc/ubuntu/ubuntu.go
@@ -152,10 +152,10 @@ func (vs VulnSrc) commit(tx *bolt.Tx, cves []UbuntuCVE) error {
 	return nil
 }
 
-func (vs VulnSrc) Get(release, pkgName, _ string) ([]types.Advisory, error) {
-	eb := oops.In("ubuntu").With("release", release).With("package_name", pkgName)
-	bucket := fmt.Sprintf(platformFormat, release)
-	advisories, err := vs.dbc.GetAdvisories(bucket, pkgName)
+func (vs VulnSrc) Get(params db.GetParams) ([]types.Advisory, error) {
+	eb := oops.In("ubuntu").With("release", params.Release).With("package_name", params.PkgName)
+	bucket := fmt.Sprintf(platformFormat, params.Release)
+	advisories, err := vs.dbc.GetAdvisories(bucket, params.PkgName)
 	if err != nil {
 		return nil, eb.Wrapf(err, "failed to get advisories")
 	}

--- a/pkg/vulnsrc/ubuntu/ubuntu.go
+++ b/pkg/vulnsrc/ubuntu/ubuntu.go
@@ -152,7 +152,7 @@ func (vs VulnSrc) commit(tx *bolt.Tx, cves []UbuntuCVE) error {
 	return nil
 }
 
-func (vs VulnSrc) Get(release, pkgName string) ([]types.Advisory, error) {
+func (vs VulnSrc) Get(release, pkgName, _ string) ([]types.Advisory, error) {
 	eb := oops.In("ubuntu").With("release", release).With("package_name", pkgName)
 	bucket := fmt.Sprintf(platformFormat, release)
 	advisories, err := vs.dbc.GetAdvisories(bucket, pkgName)

--- a/pkg/vulnsrc/wolfi/wolfi.go
+++ b/pkg/vulnsrc/wolfi/wolfi.go
@@ -113,10 +113,10 @@ func (vs VulnSrc) saveSecFixes(tx *bolt.Tx, platform, pkgName string, secfixes m
 	return nil
 }
 
-func (vs VulnSrc) Get(_, pkgName, _ string) ([]types.Advisory, error) {
+func (vs VulnSrc) Get(params db.GetParams) ([]types.Advisory, error) {
 	eb := oops.In(string(source.ID))
 	bucket := distroName
-	advisories, err := vs.dbc.GetAdvisories(bucket, pkgName)
+	advisories, err := vs.dbc.GetAdvisories(bucket, params.PkgName)
 	if err != nil {
 		return nil, eb.Wrapf(err, "failed to get advisories")
 	}

--- a/pkg/vulnsrc/wolfi/wolfi.go
+++ b/pkg/vulnsrc/wolfi/wolfi.go
@@ -113,7 +113,7 @@ func (vs VulnSrc) saveSecFixes(tx *bolt.Tx, platform, pkgName string, secfixes m
 	return nil
 }
 
-func (vs VulnSrc) Get(_, pkgName string) ([]types.Advisory, error) {
+func (vs VulnSrc) Get(_, pkgName, _ string) ([]types.Advisory, error) {
 	eb := oops.In(string(source.ID))
 	bucket := distroName
 	advisories, err := vs.dbc.GetAdvisories(bucket, pkgName)

--- a/pkg/vulnsrctest/vulnsrctest.go
+++ b/pkg/vulnsrctest/vulnsrctest.go
@@ -59,9 +59,7 @@ func TestUpdate(t *testing.T, vulnsrc Updater, args TestUpdateArgs) {
 type TestGetArgs struct {
 	Fixtures   []string
 	WantValues []types.Advisory
-	Release    string
-	PkgName    string
-	Arch       string
+	GetParams  db.GetParams
 	WantErr    string
 }
 
@@ -71,11 +69,7 @@ func TestGet(t *testing.T, vulnsrc db.Getter, args TestGetArgs) {
 	_ = dbtest.InitDB(t, args.Fixtures)
 	defer db.Close()
 
-	got, err := vulnsrc.Get(db.GetParams{
-		Release: args.Release,
-		PkgName: args.PkgName,
-		Arch:    args.Arch,
-	})
+	got, err := vulnsrc.Get(args.GetParams)
 
 	if args.WantErr != "" {
 		require.Error(t, err)

--- a/pkg/vulnsrctest/vulnsrctest.go
+++ b/pkg/vulnsrctest/vulnsrctest.go
@@ -71,7 +71,11 @@ func TestGet(t *testing.T, vulnsrc db.Getter, args TestGetArgs) {
 	_ = dbtest.InitDB(t, args.Fixtures)
 	defer db.Close()
 
-	got, err := vulnsrc.Get(args.Release, args.PkgName, args.Arch)
+	got, err := vulnsrc.Get(db.GetParams{
+		Release: args.Release,
+		PkgName: args.PkgName,
+		Arch:    args.Arch,
+	})
 
 	if args.WantErr != "" {
 		require.Error(t, err)

--- a/pkg/vulnsrctest/vulnsrctest.go
+++ b/pkg/vulnsrctest/vulnsrctest.go
@@ -61,6 +61,7 @@ type TestGetArgs struct {
 	WantValues []types.Advisory
 	Release    string
 	PkgName    string
+	Arch       string
 	WantErr    string
 }
 
@@ -70,7 +71,7 @@ func TestGet(t *testing.T, vulnsrc db.Getter, args TestGetArgs) {
 	_ = dbtest.InitDB(t, args.Fixtures)
 	defer db.Close()
 
-	got, err := vulnsrc.Get(args.Release, args.PkgName)
+	got, err := vulnsrc.Get(args.Release, args.PkgName, args.Arch)
 
 	if args.WantErr != "" {
 		require.Error(t, err)


### PR DESCRIPTION
## Description
We have 3 implementation for `Get` function:
- `Get(osVer, pkgName)` - `Getter` interface
- `Get(osVer, pkgName, arch)` - rocky linux + oracle linux
- `Get(pkgName, repositories, nvrs)` - RedHat

This PR refactors `Getter` interface to include an architecture parameter.
These changes create one common interface for all Get function (except RedHat). 
Sources with changed `Get` function - Alma, Alpine, Amazon, Azure, Chainguard, Debian, Echo, Minimos, Oracle, Photon, Rocky, SUSE, Ubuntu, and Wolfi.

These changes will also make it easier to use sources inside another source (eg root.io + debian)