### PR TITLE
ci: use digests instead of versions for actions

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -27,10 +27,10 @@ jobs:
           remove-swapfile: 'true'
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4 (v4.3.0)
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5 (v5.5.0)
         with:
           go-version-file: go.mod
 
@@ -56,20 +56,20 @@ jobs:
         run: mv assets/db.tar.gz .
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3 (v3.6.0)
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GitHub Packages Container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3 (v3.6.0)
         with:
           registry: ghcr.io
           username: ${{ env.GH_USER }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to ECR
-        uses: docker/login-action@v3
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3 (v3.6.0)
         with:
           registry: public.ecr.aws
           username: ${{ secrets.ECR_ACCESS_KEY_ID }}

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -27,10 +27,10 @@ jobs:
           remove-swapfile: 'true'
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4 (v4.3.0)
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
       - name: Set up Go
-        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5 (v5.5.0)
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version-file: go.mod
 
@@ -56,20 +56,20 @@ jobs:
         run: mv assets/db.tar.gz .
 
       - name: Login to Docker Hub
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3 (v3.6.0)
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GitHub Packages Container registry
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3 (v3.6.0)
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
         with:
           registry: ghcr.io
           username: ${{ env.GH_USER }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to ECR
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3 (v3.6.0)
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
         with:
           registry: public.ecr.aws
           username: ${{ secrets.ECR_ACCESS_KEY_ID }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4 (v4.3.0)
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
       - name: Set up Go
-        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5 (v5.5.0)
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4 (v4.3.0)
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5 (v5.5.0)
         with:
           go-version-file: go.mod
 


### PR DESCRIPTION
## Description

  This PR updates GitHub Actions workflow dependencies to use commit digests instead of semantic version tags for enhanced security. The changes affect two workflow files:

  - .github/workflows/cron.yml: Updates 4 action references to use SHA digests
  - .github/workflows/go.yml: Updates 2 action references to use SHA digests

  The specific actions updated include:
  - actions/checkout@v4 → actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
  - actions/setup-go@v5 → actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5
  - docker/login-action@v3 → docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef

  Each digest reference includes a comment indicating the corresponding semantic version for maintainability.

## Reasons for Change

  1. Security Enhancement: Using commit digests prevents potential supply chain attacks where malicious actors could compromise action repositories and push malicious code under existing version tags.
  2. Immutable References: Commit hashes provide immutable references that cannot be changed, ensuring the exact same code runs every time the workflow executes.
  3. Compliance with Security Best Practices: Many security frameworks and guidelines recommend pinning dependencies to specific commits rather than mutable tags.
  4. Audit Trail: Explicit commit references make it easier to audit exactly which version of each action is being used and track changes over time.
