### PR TITLE
fix(photon): skip `NA` versions

### DIFF
--- a/pkg/vulnsrc/photon/photon_test.go
+++ b/pkg/vulnsrc/photon/photon_test.go
@@ -15,6 +15,7 @@ func TestVulnSrc_Update(t *testing.T) {
 		name       string
 		dir        string
 		wantValues []vulnsrctest.WantValues
+		noBuckets  [][]string
 		wantErr    string
 	}{
 		{
@@ -46,6 +47,21 @@ func TestVulnSrc_Update(t *testing.T) {
 					Value: map[string]any{},
 				},
 			},
+			noBuckets: [][]string{
+				// Skip advisories with no fixed and affected version
+				{
+					"advisory-detail",
+					"CVE-2025-0725",
+				},
+				{
+					"vulnerability-detail",
+					"CVE-2025-0725",
+				},
+				{
+					"vulnerability-id",
+					"CVE-2025-0725",
+				},
+			},
 		},
 		{
 			name:    "sad path (dir doesn't exist)",
@@ -65,6 +81,7 @@ func TestVulnSrc_Update(t *testing.T) {
 				Dir:        tt.dir,
 				WantValues: tt.wantValues,
 				WantErr:    tt.wantErr,
+				NoBuckets:  tt.noBuckets,
 			})
 		})
 	}

--- a/pkg/vulnsrc/photon/testdata/happy/vuln-list/photon/3.0/curl/CVE-2025-0725.json
+++ b/pkg/vulnsrc/photon/testdata/happy/vuln-list/photon/3.0/curl/CVE-2025-0725.json
@@ -1,0 +1,8 @@
+{
+  "os_version": "3.0",
+  "cve_id": "CVE-2025-0725",
+  "pkg": "curl",
+  "cve_score": 7.3,
+  "aff_ver": "NA",
+  "res_ver": "NA"
+}


### PR DESCRIPTION
## Description

  This PR fixes the handling of "NA" (not available) versions in the Photon vulnerability source. The changes normalize "NA" strings to empty strings and skip advisories that have both empty fixed and affected versions to prevent invalid
  version data from being stored in the database.

  This ensures that Photon vulnerability data maintains consistency with other vulnerability sources and prevents "NA" from being interpreted as an actual version string.

Example advisories with `NA` versions:
- https://github.com/DmitriyLewen/vuln-list/blob/e6dc03cef6b65145de5a8489284473002dda74f1/photon/3.0/ImageMagick/CVE-2023-2157.json
- https://github.com/DmitriyLewen/vuln-list/blob/e6dc03cef6b65145de5a8489284473002dda74f1/photon/3.0/dnsmasq/CVE-2017-14495.json

