### PR TITLE
feat(suse): Implement handling for SUSE Linux Enterprise Server 16.0

### DIFF
--- a/pkg/vulnsrc/suse-cvrf/suse-cvrf.go
+++ b/pkg/vulnsrc/suse-cvrf/suse-cvrf.go
@@ -279,7 +279,8 @@ func (vs VulnSrc) getOSVersion(platformName string) string {
 			return ""
 		}
 
-		ss := strings.Fields(strings.ReplaceAll(platformName, "-", " "))
+		// Handle both 15-SP7 and 16.0
+		ss := strings.Fields(strings.ReplaceAll(strings.ReplaceAll(platformName, "-", " "), ".", " "))
 		versions := make([]string, 0, 2)
 		for i := len(ss) - 1; i > 0; i-- {
 			v, err := strconv.Atoi(strings.TrimPrefix(ss[i], "SP"))

--- a/pkg/vulnsrc/suse-cvrf/suse-cvrf_test.go
+++ b/pkg/vulnsrc/suse-cvrf/suse-cvrf_test.go
@@ -673,6 +673,10 @@ func TestGetOSVersion(t *testing.T) {
 			inputPlatformName:    "SUSE Linux Enterprise Micro 5.1",
 			expectedPlatformName: "SUSE Linux Enterprise Micro 5.1",
 		},
+		{
+			inputPlatformName:    "SUSE Linux Enterprise Server 16.0",
+			expectedPlatformName: "SUSE Linux Enterprise 16.0",
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.inputPlatformName, func(t *testing.T) {


### PR DESCRIPTION
Starting with 16, SUSE stopped using the "SP" suffixing and changed to a major.minor format.