### PR TITLE
docs: add partner code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,8 @@
 # Global
 *   @knqyf263
+
+# Partner
+/pkg/vulnsrc/echo/       @DmitriyLewen
+/pkg/vulnsrc/minimos/    @DmitriyLewen
+/pkg/vulnsrc/rootio/     @DmitriyLewen
+/pkg/vulnsrc/seal/       @DmitriyLewen


### PR DESCRIPTION
## Summary
- Add @DmitriyLewen as code owner for partner-related vulnerability sources:
  - `/pkg/vulnsrc/echo/`
  - `/pkg/vulnsrc/minimos/`
  - `/pkg/vulnsrc/rootio/`
  - `/pkg/vulnsrc/seal/`