### PR TITLE
Update PhotonOS feed URL

### DIFF
--- a/pkg/vulnsrc/photon/photon.go
+++ b/pkg/vulnsrc/photon/photon.go
@@ -22,7 +22,7 @@ const photonDir = "photon"
 var source = types.DataSource{
 	ID:   vulnerability.Photon,
 	Name: "Photon OS CVE metadata",
-	URL:  "https://packages.vmware.com/photon/photon_cve_metadata/",
+	URL:  "https://packages.broadcom.com/photon/photon_cve_metadata/",
 }
 
 type VulnSrc struct {

--- a/pkg/vulnsrc/photon/photon_test.go
+++ b/pkg/vulnsrc/photon/photon_test.go
@@ -27,7 +27,7 @@ func TestVulnSrc_Update(t *testing.T) {
 					Value: types.DataSource{
 						ID:   vulnerability.Photon,
 						Name: "Photon OS CVE metadata",
-						URL:  "https://packages.vmware.com/photon/photon_cve_metadata/",
+						URL:  "https://packages.broadcom.com/photon/photon_cve_metadata/",
 					},
 				},
 				{


### PR DESCRIPTION
There was a change in the Photon OS CVE feed. It is now served at https://packages.broadcom.com/photon/photon_cve_metadata.

The previous feed (https://packages.vmware.com/photon/photon_cve_metadata/) was last updated in December 2025 and is no longer maintained in favor of the new feed, which was recently updated.

Related PRs:
- https://github.com/aquasecurity/trivy/pull/10122
- https://github.com/aquasecurity/vuln-list-update/pull/402