### PR TITLE
feat(ubuntu): add advs for 25.10

### DIFF
--- a/pkg/vulnsrc/ubuntu/ubuntu.go
+++ b/pkg/vulnsrc/ubuntu/ubuntu.go
@@ -49,6 +49,7 @@ var (
 		"noble":    "24.04",
 		"oracular": "24.10",
 		"plucky":   "25.04",
+		"questing": "25.10",
 		// ESM versions:
 		"precise/esm": "12.04-ESM",
 		"trusty/esm":  "14.04-ESM",


### PR DESCRIPTION
## Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 
  This PR adds support for Ubuntu 25.10 (codenamed "Questing") to the vulnerability database. This ensures that Trivy can detect vulnerabilities for the upcoming Ubuntu release.     

<img width="198" height="50" alt="изображение" src="https://github.com/user-attachments/assets/cc3983ec-9410-45cf-94bd-e48dacdc732e" />
 