### PR TITLE
fix(makefile): separate download and extraction steps for stability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,11 @@ ASSET_DIR ?= assets
 # Usage: $(call download_and_extract,URL,TARGET_DIR)
 # This approach prevents pipe failures when wget encounters recoverable errors
 define download_and_extract
-	@echo "Downloading $(1)..."
-	wget -q $(1) -O $(CACHE_DIR)/tmp-archive.tar.gz
-	tar xzf $(CACHE_DIR)/tmp-archive.tar.gz -C $(2) --strip-components=1
-	rm -f $(CACHE_DIR)/tmp-archive.tar.gz
+	@echo "Downloading $(1)..." && \
+	TMP_FILE=$$(mktemp) && \
+	wget -q $(1) -O "$$TMP_FILE" && \
+	tar xzf "$$TMP_FILE" -C $(2) --strip-components=1 && \
+	rm -f "$$TMP_FILE"
 endef
 
 GOPATH=$(shell go env GOPATH)


### PR DESCRIPTION
 ## Summary 
Replace piped `wget | tar` with two-step download-then-extract approach                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                                                               
## Details
When using pipe, if wget encounters a recoverable error (timeout, connection drop), it closes the pipe on its end. This causes tar to receive EOF and exit completely, even though wget could have recovered. 
By separating the steps, wget can use its built-in retry mechanism (20 attempts by default) without affecting tar. 

## Test runs
- https://github.com/DmitriyLewen/trivy-db/actions/runs/21856329850/job/63073946275
- https://github.com/DmitriyLewen/trivy-db/actions/runs/21856334341/job/63073959061

## Related issues
- Closes #627 