### PR TITLE
fix(redhat-csaf): merge CPE list with existing OVAL CPEs

### DIFF
--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -55,7 +55,7 @@ type Operation interface {
 	PutRedHatCPEs(tx *bolt.Tx, cpeIndex int, cpe string) (err error)
 	RedHatRepoToCPEs(repository string) (cpeIndices []int, err error)
 	RedHatNVRToCPEs(nvr string) (cpeIndices []int, err error)
-	GetAllRedHatCPEs(tx *bolt.Tx) (cpes map[int]string, err error)
+	GetAllRedHatCPEs(tx *bolt.Tx) (cpes []string, err error)
 }
 
 type Getter interface {

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -55,6 +55,7 @@ type Operation interface {
 	PutRedHatCPEs(tx *bolt.Tx, cpeIndex int, cpe string) (err error)
 	RedHatRepoToCPEs(repository string) (cpeIndices []int, err error)
 	RedHatNVRToCPEs(nvr string) (cpeIndices []int, err error)
+	GetAllRedHatCPEs(tx *bolt.Tx) (cpes map[int]string, err error)
 }
 
 type Getter interface {

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -55,7 +55,7 @@ type Operation interface {
 	PutRedHatCPEs(tx *bolt.Tx, cpeIndex int, cpe string) (err error)
 	RedHatRepoToCPEs(repository string) (cpeIndices []int, err error)
 	RedHatNVRToCPEs(nvr string) (cpeIndices []int, err error)
-	GetAllRedHatCPEs(tx *bolt.Tx) (cpes []string, err error)
+	RedHatCPEs(tx *bolt.Tx) (cpes []string, err error)
 }
 
 type Getter interface {

--- a/pkg/db/redhat_cpe.go
+++ b/pkg/db/redhat_cpe.go
@@ -65,3 +65,37 @@ func (dbc Config) getCPEs(bucket, key string) ([]int, error) {
 	}
 	return cpes, nil
 }
+
+// GetAllRedHatCPEs returns all stored CPE mappings (index -> CPE string).
+// This is used to merge CSAF CPEs with existing OVAL CPEs.
+func (dbc Config) GetAllRedHatCPEs(tx *bolt.Tx) (map[int]string, error) {
+	result := make(map[int]string)
+
+	root := tx.Bucket([]byte(redhatCPERootBucket))
+	if root == nil {
+		return result, nil
+	}
+
+	cpeBucket := root.Bucket([]byte(redhatCPEBucket))
+	if cpeBucket == nil {
+		return result, nil
+	}
+
+	err := cpeBucket.ForEach(func(k, v []byte) error {
+		index, err := strconv.Atoi(string(k))
+		if err != nil {
+			return oops.Wrapf(err, "invalid CPE index key: %s", string(k))
+		}
+		var cpe string
+		if err := json.Unmarshal(v, &cpe); err != nil {
+			return oops.Wrapf(err, "failed to unmarshal CPE value")
+		}
+		result[index] = cpe
+		return nil
+	})
+	if err != nil {
+		return nil, oops.Wrapf(err, "failed to iterate CPE bucket")
+	}
+
+	return result, nil
+}

--- a/pkg/db/redhat_cpe.go
+++ b/pkg/db/redhat_cpe.go
@@ -66,9 +66,9 @@ func (dbc Config) getCPEs(bucket, key string) ([]int, error) {
 	return cpes, nil
 }
 
-// GetAllRedHatCPEs returns all stored CPE strings ordered by their index.
+// RedHatCPEs returns all stored CPE strings ordered by their index.
 // This is used to merge CSAF CPEs with existing OVAL CPEs.
-func (dbc Config) GetAllRedHatCPEs(tx *bolt.Tx) ([]string, error) {
+func (dbc Config) RedHatCPEs(tx *bolt.Tx) ([]string, error) {
 	root := tx.Bucket([]byte(redhatCPERootBucket))
 	if root == nil {
 		return nil, nil

--- a/pkg/db/redhat_cpe.go
+++ b/pkg/db/redhat_cpe.go
@@ -66,21 +66,20 @@ func (dbc Config) getCPEs(bucket, key string) ([]int, error) {
 	return cpes, nil
 }
 
-// GetAllRedHatCPEs returns all stored CPE mappings (index -> CPE string).
+// GetAllRedHatCPEs returns all stored CPE strings ordered by their index.
 // This is used to merge CSAF CPEs with existing OVAL CPEs.
-func (dbc Config) GetAllRedHatCPEs(tx *bolt.Tx) (map[int]string, error) {
-	result := make(map[int]string)
-
+func (dbc Config) GetAllRedHatCPEs(tx *bolt.Tx) ([]string, error) {
 	root := tx.Bucket([]byte(redhatCPERootBucket))
 	if root == nil {
-		return result, nil
+		return nil, nil
 	}
-
 	cpeBucket := root.Bucket([]byte(redhatCPEBucket))
 	if cpeBucket == nil {
-		return result, nil
+		return nil, nil
 	}
-
+	// BoltDB iterates keys in lexicographic order ("0","1","10","2",...),
+	// so we parse each key as an integer and assign by index directly.
+	var result []string
 	err := cpeBucket.ForEach(func(k, v []byte) error {
 		index, err := strconv.Atoi(string(k))
 		if err != nil {
@@ -90,12 +89,14 @@ func (dbc Config) GetAllRedHatCPEs(tx *bolt.Tx) (map[int]string, error) {
 		if err := json.Unmarshal(v, &cpe); err != nil {
 			return oops.Wrapf(err, "failed to unmarshal CPE value")
 		}
+		for len(result) <= index {
+			result = append(result, "")
+		}
 		result[index] = cpe
 		return nil
 	})
 	if err != nil {
 		return nil, oops.Wrapf(err, "failed to iterate CPE bucket")
 	}
-
 	return result, nil
 }

--- a/pkg/vulnsrc/redhat-csaf/csaf.go
+++ b/pkg/vulnsrc/redhat-csaf/csaf.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/samber/lo"
 	"github.com/samber/oops"
 	bolt "go.etcd.io/bbolt"
 
@@ -154,7 +155,7 @@ func (vs VulnSrc) update(tx *bolt.Tx, dir string) error {
 // mergeCPEList merges the CSAF CPE list with existing OVAL CPEs in the database.
 // Existing OVAL CPE indices are preserved; new CPEs (e.g. RHEL 10-only, not in OVAL) are appended.
 func (vs VulnSrc) mergeCPEList(tx *bolt.Tx, csafCPEs redhatoval.CPEList) (redhatoval.CPEList, error) {
-	existingCPEs, err := vs.dbc.GetAllRedHatCPEs(tx)
+	existingCPEs, err := vs.dbc.RedHatCPEs(tx)
 	if err != nil {
 		return nil, oops.Wrapf(err, "failed to get existing CPEs")
 	}
@@ -163,27 +164,7 @@ func (vs VulnSrc) mergeCPEList(tx *bolt.Tx, csafCPEs redhatoval.CPEList) (redhat
 	if len(existingCPEs) == 0 {
 		return nil, oops.Errorf("no OVAL CPEs in DB; run redhat-oval before redhat-csaf when using WithRunAlongsideOVAL")
 	}
-
-	// Build a set of existing CPE strings (index-ordered slice from DB)
-	existingSet := make(map[string]bool, len(existingCPEs))
-	for _, cpe := range existingCPEs {
-		if cpe != "" {
-			existingSet[cpe] = true
-		}
-	}
-
-	// Start with existing CPEs in order
-	merged := make(redhatoval.CPEList, len(existingCPEs))
-	copy(merged, existingCPEs)
-
-	// Append new CSAF CPEs that don't exist in OVAL
-	for _, cpe := range csafCPEs {
-		if !existingSet[cpe] {
-			merged = append(merged, cpe)
-			existingSet[cpe] = true
-		}
-	}
-
+	merged := redhatoval.CPEList(lo.Uniq(append(existingCPEs, csafCPEs...)))
 	log.Info("Merged CPE list", "oval_count", len(existingCPEs), "csaf_count", len(csafCPEs), "merged_count", len(merged))
 	return merged, nil
 }

--- a/pkg/vulnsrc/redhat-csaf/csaf.go
+++ b/pkg/vulnsrc/redhat-csaf/csaf.go
@@ -51,21 +51,20 @@ func WithCustomPut(put db.CustomPut) Option {
 	}
 }
 
-// WithSkipRepoNVRMappings skips storing repository-to-CPE and NVR-to-CPE mappings.
-// Use this when OVAL already stores these mappings and CSAF should not overwrite them.
-// This is useful when CSAF runs alongside OVAL (e.g., for RHEL 10 support while OVAL handles RHEL 7-9).
-func WithSkipRepoNVRMappings() Option {
+// WithRunAlongsideOVAL enables mode for CSAF running alongside redhat-oval (e.g. RHEL 10 from CSAF, RHEL 7–9 from OVAL).
+// When set: (1) CPE list is merged with existing OVAL CPEs in the DB; (2) repo-to-CPE and NVR-to-CPE mappings are not written (OVAL already stores them).
+func WithRunAlongsideOVAL() Option {
 	return func(src *VulnSrc) {
-		src.skipRepoNVRMappings = true
+		src.runAlongsideOVAL = true
 	}
 }
 
 type VulnSrc struct {
-	put                 db.CustomPut
-	skipRepoNVRMappings bool
-	dbc                 db.Operation
-	parser              Parser
-	aggregator          Aggregator
+	put              db.CustomPut
+	runAlongsideOVAL bool
+	dbc              db.Operation
+	parser           Parser
+	aggregator       Aggregator
 }
 
 func NewVulnSrc(opts ...Option) VulnSrc {
@@ -105,17 +104,14 @@ func (vs VulnSrc) update(tx *bolt.Tx, dir string) error {
 	}
 	log.Info("Parsed CSAF VEX")
 
-	var cpeList redhatoval.CPEList
-	if vs.skipRepoNVRMappings {
-		// OVAL runs alongside CSAF: merge to preserve OVAL CPE indices.
+	cpeList := vs.parser.CPEList()
+	if vs.runAlongsideOVAL {
+		// Merge with existing OVAL CPEs in DB and preserve OVAL indices.
 		var err error
-		cpeList, err = vs.mergeCPEList(tx, vs.parser.CPEList())
+		cpeList, err = vs.mergeCPEList(tx, cpeList)
 		if err != nil {
 			return eb.Wrapf(err, "failed to merge CPE list")
 		}
-	} else {
-		// use CSAF CPE list as-is; no OVAL in DB.
-		cpeList = vs.parser.CPEList()
 	}
 
 	log.Info("Inserting mappings...")
@@ -156,32 +152,29 @@ func (vs VulnSrc) update(tx *bolt.Tx, dir string) error {
 }
 
 // mergeCPEList merges the CSAF CPE list with existing OVAL CPEs in the database.
-// Existing OVAL CPE indices are preserved, and new CSAF-only CPEs are appended.
+// Existing OVAL CPE indices are preserved; new CPEs (e.g. RHEL 10-only, not in OVAL) are appended.
 func (vs VulnSrc) mergeCPEList(tx *bolt.Tx, csafCPEs redhatoval.CPEList) (redhatoval.CPEList, error) {
 	existingCPEs, err := vs.dbc.GetAllRedHatCPEs(tx)
 	if err != nil {
 		return nil, oops.Wrapf(err, "failed to get existing CPEs")
 	}
-
+	// No OVAL CPEs in DB (e.g. CPEs only affect RHEL 10): use CSAF list as-is.
 	if len(existingCPEs) == 0 {
+		log.Debug("No OVAL CPEs in DB when merging, using CSAF list as-is", log.Int("csaf_count", len(csafCPEs)))
 		return csafCPEs, nil
 	}
 
-	// Build a set of existing CPE strings and find max index
+	// Build a set of existing CPE strings (index-ordered slice from DB)
 	existingSet := make(map[string]bool, len(existingCPEs))
-	maxIndex := -1
-	for idx, cpe := range existingCPEs {
-		existingSet[cpe] = true
-		if idx > maxIndex {
-			maxIndex = idx
+	for _, cpe := range existingCPEs {
+		if cpe != "" {
+			existingSet[cpe] = true
 		}
 	}
 
 	// Start with existing CPEs in order
-	merged := make(redhatoval.CPEList, maxIndex+1)
-	for idx, cpe := range existingCPEs {
-		merged[idx] = cpe
-	}
+	merged := make(redhatoval.CPEList, len(existingCPEs))
+	copy(merged, existingCPEs)
 
 	// Append new CSAF CPEs that don't exist in OVAL
 	for _, cpe := range csafCPEs {
@@ -203,10 +196,8 @@ func (vs VulnSrc) putMappings(tx *bolt.Tx, cpeList redhatoval.CPEList) error {
 		return oops.Wrapf(err, "failed to put data source")
 	}
 
-	// Skip repo/NVR mappings if requested (e.g., when OVAL already stores them).
-	// This prevents CSAF from overwriting OVAL's correct mappings with indices
-	// computed from a different CPE directory.
-	if !vs.skipRepoNVRMappings {
+	// When running alongside OVAL, do not write repo/NVR mappings (OVAL already stores them).
+	if !vs.runAlongsideOVAL {
 		// Store the mapping between repository and CPE names
 		for repo, cpes := range vs.parser.RepoToCPE() {
 			if err := vs.dbc.PutRedHatRepositories(tx, repo, cpeList.Indices(cpes)); err != nil {
@@ -222,7 +213,7 @@ func (vs VulnSrc) putMappings(tx *bolt.Tx, cpeList redhatoval.CPEList) error {
 		}
 	}
 
-	// Store CPE indices (when skipRepoNVRMappings, cpeList is merged with OVAL; otherwise CSAF-only)
+	// Store CPE indices (when runAlongsideOVAL, cpeList is merged with OVAL; otherwise CSAF-only)
 	for i, cpe := range cpeList {
 		if err := vs.dbc.PutRedHatCPEs(tx, i, cpe); err != nil {
 			return oops.With("cpe", cpe).Wrapf(err, "CPE put error")

--- a/pkg/vulnsrc/redhat-csaf/csaf.go
+++ b/pkg/vulnsrc/redhat-csaf/csaf.go
@@ -35,9 +35,10 @@ var (
 // PutInput is the argument passed to the put function (default or custom).
 // Custom put implementations (e.g. WithCustomPut) can type-assert adv to *PutInput.
 type PutInput struct {
-	Bucket   Bucket
-	Advisory Advisory
-	CPEList  redhatoval.CPEList
+	Bucket      Bucket
+	Advisory    Advisory
+	CPEList     redhatoval.CPEList
+	ReleaseDate string // Advisory's initial release date (YYYY-MM-DD), used by CustomPut for PublishDate
 }
 
 type Option func(src *VulnSrc)
@@ -131,7 +132,12 @@ func (vs VulnSrc) update(tx *bolt.Tx, dir string) error {
 		advisory := Advisory{Entries: entries}
 
 		// Store the advisory in the DB (default or custom put)
-		input := &PutInput{Bucket: bkt, Advisory: advisory, CPEList: cpeList}
+		input := &PutInput{
+			Bucket:      bkt,
+			Advisory:    advisory,
+			CPEList:     cpeList,
+			ReleaseDate: vs.parser.ReleaseDate(bkt.VulnerabilityID),
+		}
 		if err := vs.put(vs.dbc, tx, input); err != nil {
 			return eb.Wrapf(err, "failed to put advisory")
 		}

--- a/pkg/vulnsrc/redhat-csaf/csaf.go
+++ b/pkg/vulnsrc/redhat-csaf/csaf.go
@@ -105,10 +105,17 @@ func (vs VulnSrc) update(tx *bolt.Tx, dir string) error {
 	}
 	log.Info("Parsed CSAF VEX")
 
-	// Merge CSAF CPEs with existing OVAL CPEs to preserve OVAL indices.
-	cpeList, err := vs.mergeCPEList(tx, vs.parser.CPEList())
-	if err != nil {
-		return eb.Wrapf(err, "failed to merge CPE list")
+	var cpeList redhatoval.CPEList
+	if vs.skipRepoNVRMappings {
+		// OVAL runs alongside CSAF: merge to preserve OVAL CPE indices.
+		var err error
+		cpeList, err = vs.mergeCPEList(tx, vs.parser.CPEList())
+		if err != nil {
+			return eb.Wrapf(err, "failed to merge CPE list")
+		}
+	} else {
+		// use CSAF CPE list as-is; no OVAL in DB.
+		cpeList = vs.parser.CPEList()
 	}
 
 	log.Info("Inserting mappings...")
@@ -215,7 +222,7 @@ func (vs VulnSrc) putMappings(tx *bolt.Tx, cpeList redhatoval.CPEList) error {
 		}
 	}
 
-	// Store CPE indices (the merged list preserves OVAL indices and appends new CSAF CPEs)
+	// Store CPE indices (when skipRepoNVRMappings, cpeList is merged with OVAL; otherwise CSAF-only)
 	for i, cpe := range cpeList {
 		if err := vs.dbc.PutRedHatCPEs(tx, i, cpe); err != nil {
 			return oops.With("cpe", cpe).Wrapf(err, "CPE put error")

--- a/pkg/vulnsrc/redhat-csaf/csaf.go
+++ b/pkg/vulnsrc/redhat-csaf/csaf.go
@@ -158,10 +158,10 @@ func (vs VulnSrc) mergeCPEList(tx *bolt.Tx, csafCPEs redhatoval.CPEList) (redhat
 	if err != nil {
 		return nil, oops.Wrapf(err, "failed to get existing CPEs")
 	}
-	// No OVAL CPEs in DB (e.g. CPEs only affect RHEL 10): use CSAF list as-is.
+	// runAlongsideOVAL is only used when OVAL has already run and written advisories/CPEs.
+	// Empty existingCPEs here is unexpected and indicates misconfiguration (e.g. wrong build order).
 	if len(existingCPEs) == 0 {
-		log.Debug("No OVAL CPEs in DB when merging, using CSAF list as-is", log.Int("csaf_count", len(csafCPEs)))
-		return csafCPEs, nil
+		return nil, oops.Errorf("no OVAL CPEs in DB; run redhat-oval before redhat-csaf when using WithRunAlongsideOVAL")
 	}
 
 	// Build a set of existing CPE strings (index-ordered slice from DB)

--- a/pkg/vulnsrc/redhat-csaf/csaf.go
+++ b/pkg/vulnsrc/redhat-csaf/csaf.go
@@ -50,11 +50,21 @@ func WithCustomPut(put db.CustomPut) Option {
 	}
 }
 
+// WithSkipRepoNVRMappings skips storing repository-to-CPE and NVR-to-CPE mappings.
+// Use this when OVAL already stores these mappings and CSAF should not overwrite them.
+// This is useful when CSAF runs alongside OVAL (e.g., for RHEL 10 support while OVAL handles RHEL 7-9).
+func WithSkipRepoNVRMappings() Option {
+	return func(src *VulnSrc) {
+		src.skipRepoNVRMappings = true
+	}
+}
+
 type VulnSrc struct {
-	put        db.CustomPut
-	dbc        db.Operation
-	parser     Parser
-	aggregator Aggregator
+	put                 db.CustomPut
+	skipRepoNVRMappings bool
+	dbc                 db.Operation
+	parser              Parser
+	aggregator          Aggregator
 }
 
 func NewVulnSrc(opts ...Option) VulnSrc {
@@ -94,7 +104,11 @@ func (vs VulnSrc) update(tx *bolt.Tx, dir string) error {
 	}
 	log.Info("Parsed CSAF VEX")
 
-	cpeList := vs.parser.CPEList()
+	// Merge CSAF CPEs with existing OVAL CPEs to preserve OVAL indices.
+	cpeList, err := vs.mergeCPEList(tx, vs.parser.CPEList())
+	if err != nil {
+		return eb.Wrapf(err, "failed to merge CPE list")
+	}
 
 	log.Info("Inserting mappings...")
 	if err := vs.putMappings(tx, cpeList); err != nil {
@@ -128,6 +142,46 @@ func (vs VulnSrc) update(tx *bolt.Tx, dir string) error {
 	return nil
 }
 
+// mergeCPEList merges the CSAF CPE list with existing OVAL CPEs in the database.
+// Existing OVAL CPE indices are preserved, and new CSAF-only CPEs are appended.
+func (vs VulnSrc) mergeCPEList(tx *bolt.Tx, csafCPEs redhatoval.CPEList) (redhatoval.CPEList, error) {
+	existingCPEs, err := vs.dbc.GetAllRedHatCPEs(tx)
+	if err != nil {
+		return nil, oops.Wrapf(err, "failed to get existing CPEs")
+	}
+
+	if len(existingCPEs) == 0 {
+		return csafCPEs, nil
+	}
+
+	// Build a set of existing CPE strings and find max index
+	existingSet := make(map[string]bool, len(existingCPEs))
+	maxIndex := -1
+	for idx, cpe := range existingCPEs {
+		existingSet[cpe] = true
+		if idx > maxIndex {
+			maxIndex = idx
+		}
+	}
+
+	// Start with existing CPEs in order
+	merged := make(redhatoval.CPEList, maxIndex+1)
+	for idx, cpe := range existingCPEs {
+		merged[idx] = cpe
+	}
+
+	// Append new CSAF CPEs that don't exist in OVAL
+	for _, cpe := range csafCPEs {
+		if !existingSet[cpe] {
+			merged = append(merged, cpe)
+			existingSet[cpe] = true
+		}
+	}
+
+	log.Info("Merged CPE list", "oval_count", len(existingCPEs), "csaf_count", len(csafCPEs), "merged_count", len(merged))
+	return merged, nil
+}
+
 // TODO: The CPEList type is the same as redhat-oval since both use the same DB structure.
 // When redhat-oval is removed in the future, move the CPEList type definition here.
 func (vs VulnSrc) putMappings(tx *bolt.Tx, cpeList redhatoval.CPEList) error {
@@ -136,21 +190,26 @@ func (vs VulnSrc) putMappings(tx *bolt.Tx, cpeList redhatoval.CPEList) error {
 		return oops.Wrapf(err, "failed to put data source")
 	}
 
-	// Store the mapping between repository and CPE names
-	for repo, cpes := range vs.parser.RepoToCPE() {
-		if err := vs.dbc.PutRedHatRepositories(tx, repo, cpeList.Indices(cpes)); err != nil {
-			return oops.With("repo", repo).With("cpes", cpes).Wrapf(err, "repository put error")
+	// Skip repo/NVR mappings if requested (e.g., when OVAL already stores them).
+	// This prevents CSAF from overwriting OVAL's correct mappings with indices
+	// computed from a different CPE directory.
+	if !vs.skipRepoNVRMappings {
+		// Store the mapping between repository and CPE names
+		for repo, cpes := range vs.parser.RepoToCPE() {
+			if err := vs.dbc.PutRedHatRepositories(tx, repo, cpeList.Indices(cpes)); err != nil {
+				return oops.With("repo", repo).With("cpes", cpes).Wrapf(err, "repository put error")
+			}
+		}
+
+		// Store the mapping between NVR and CPE names
+		for nvr, cpes := range vs.parser.NVRToCPE() {
+			if err := vs.dbc.PutRedHatNVRs(tx, nvr, cpeList.Indices(cpes)); err != nil {
+				return oops.With("nvr", nvr).With("cpes", cpes).Wrapf(err, "NVR put error")
+			}
 		}
 	}
 
-	// Store the mapping between NVR and CPE names
-	for nvr, cpes := range vs.parser.NVRToCPE() {
-		if err := vs.dbc.PutRedHatNVRs(tx, nvr, cpeList.Indices(cpes)); err != nil {
-			return oops.With("nvr", nvr).With("cpes", cpes).Wrapf(err, "NVR put error")
-		}
-	}
-
-	// Store CPE indices for debug information
+	// Store CPE indices (the merged list preserves OVAL indices and appends new CSAF CPEs)
 	for i, cpe := range cpeList {
 		if err := vs.dbc.PutRedHatCPEs(tx, i, cpe); err != nil {
 			return oops.With("cpe", cpe).Wrapf(err, "CPE put error")

--- a/pkg/vulnsrc/redhat-csaf/parse.go
+++ b/pkg/vulnsrc/redhat-csaf/parse.go
@@ -27,10 +27,11 @@ import (
 const dataPath = "redhat-csaf.data"
 
 type Parser struct {
-	repoToCPE  map[string][]string
-	nvrToCPE   map[string][]string
-	advisories map[Package]map[VulnerabilityID]RawEntries
-	cpeSet     set.Ordered[string]
+	repoToCPE    map[string][]string
+	nvrToCPE     map[string][]string
+	advisories   map[Package]map[VulnerabilityID]RawEntries
+	cpeSet       set.Ordered[string]
+	releaseDates map[VulnerabilityID]string // Advisory initial release date per vulnerability ID
 }
 
 func NewParser() Parser {
@@ -42,10 +43,11 @@ func NewParser() Parser {
 	gob.Register(csaf.CPE(""))
 
 	return Parser{
-		repoToCPE:  map[string][]string{},
-		nvrToCPE:   map[string][]string{},
-		advisories: map[Package]map[VulnerabilityID]RawEntries{},
-		cpeSet:     set.NewOrdered[string](),
+		repoToCPE:    map[string][]string{},
+		nvrToCPE:     map[string][]string{},
+		advisories:   map[Package]map[VulnerabilityID]RawEntries{},
+		cpeSet:       set.NewOrdered[string](),
+		releaseDates: map[VulnerabilityID]string{},
 	}
 }
 
@@ -303,6 +305,12 @@ func (p *Parser) parseVulnerability(adv CSAFAdvisory, vuln *csaf.Vulnerability) 
 			if status == types.StatusFixed {
 				vulnID = p.extractRHSAID(remediation)
 				alias = cveID
+				// Store the advisory release date for this RHSA ID
+				if _, exists := p.releaseDates[vulnID]; !exists {
+					if adv.Document != nil && adv.Document.Tracking != nil && adv.Document.Tracking.InitialReleaseDate != nil {
+						p.releaseDates[vulnID] = p.formatDate(*adv.Document.Tracking.InitialReleaseDate)
+					}
+				}
 			} else {
 				vulnID = cveID
 			}
@@ -430,6 +438,19 @@ func (p *Parser) RepoToCPE() iter.Seq2[string, []string] {
 
 func (p *Parser) NVRToCPE() iter.Seq2[string, []string] {
 	return maps.All(p.nvrToCPE)
+}
+
+// ReleaseDate returns the advisory release date for a given vulnerability ID.
+func (p *Parser) ReleaseDate(vulnID VulnerabilityID) string {
+	return p.releaseDates[vulnID]
+}
+
+// formatDate extracts the date portion (YYYY-MM-DD) from an RFC3339 timestamp.
+func (p *Parser) formatDate(timestamp string) string {
+	if len(timestamp) >= 10 {
+		return timestamp[:10]
+	}
+	return timestamp
 }
 
 // SerializeAdvisories saves the current advisories map to a file

--- a/pkg/vulnsrc/redhat-csaf/parse.go
+++ b/pkg/vulnsrc/redhat-csaf/parse.go
@@ -9,6 +9,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/gocsaf/csaf/v3/csaf"
 	"github.com/package-url/packageurl-go"
@@ -447,10 +448,11 @@ func (p *Parser) ReleaseDate(vulnID VulnerabilityID) string {
 
 // formatDate extracts the date portion (YYYY-MM-DD) from an RFC3339 timestamp.
 func (p *Parser) formatDate(timestamp string) string {
-	if len(timestamp) >= 10 {
-		return timestamp[:10]
+	t, err := time.Parse(time.RFC3339, timestamp)
+	if err != nil {
+		return ""
 	}
-	return timestamp
+	return t.Format(time.DateOnly)
 }
 
 // SerializeAdvisories saves the current advisories map to a file

--- a/pkg/vulnsrc/redhat-csaf/parse_test.go
+++ b/pkg/vulnsrc/redhat-csaf/parse_test.go
@@ -211,54 +211,66 @@ func TestParser_DetectStatus(t *testing.T) {
 		})
 	}
 }
-
 func TestMergeCPEList(t *testing.T) {
-	tempDir := t.TempDir()
-	err := db.Init(tempDir)
-	require.NoError(t, err)
-	defer db.Close()
-
-	dbc := db.Config{}
-	vs := NewVulnSrc(WithRunAlongsideOVAL())
-	vs.dbc = dbc
-
-	t.Run("empty existing CPEs returns error (OVAL must run first)", func(t *testing.T) {
-		csafCPEs := redhatoval.CPEList{"cpe:/o:redhat:el10", "cpe:/o:redhat:el10::appstream"}
-		err := dbc.BatchUpdate(func(tx *bolt.Tx) error {
-			_, err := vs.mergeCPEList(tx, csafCPEs)
-			return err
+	tests := []struct {
+		name         string
+		existingCPEs redhatoval.CPEList
+		csafCPEs     redhatoval.CPEList
+		want         redhatoval.CPEList
+		wantErr      string
+	}{
+		{
+			name:     "no existing OVAL CPEs returns error",
+			csafCPEs: redhatoval.CPEList{"cpe:/o:redhat:el10", "cpe:/o:redhat:el10::appstream"},
+			wantErr:  "no OVAL CPEs in DB",
+		},
+		{
+			name:         "appends new CSAF CPEs to OVAL CPEs",
+			existingCPEs: redhatoval.CPEList{"cpe:/o:redhat:el8::baseos", "cpe:/o:redhat:el9::baseos"},
+			csafCPEs:     redhatoval.CPEList{"cpe:/o:redhat:el10::baseos"},
+			want: redhatoval.CPEList{
+				"cpe:/o:redhat:el8::baseos", "cpe:/o:redhat:el9::baseos", "cpe:/o:redhat:el10::baseos",
+			},
+		},
+		{
+			name:         "deduplicates CPEs already present in OVAL",
+			existingCPEs: redhatoval.CPEList{"cpe:/o:redhat:el8::baseos", "cpe:/o:redhat:el9::baseos"},
+			csafCPEs:     redhatoval.CPEList{"cpe:/o:redhat:el9::baseos", "cpe:/o:redhat:el10::baseos"},
+			want: redhatoval.CPEList{
+				"cpe:/o:redhat:el8::baseos", "cpe:/o:redhat:el9::baseos", "cpe:/o:redhat:el10::baseos",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			require.NoError(t, db.Init(tempDir))
+			t.Cleanup(func() {
+				_ = db.Close()
+			})
+			dbc := db.Config{}
+			vs := NewVulnSrc(WithRunAlongsideOVAL())
+			vs.dbc = dbc
+			if len(tt.existingCPEs) > 0 {
+				require.NoError(t, dbc.BatchUpdate(func(tx *bolt.Tx) error {
+					for i, cpe := range tt.existingCPEs {
+						require.NoError(t, dbc.PutRedHatCPEs(tx, i, cpe))
+					}
+					return nil
+				}))
+			}
+			var got redhatoval.CPEList
+			err := dbc.BatchUpdate(func(tx *bolt.Tx) error {
+				var err error
+				got, err = vs.mergeCPEList(tx, tt.csafCPEs)
+				return err
+			})
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
 		})
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "no OVAL CPEs in DB")
-	})
-
-	t.Run("merges existing OVAL CPEs with new CSAF CPEs", func(t *testing.T) {
-		csafCPEs := redhatoval.CPEList{"cpe:/o:redhat:el10::baseos"}
-		var merged redhatoval.CPEList
-		err := dbc.BatchUpdate(func(tx *bolt.Tx) error {
-			require.NoError(t, dbc.PutRedHatCPEs(tx, 0, "cpe:/o:redhat:el8::baseos"))
-			require.NoError(t, dbc.PutRedHatCPEs(tx, 1, "cpe:/o:redhat:el9::baseos"))
-			var err error
-			merged, err = vs.mergeCPEList(tx, csafCPEs)
-			return err
-		})
-		require.NoError(t, err)
-		want := redhatoval.CPEList{"cpe:/o:redhat:el8::baseos", "cpe:/o:redhat:el9::baseos", "cpe:/o:redhat:el10::baseos"}
-		assert.Equal(t, want, merged)
-	})
-
-	t.Run("does not duplicate CPEs that exist in OVAL", func(t *testing.T) {
-		csafCPEs := redhatoval.CPEList{"cpe:/o:redhat:el9::baseos", "cpe:/o:redhat:el10::baseos"}
-		var merged redhatoval.CPEList
-		err := dbc.BatchUpdate(func(tx *bolt.Tx) error {
-			require.NoError(t, dbc.PutRedHatCPEs(tx, 0, "cpe:/o:redhat:el8::baseos"))
-			require.NoError(t, dbc.PutRedHatCPEs(tx, 1, "cpe:/o:redhat:el9::baseos"))
-			var err error
-			merged, err = vs.mergeCPEList(tx, csafCPEs)
-			return err
-		})
-		require.NoError(t, err)
-		want := redhatoval.CPEList{"cpe:/o:redhat:el8::baseos", "cpe:/o:redhat:el9::baseos", "cpe:/o:redhat:el10::baseos"}
-		assert.Equal(t, want, merged)
-	})
+	}
 }

--- a/pkg/vulnsrc/redhat-csaf/parse_test.go
+++ b/pkg/vulnsrc/redhat-csaf/parse_test.go
@@ -8,8 +8,11 @@ import (
 	"github.com/gocsaf/csaf/v3/csaf"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	bolt "go.etcd.io/bbolt"
 
+	"github.com/aquasecurity/trivy-db/pkg/db"
 	"github.com/aquasecurity/trivy-db/pkg/types"
+	redhatoval "github.com/aquasecurity/trivy-db/pkg/vulnsrc/redhat-oval"
 )
 
 func TestParser_Parse(t *testing.T) {
@@ -111,6 +114,47 @@ func TestParser_Parse(t *testing.T) {
 	}
 }
 
+func TestParser_FormatDate(t *testing.T) {
+	tests := []struct {
+		name      string
+		timestamp string
+		wantDate  string
+	}{
+		{
+			name:      "valid RFC3339 with Z",
+			timestamp: "2024-12-18T09:14:23Z",
+			wantDate:  "2024-12-18",
+		},
+		{
+			name:      "valid RFC3339 with timezone offset",
+			timestamp: "2025-01-01T00:00:00+00:00",
+			wantDate:  "2025-01-01",
+		},
+		{
+			name:      "invalid timestamp",
+			timestamp: "not-a-date",
+			wantDate:  "",
+		},
+		{
+			name:      "empty string",
+			timestamp: "",
+			wantDate:  "",
+		},
+		{
+			name:      "wrong format (date only)",
+			timestamp: "2024-12-18",
+			wantDate:  "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewParser()
+			got := p.formatDate(tt.timestamp)
+			assert.Equal(t, tt.wantDate, got)
+		})
+	}
+}
+
 func TestParser_DetectStatus(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -166,4 +210,57 @@ func TestParser_DetectStatus(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestMergeCPEList(t *testing.T) {
+	tempDir := t.TempDir()
+	err := db.Init(tempDir)
+	require.NoError(t, err)
+	defer db.Close()
+
+	dbc := db.Config{}
+	vs := NewVulnSrc(WithRunAlongsideOVAL())
+	vs.dbc = dbc
+
+	t.Run("empty existing CPEs returns CSAF list as-is", func(t *testing.T) {
+		csafCPEs := redhatoval.CPEList{"cpe:/o:redhat:el10", "cpe:/o:redhat:el10::appstream"}
+		var merged redhatoval.CPEList
+		err := dbc.BatchUpdate(func(tx *bolt.Tx) error {
+			var err error
+			merged, err = vs.mergeCPEList(tx, csafCPEs)
+			return err
+		})
+		require.NoError(t, err)
+		assert.Equal(t, csafCPEs, merged)
+	})
+
+	t.Run("merges existing OVAL CPEs with new CSAF CPEs", func(t *testing.T) {
+		csafCPEs := redhatoval.CPEList{"cpe:/o:redhat:el10::baseos"}
+		var merged redhatoval.CPEList
+		err := dbc.BatchUpdate(func(tx *bolt.Tx) error {
+			require.NoError(t, dbc.PutRedHatCPEs(tx, 0, "cpe:/o:redhat:el8::baseos"))
+			require.NoError(t, dbc.PutRedHatCPEs(tx, 1, "cpe:/o:redhat:el9::baseos"))
+			var err error
+			merged, err = vs.mergeCPEList(tx, csafCPEs)
+			return err
+		})
+		require.NoError(t, err)
+		want := redhatoval.CPEList{"cpe:/o:redhat:el8::baseos", "cpe:/o:redhat:el9::baseos", "cpe:/o:redhat:el10::baseos"}
+		assert.Equal(t, want, merged)
+	})
+
+	t.Run("does not duplicate CPEs that exist in OVAL", func(t *testing.T) {
+		csafCPEs := redhatoval.CPEList{"cpe:/o:redhat:el9::baseos", "cpe:/o:redhat:el10::baseos"}
+		var merged redhatoval.CPEList
+		err := dbc.BatchUpdate(func(tx *bolt.Tx) error {
+			require.NoError(t, dbc.PutRedHatCPEs(tx, 0, "cpe:/o:redhat:el8::baseos"))
+			require.NoError(t, dbc.PutRedHatCPEs(tx, 1, "cpe:/o:redhat:el9::baseos"))
+			var err error
+			merged, err = vs.mergeCPEList(tx, csafCPEs)
+			return err
+		})
+		require.NoError(t, err)
+		want := redhatoval.CPEList{"cpe:/o:redhat:el8::baseos", "cpe:/o:redhat:el9::baseos", "cpe:/o:redhat:el10::baseos"}
+		assert.Equal(t, want, merged)
+	})
 }

--- a/pkg/vulnsrc/redhat-csaf/parse_test.go
+++ b/pkg/vulnsrc/redhat-csaf/parse_test.go
@@ -222,16 +222,14 @@ func TestMergeCPEList(t *testing.T) {
 	vs := NewVulnSrc(WithRunAlongsideOVAL())
 	vs.dbc = dbc
 
-	t.Run("empty existing CPEs returns CSAF list as-is", func(t *testing.T) {
+	t.Run("empty existing CPEs returns error (OVAL must run first)", func(t *testing.T) {
 		csafCPEs := redhatoval.CPEList{"cpe:/o:redhat:el10", "cpe:/o:redhat:el10::appstream"}
-		var merged redhatoval.CPEList
 		err := dbc.BatchUpdate(func(tx *bolt.Tx) error {
-			var err error
-			merged, err = vs.mergeCPEList(tx, csafCPEs)
+			_, err := vs.mergeCPEList(tx, csafCPEs)
 			return err
 		})
-		require.NoError(t, err)
-		assert.Equal(t, csafCPEs, merged)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no OVAL CPEs in DB")
 	})
 
 	t.Run("merges existing OVAL CPEs with new CSAF CPEs", func(t *testing.T) {


### PR DESCRIPTION
-  added a param to skip adding mappings when csaf (rhel 10) runs alongside oval (rhel 6-9)
- merge CPE list with existing OVAL CPEs instead of overwriting. Prevents CSAF from corrupting OVALs CPE indices by reading existingCPEs and appending new CSAF-only CPEs at the end.
- parse and add rhsa release date from csaf to CustomPutInput
- get PublishDate from advisory
