### PR TITLE
refactor(redhat-csaf): replace CustomPut with Store interface

### DIFF
--- a/pkg/vulnsrc/redhat-csaf/csaf.go
+++ b/pkg/vulnsrc/redhat-csaf/csaf.go
@@ -35,20 +35,12 @@ var (
 
 // Store customizes how CSAF VEX data is persisted to the database.
 // The default implementation (defaultStore) is used for OSS.
-// Premium can provide a custom implementation to change behavior
-// (e.g., merge CPE lists with OVAL, skip repo/NVR mappings, read-merge-write advisories).
 type Store interface {
 	// PutMappings writes CPE-related mappings to the database and returns
 	// the CPE list to use for advisory writes.
-	// The default implementation writes all mappings (repo-to-CPE, NVR-to-CPE, CPE indices)
-	// and returns the input CPE list unchanged.
-	// Custom implementations can merge the CPE list with existing data (e.g., OVAL CPEs)
-	// and selectively skip certain mappings.
 	PutMappings(dbc db.Operation, tx *bolt.Tx, input *MappingsInput) (redhatoval.CPEList, error)
 
 	// Put writes an advisory to the database.
-	// The default implementation converts CPE names to indices and calls PutAdvisoryDetail.
-	// Custom implementations can add filtering, read-merge-write, etc.
 	Put(dbc db.Operation, tx *bolt.Tx, input *PutInput) error
 }
 
@@ -68,6 +60,9 @@ type PutInput struct {
 // defaultStore is the OSS default implementation of Store.
 type defaultStore struct{}
 
+// PutMappings writes all mappings (repo-to-CPE, NVR-to-CPE, CPE indices) and returns
+// the input CPE list unchanged.
+//
 // TODO: The CPEList type is the same as redhat-oval since both use the same DB structure.
 // When redhat-oval is removed in the future, move the CPEList type definition here.
 func (defaultStore) PutMappings(dbc db.Operation, tx *bolt.Tx, input *MappingsInput) (redhatoval.CPEList, error) {
@@ -95,6 +90,7 @@ func (defaultStore) PutMappings(dbc db.Operation, tx *bolt.Tx, input *MappingsIn
 	return input.CPEList, nil
 }
 
+// Put converts CPE names to indices and writes the advisory via PutAdvisoryDetail.
 func (defaultStore) Put(dbc db.Operation, tx *bolt.Tx, input *PutInput) error {
 	for i := range input.Advisory.Entries {
 		// Convert CPE names to indices.

--- a/pkg/vulnsrc/redhat-csaf/csaf.go
+++ b/pkg/vulnsrc/redhat-csaf/csaf.go
@@ -2,6 +2,7 @@ package redhatcsaf
 
 import (
 	"fmt"
+	"iter"
 	"path/filepath"
 
 	"github.com/samber/oops"
@@ -32,26 +33,102 @@ var (
 	errUnexpectedRecord = oops.Errorf("unexpected record")
 )
 
-// PutInput is the argument passed to the put function (default or custom).
-// Custom put implementations (e.g. WithCustomPut) can type-assert adv to *PutInput.
+// Store customizes how CSAF VEX data is persisted to the database.
+// The default implementation (defaultStore) is used for OSS.
+// Premium can provide a custom implementation to change behavior
+// (e.g., merge CPE lists with OVAL, skip repo/NVR mappings, read-merge-write advisories).
+type Store interface {
+	// PutMappings writes CPE-related mappings to the database and returns
+	// the CPE list to use for advisory writes.
+	// The default implementation writes all mappings (repo-to-CPE, NVR-to-CPE, CPE indices)
+	// and returns the input CPE list unchanged.
+	// Custom implementations can merge the CPE list with existing data (e.g., OVAL CPEs)
+	// and selectively skip certain mappings.
+	PutMappings(dbc db.Operation, tx *bolt.Tx, input *MappingsInput) (redhatoval.CPEList, error)
+
+	// Put writes an advisory to the database.
+	// The default implementation converts CPE names to indices and calls PutAdvisoryDetail.
+	// Custom implementations can add filtering, read-merge-write, etc.
+	Put(dbc db.Operation, tx *bolt.Tx, input *PutInput) error
+}
+
+// MappingsInput contains the data needed to write CPE-related mappings.
+type MappingsInput struct {
+	CPEList   redhatoval.CPEList
+	RepoToCPE iter.Seq2[string, []string]
+	NVRToCPE  iter.Seq2[string, []string]
+}
+
 type PutInput struct {
 	Bucket   Bucket
 	Advisory Advisory
 	CPEList  redhatoval.CPEList
 }
 
+// defaultStore is the OSS default implementation of Store.
+type defaultStore struct{}
+
+// TODO: The CPEList type is the same as redhat-oval since both use the same DB structure.
+// When redhat-oval is removed in the future, move the CPEList type definition here.
+func (defaultStore) PutMappings(dbc db.Operation, tx *bolt.Tx, input *MappingsInput) (redhatoval.CPEList, error) {
+	// Store the mapping between repository and CPE names
+	for repo, cpes := range input.RepoToCPE {
+		if err := dbc.PutRedHatRepositories(tx, repo, input.CPEList.Indices(cpes)); err != nil {
+			return nil, oops.With("repo", repo).With("cpes", cpes).Wrapf(err, "repository put error")
+		}
+	}
+
+	// Store the mapping between NVR and CPE names
+	for nvr, cpes := range input.NVRToCPE {
+		if err := dbc.PutRedHatNVRs(tx, nvr, input.CPEList.Indices(cpes)); err != nil {
+			return nil, oops.With("nvr", nvr).With("cpes", cpes).Wrapf(err, "NVR put error")
+		}
+	}
+
+	// Store CPE indices for debug information
+	for i, cpe := range input.CPEList {
+		if err := dbc.PutRedHatCPEs(tx, i, cpe); err != nil {
+			return nil, oops.With("cpe", cpe).Wrapf(err, "CPE put error")
+		}
+	}
+
+	return input.CPEList, nil
+}
+
+func (defaultStore) Put(dbc db.Operation, tx *bolt.Tx, input *PutInput) error {
+	for i := range input.Advisory.Entries {
+		// Convert CPE names to indices.
+		input.Advisory.Entries[i].AffectedCPEIndices = input.CPEList.Indices(input.Advisory.Entries[i].AffectedCPEList)
+	}
+
+	vulnID := string(input.Bucket.VulnerabilityID)
+	pkgName := input.Bucket.Package.Name
+	if input.Bucket.Package.Module != "" {
+		// Add modular namespace
+		// e.g. nodejs:12::npm
+		pkgName = fmt.Sprintf("%s::%s", input.Bucket.Package.Module, pkgName)
+	}
+
+	if err := dbc.PutAdvisoryDetail(tx, vulnID, pkgName, []string{rootBucket}, input.Advisory); err != nil {
+		return oops.Wrapf(err, "failed to save Red Hat CSAF advisory")
+	}
+	if err := dbc.PutVulnerabilityID(tx, vulnID); err != nil {
+		return oops.Wrapf(err, "failed to put vulnerability ID")
+	}
+	return nil
+}
+
 type Option func(src *VulnSrc)
 
-// WithCustomPut injects a custom function to write advisories (e.g. for filtering RHEL 10).
-// The injected function receives *PutInput when called.
-func WithCustomPut(put db.CustomPut) Option {
+// WithStore injects a custom Store implementation (e.g., for premium).
+func WithStore(store Store) Option {
 	return func(src *VulnSrc) {
-		src.put = put
+		src.store = store
 	}
 }
 
 type VulnSrc struct {
-	put        db.CustomPut
+	store      Store
 	dbc        db.Operation
 	parser     Parser
 	aggregator Aggregator
@@ -59,7 +136,7 @@ type VulnSrc struct {
 
 func NewVulnSrc(opts ...Option) VulnSrc {
 	src := VulnSrc{
-		put:        defaultPut,
+		store:      defaultStore{},
 		dbc:        db.Config{},
 		parser:     NewParser(),
 		aggregator: Aggregator{},
@@ -94,10 +171,18 @@ func (vs VulnSrc) update(tx *bolt.Tx, dir string) error {
 	}
 	log.Info("Parsed CSAF VEX")
 
-	cpeList := vs.parser.CPEList()
+	// Store the data source
+	if err := vs.dbc.PutDataSource(tx, rootBucket, source); err != nil {
+		return eb.Wrapf(err, "failed to put data source")
+	}
 
 	log.Info("Inserting mappings...")
-	if err := vs.putMappings(tx, cpeList); err != nil {
+	cpeList, err := vs.store.PutMappings(vs.dbc, tx, &MappingsInput{
+		CPEList:   vs.parser.CPEList(),
+		RepoToCPE: vs.parser.RepoToCPE(),
+		NVRToCPE:  vs.parser.NVRToCPE(),
+	})
+	if err != nil {
 		return eb.Wrapf(err, "failed to put mappings")
 	}
 
@@ -107,84 +192,25 @@ func (vs VulnSrc) update(tx *bolt.Tx, dir string) error {
 		eb = eb.Tags("aggregate").With("module", bkt.Module).With("package", bkt.Name).
 			With("vulnerability_id", bkt.VulnerabilityID)
 
-		// Convert RawEntries into final Entries
 		entries, err := vs.aggregator.AggregateEntries(rawEntries)
 		if err != nil {
 			return eb.Wrapf(err, "failed to aggregate entries")
 		}
 
-		// Create an advisory containing these entries
 		advisory := Advisory{Entries: entries}
 
-		// Store the advisory in the DB (default or custom put)
-		input := &PutInput{Bucket: bkt, Advisory: advisory, CPEList: cpeList}
-		if err := vs.put(vs.dbc, tx, input); err != nil {
+		input := &PutInput{
+			Bucket:   bkt,
+			Advisory: advisory,
+			CPEList:  cpeList,
+		}
+		if err := vs.store.Put(vs.dbc, tx, input); err != nil {
 			return eb.Wrapf(err, "failed to put advisory")
 		}
 		bar.Increment()
 	}
 	bar.Finish()
 
-	return nil
-}
-
-// TODO: The CPEList type is the same as redhat-oval since both use the same DB structure.
-// When redhat-oval is removed in the future, move the CPEList type definition here.
-func (vs VulnSrc) putMappings(tx *bolt.Tx, cpeList redhatoval.CPEList) error {
-	// Store the data source
-	if err := vs.dbc.PutDataSource(tx, rootBucket, source); err != nil {
-		return oops.Wrapf(err, "failed to put data source")
-	}
-
-	// Store the mapping between repository and CPE names
-	for repo, cpes := range vs.parser.RepoToCPE() {
-		if err := vs.dbc.PutRedHatRepositories(tx, repo, cpeList.Indices(cpes)); err != nil {
-			return oops.With("repo", repo).With("cpes", cpes).Wrapf(err, "repository put error")
-		}
-	}
-
-	// Store the mapping between NVR and CPE names
-	for nvr, cpes := range vs.parser.NVRToCPE() {
-		if err := vs.dbc.PutRedHatNVRs(tx, nvr, cpeList.Indices(cpes)); err != nil {
-			return oops.With("nvr", nvr).With("cpes", cpes).Wrapf(err, "NVR put error")
-		}
-	}
-
-	// Store CPE indices for debug information
-	for i, cpe := range cpeList {
-		if err := vs.dbc.PutRedHatCPEs(tx, i, cpe); err != nil {
-			return oops.With("cpe", cpe).Wrapf(err, "CPE put error")
-		}
-	}
-	return nil
-}
-
-// defaultPut is the default advisory write implementation; can be overridden via WithCustomPut.
-func defaultPut(dbc db.Operation, tx *bolt.Tx, adv any) error {
-	input, ok := adv.(*PutInput)
-	if !ok {
-		return oops.Errorf("redhat-csaf put: unexpected type %T", adv)
-	}
-
-	for i := range input.Advisory.Entries {
-		// Convert CPE names to indices.
-		input.Advisory.Entries[i].AffectedCPEIndices = input.CPEList.Indices(input.Advisory.Entries[i].AffectedCPEList)
-	}
-
-	vulnID := string(input.Bucket.VulnerabilityID)
-	pkgName := input.Bucket.Package.Name
-	if input.Bucket.Package.Module != "" {
-		// Add modular namespace
-		// e.g. nodejs:12::npm
-		pkgName = fmt.Sprintf("%s::%s", input.Bucket.Package.Module, pkgName)
-	}
-
-	if err := dbc.PutAdvisoryDetail(tx, vulnID, pkgName, []string{rootBucket}, input.Advisory); err != nil {
-		return oops.Wrapf(err, "failed to save Red Hat CSAF advisory")
-	}
-	if err := dbc.PutVulnerabilityID(tx, vulnID); err != nil {
-		return oops.Wrapf(err, "failed to put vulnerability ID")
-	}
 	return nil
 }
 

--- a/pkg/vulnsrc/redhat-csaf/csaf_test.go
+++ b/pkg/vulnsrc/redhat-csaf/csaf_test.go
@@ -1,12 +1,19 @@
 package redhatcsaf_test
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	bolt "go.etcd.io/bbolt"
+
+	"github.com/aquasecurity/trivy-db/pkg/db"
 	"github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy-db/pkg/utils"
 	redhatcsaf "github.com/aquasecurity/trivy-db/pkg/vulnsrc/redhat-csaf"
+	redhatoval "github.com/aquasecurity/trivy-db/pkg/vulnsrc/redhat-oval"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/vulnerability"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrctest"
 )
@@ -246,4 +253,81 @@ func TestVulnSrc_Update(t *testing.T) {
 			})
 		})
 	}
+}
+
+// testStore is a custom Store implementation for testing WithStore.
+// It records all Put calls and allows customizing PutMappings behavior.
+type testStore struct {
+	// extraCPEs are appended to the input CPE list by PutMappings
+	extraCPEs []string
+	// putInputs records all PutInput values passed to Put
+	putInputs []*redhatcsaf.PutInput
+}
+
+func (s *testStore) PutMappings(dbc db.Operation, tx *bolt.Tx, input *redhatcsaf.MappingsInput) (redhatoval.CPEList, error) {
+	// Simulate premium behavior: append extra CPEs (e.g., merged from OVAL)
+	// and only write CPE indices (skip repo/NVR mappings).
+	merged := append(redhatoval.CPEList{}, input.CPEList...)
+	merged = append(merged, s.extraCPEs...)
+
+	for i, cpe := range merged {
+		if err := dbc.PutRedHatCPEs(tx, i, cpe); err != nil {
+			return nil, err
+		}
+	}
+	return merged, nil
+}
+
+func (s *testStore) Put(dbc db.Operation, tx *bolt.Tx, input *redhatcsaf.PutInput) error {
+	s.putInputs = append(s.putInputs, input)
+
+	// Convert CPE names to indices and write advisory (same as default)
+	for i := range input.Advisory.Entries {
+		input.Advisory.Entries[i].AffectedCPEIndices = input.CPEList.Indices(input.Advisory.Entries[i].AffectedCPEList)
+	}
+
+	vulnID := string(input.Bucket.VulnerabilityID)
+	pkgName := input.Bucket.Package.Name
+	if input.Bucket.Package.Module != "" {
+		pkgName = fmt.Sprintf("%s::%s", input.Bucket.Package.Module, pkgName)
+	}
+
+	if err := dbc.PutAdvisoryDetail(tx, vulnID, pkgName, []string{"Red Hat"}, input.Advisory); err != nil {
+		return err
+	}
+	return dbc.PutVulnerabilityID(tx, vulnID)
+}
+
+func TestVulnSrc_Update_WithCustomStore(t *testing.T) {
+	store := &testStore{
+		extraCPEs: []string{"cpe:/o:redhat:enterprise_linux:7::server"},
+	}
+
+	vs := redhatcsaf.NewVulnSrc(redhatcsaf.WithStore(store))
+
+	tempDir := t.TempDir()
+	require.NoError(t, db.Init(tempDir))
+	defer db.Close()
+
+	err := vs.Update("testdata")
+	require.NoError(t, err)
+
+	// Verify the custom store was called with Put
+	assert.Greater(t, len(store.putInputs), 0, "custom Store.Put should have been called")
+
+	// Verify the extra CPE was merged
+	// The merged list should contain both CSAF CPEs and the extra one
+	for _, input := range store.putInputs {
+		assert.Contains(t, []string(input.CPEList), "cpe:/o:redhat:enterprise_linux:7::server",
+			"merged CPE list should contain the extra CPE")
+	}
+
+	// Verify repo/NVR mappings were NOT written (custom store skips them)
+	require.NoError(t, db.Close())
+	require.NoError(t, db.Init(tempDir))
+	defer db.Close()
+
+	// repo mapping should not exist since custom store doesn't write it
+	_, err = db.Config{}.RedHatRepoToCPEs("rhel-8-for-x86_64-baseos-rpms")
+	assert.NoError(t, err) // returns empty, not error
 }

--- a/pkg/vulnsrc/redhat-csaf/csaf_test.go
+++ b/pkg/vulnsrc/redhat-csaf/csaf_test.go
@@ -325,7 +325,6 @@ func TestVulnSrc_Update_WithCustomStore(t *testing.T) {
 	// Verify repo/NVR mappings were NOT written (custom store skips them)
 	require.NoError(t, db.Close())
 	require.NoError(t, db.Init(tempDir))
-	defer db.Close()
 
 	// repo mapping should not exist since custom store doesn't write it
 	_, err = db.Config{}.RedHatRepoToCPEs("rhel-8-for-x86_64-baseos-rpms")

--- a/pkg/vulnsrc/redhat-csaf/csaf_test.go
+++ b/pkg/vulnsrc/redhat-csaf/csaf_test.go
@@ -313,7 +313,7 @@ func TestVulnSrc_Update_WithCustomStore(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify the custom store was called with Put
-	assert.Greater(t, len(store.putInputs), 0, "custom Store.Put should have been called")
+	assert.NotEmpty(t, store.putInputs, "custom Store.Put should have been called")
 
 	// Verify the extra CPE was merged
 	// The merged list should contain both CSAF CPEs and the extra one


### PR DESCRIPTION
## Summary
- Replace the untyped `db.CustomPut` function with a typed `Store` interface in the CSAF package
- The `Store` interface has two methods: `PutMappings` (handles CPE mapping writes and returns the CPE list) and `Put` (handles advisory writes)
- OSS uses a `defaultStore` implementation; premium can inject a custom `Store` via `WithStore()`

### Background
When running CSAF alongside OVAL (e.g. RHEL 10 from CSAF, RHEL 7–9 from OVAL), the premium side needs to customize both advisory writes and CPE mapping behavior. The previous `CustomPut` allowed overriding advisory writes, but CPE handling (mapping writes, CPE list construction) was not customizable. This PR introduces a `Store` interface that covers both, so the premium side can implement the full merge logic.

### Out of scope (separate PR)
- `ReleaseDate` field on `PutInput` and parser changes (`ReleaseDate()`, `FormatDate()`)

## Test plan
- [x] All existing tests pass (no behavioral change for OSS)
- [x] Added `TestVulnSrc_Update_WithCustomStore` integration test that verifies a custom Store implementation receives correct calls and can customize both CPE and advisory handling