### PR TITLE
feat: parse and format csaf Publish Date with unit tests

### DIFF
--- a/pkg/vulnsrc/redhat-csaf/csaf.go
+++ b/pkg/vulnsrc/redhat-csaf/csaf.go
@@ -52,9 +52,10 @@ type MappingsInput struct {
 }
 
 type PutInput struct {
-	Bucket   Bucket
-	Advisory Advisory
-	CPEList  redhatoval.CPEList
+	Bucket      Bucket
+	Advisory    Advisory
+	CPEList     redhatoval.CPEList
+	ReleaseDate string // Advisory initial release date (YYYY-MM-DD), used by CustomPut for PublishDate
 }
 
 // defaultStore is the OSS default implementation of Store.
@@ -196,9 +197,10 @@ func (vs VulnSrc) update(tx *bolt.Tx, dir string) error {
 		advisory := Advisory{Entries: entries}
 
 		input := &PutInput{
-			Bucket:   bkt,
-			Advisory: advisory,
-			CPEList:  cpeList,
+			Bucket:      bkt,
+			Advisory:    advisory,
+			CPEList:     cpeList,
+			ReleaseDate: vs.parser.ReleaseDate(bkt.VulnerabilityID),
 		}
 		if err := vs.store.Put(vs.dbc, tx, input); err != nil {
 			return eb.Wrapf(err, "failed to put advisory")

--- a/pkg/vulnsrc/redhat-csaf/csaf.go
+++ b/pkg/vulnsrc/redhat-csaf/csaf.go
@@ -53,9 +53,9 @@ type MappingsInput struct {
 }
 
 type PutInput struct {
-	Bucket      Bucket
-	Advisory    Advisory
-	CPEList     redhatoval.CPEList
+	Bucket   Bucket
+	Advisory Advisory
+	CPEList  redhatoval.CPEList
 	// ReleaseDate is the RHSA vendor_fix remediation instant from CSAF (RFC3339). Zero means
 	// unknown or not applicable (e.g. CVE-only rows). Custom Store implementations may use
 	// it for PublishDate (calendar day: t.UTC().Format(time.DateOnly)).

--- a/pkg/vulnsrc/redhat-csaf/csaf.go
+++ b/pkg/vulnsrc/redhat-csaf/csaf.go
@@ -56,9 +56,9 @@ type PutInput struct {
 	Bucket   Bucket
 	Advisory Advisory
 	CPEList  redhatoval.CPEList
-	// ReleaseDate is the RHSA vendor_fix remediation instant from CSAF (RFC3339). Zero means
-	// unknown or not applicable (e.g. CVE-only rows). Custom Store implementations may use
-	// it for PublishDate (calendar day: t.UTC().Format(time.DateOnly)).
+	// ReleaseDate is the vendor_fix remediation timestamp from CSAF. Zero when there is
+	// no RHSA (CVE-only rows) or when the feed omits Remediation.Date. Intended for
+	// Store implementations that want to expose an advisory publish date.
 	ReleaseDate time.Time
 }
 

--- a/pkg/vulnsrc/redhat-csaf/csaf.go
+++ b/pkg/vulnsrc/redhat-csaf/csaf.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"iter"
 	"path/filepath"
+	"time"
 
 	"github.com/samber/oops"
 	bolt "go.etcd.io/bbolt"
@@ -55,7 +56,10 @@ type PutInput struct {
 	Bucket      Bucket
 	Advisory    Advisory
 	CPEList     redhatoval.CPEList
-	ReleaseDate string // Advisory initial release date (YYYY-MM-DD), used by CustomPut for PublishDate
+	// ReleaseDate is the RHSA vendor_fix remediation instant from CSAF (RFC3339). Zero means
+	// unknown or not applicable (e.g. CVE-only rows). Custom Store implementations may use
+	// it for PublishDate (calendar day: t.UTC().Format(time.DateOnly)).
+	ReleaseDate time.Time
 }
 
 // defaultStore is the OSS default implementation of Store.

--- a/pkg/vulnsrc/redhat-csaf/csaf_test.go
+++ b/pkg/vulnsrc/redhat-csaf/csaf_test.go
@@ -320,6 +320,19 @@ func TestVulnSrc_Update_WithCustomStore(t *testing.T) {
 	for _, input := range store.putInputs {
 		assert.Contains(t, []string(input.CPEList), "cpe:/o:redhat:enterprise_linux:7::server",
 			"merged CPE list should contain the extra CPE")
+
+		vid := string(input.Bucket.VulnerabilityID)
+		switch vid {
+		case "RHSA-2024:9941", "RHSA-2024:9999":
+			assert.Equal(t, "2024-11-19", input.ReleaseDate,
+				"RHSA release date from remediation (YYYY-MM-DD)")
+		case "RHSA-2025:0001":
+			assert.Equal(t, "2025-01-01", input.ReleaseDate,
+				"RHSA release date from remediation (YYYY-MM-DD)")
+		default:
+			// Unpatched rows use the CVE as bucket ID; there is no RHSA remediation date.
+			assert.Empty(t, input.ReleaseDate, "ReleaseDate for %q", vid)
+		}
 	}
 
 	// Verify repo/NVR mappings were NOT written (custom store skips them)

--- a/pkg/vulnsrc/redhat-csaf/csaf_test.go
+++ b/pkg/vulnsrc/redhat-csaf/csaf_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -324,14 +325,16 @@ func TestVulnSrc_Update_WithCustomStore(t *testing.T) {
 		vid := string(input.Bucket.VulnerabilityID)
 		switch vid {
 		case "RHSA-2024:9941", "RHSA-2024:9999":
-			assert.Equal(t, "2024-11-19", input.ReleaseDate,
-				"RHSA release date from remediation (YYYY-MM-DD)")
+			want, err := time.Parse(time.RFC3339, "2024-11-19T04:46:55Z")
+			require.NoError(t, err)
+			assert.True(t, input.ReleaseDate.Equal(want), "ReleaseDate for %s", vid)
 		case "RHSA-2025:0001":
-			assert.Equal(t, "2025-01-01", input.ReleaseDate,
-				"RHSA release date from remediation (YYYY-MM-DD)")
+			want, err := time.Parse(time.RFC3339, "2025-01-01T00:00:00Z")
+			require.NoError(t, err)
+			assert.True(t, input.ReleaseDate.Equal(want), "ReleaseDate for %s", vid)
 		default:
 			// Unpatched rows use the CVE as bucket ID; there is no RHSA remediation date.
-			assert.Empty(t, input.ReleaseDate, "ReleaseDate for %q", vid)
+			assert.True(t, input.ReleaseDate.IsZero(), "ReleaseDate for %q", vid)
 		}
 	}
 

--- a/pkg/vulnsrc/redhat-csaf/parse.go
+++ b/pkg/vulnsrc/redhat-csaf/parse.go
@@ -32,7 +32,9 @@ type Parser struct {
 	nvrToCPE     map[string][]string
 	advisories   map[Package]map[VulnerabilityID]RawEntries
 	cpeSet       set.Ordered[string]
-	releaseDates map[VulnerabilityID]string // Advisory initial release date (YYYY-MM-DD) per vulnerability ID
+	// releaseDates: advisory release date (YYYY-MM-DD) per RHSA ID. Only set for fixed
+	// advisories; unpatched (CVE-only) entries do not need it for PutInput.ReleaseDate.
+	releaseDates map[VulnerabilityID]string
 }
 
 func NewParser() Parser {
@@ -306,10 +308,11 @@ func (p *Parser) parseVulnerability(adv CSAFAdvisory, vuln *csaf.Vulnerability) 
 			if status == types.StatusFixed {
 				vulnID = p.extractRHSAID(remediation)
 				alias = cveID
-				// Store the advisory release date for this RHSA ID (once per vulnID)
-				if _, exists := p.releaseDates[vulnID]; !exists &&
-					adv.Document != nil && adv.Document.Tracking != nil && adv.Document.Tracking.InitialReleaseDate != nil {
-					p.releaseDates[vulnID] = p.formatDate(*adv.Document.Tracking.InitialReleaseDate)
+				// Store the RHSA release date (once per vulnID) from Remediation.Date.
+				if _, exists := p.releaseDates[vulnID]; !exists {
+					if remediation != nil && remediation.Date != nil {
+						p.releaseDates[vulnID] = p.formatDate(*remediation.Date)
+					}
 				}
 			} else {
 				vulnID = cveID

--- a/pkg/vulnsrc/redhat-csaf/parse.go
+++ b/pkg/vulnsrc/redhat-csaf/parse.go
@@ -28,10 +28,10 @@ import (
 const dataPath = "redhat-csaf.data"
 
 type Parser struct {
-	repoToCPE    map[string][]string
-	nvrToCPE     map[string][]string
-	advisories   map[Package]map[VulnerabilityID]RawEntries
-	cpeSet       set.Ordered[string]
+	repoToCPE  map[string][]string
+	nvrToCPE   map[string][]string
+	advisories map[Package]map[VulnerabilityID]RawEntries
+	cpeSet     set.Ordered[string]
 	// releaseDates: advisory release date (YYYY-MM-DD) per RHSA ID. Only set for fixed
 	// advisories; unpatched (CVE-only) entries do not need it for PutInput.ReleaseDate.
 	releaseDates map[VulnerabilityID]string

--- a/pkg/vulnsrc/redhat-csaf/parse.go
+++ b/pkg/vulnsrc/redhat-csaf/parse.go
@@ -9,6 +9,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/gocsaf/csaf/v3/csaf"
 	"github.com/package-url/packageurl-go"
@@ -27,10 +28,11 @@ import (
 const dataPath = "redhat-csaf.data"
 
 type Parser struct {
-	repoToCPE  map[string][]string
-	nvrToCPE   map[string][]string
-	advisories map[Package]map[VulnerabilityID]RawEntries
-	cpeSet     set.Ordered[string]
+	repoToCPE    map[string][]string
+	nvrToCPE     map[string][]string
+	advisories   map[Package]map[VulnerabilityID]RawEntries
+	cpeSet       set.Ordered[string]
+	releaseDates map[VulnerabilityID]string // Advisory initial release date (YYYY-MM-DD) per vulnerability ID
 }
 
 func NewParser() Parser {
@@ -42,10 +44,11 @@ func NewParser() Parser {
 	gob.Register(csaf.CPE(""))
 
 	return Parser{
-		repoToCPE:  map[string][]string{},
-		nvrToCPE:   map[string][]string{},
-		advisories: map[Package]map[VulnerabilityID]RawEntries{},
-		cpeSet:     set.NewOrdered[string](),
+		repoToCPE:    map[string][]string{},
+		nvrToCPE:     map[string][]string{},
+		advisories:   map[Package]map[VulnerabilityID]RawEntries{},
+		cpeSet:       set.NewOrdered[string](),
+		releaseDates: map[VulnerabilityID]string{},
 	}
 }
 
@@ -303,6 +306,11 @@ func (p *Parser) parseVulnerability(adv CSAFAdvisory, vuln *csaf.Vulnerability) 
 			if status == types.StatusFixed {
 				vulnID = p.extractRHSAID(remediation)
 				alias = cveID
+				// Store the advisory release date for this RHSA ID (once per vulnID)
+				if _, exists := p.releaseDates[vulnID]; !exists &&
+					adv.Document != nil && adv.Document.Tracking != nil && adv.Document.Tracking.InitialReleaseDate != nil {
+					p.releaseDates[vulnID] = p.formatDate(*adv.Document.Tracking.InitialReleaseDate)
+				}
 			} else {
 				vulnID = cveID
 			}
@@ -430,6 +438,20 @@ func (p *Parser) RepoToCPE() iter.Seq2[string, []string] {
 
 func (p *Parser) NVRToCPE() iter.Seq2[string, []string] {
 	return maps.All(p.nvrToCPE)
+}
+
+// ReleaseDate returns the advisory release date (YYYY-MM-DD) for a given vulnerability ID.
+func (p *Parser) ReleaseDate(vulnID VulnerabilityID) string {
+	return p.releaseDates[vulnID]
+}
+
+// formatDate extracts the date portion (YYYY-MM-DD) from an RFC3339 timestamp.
+func (p *Parser) formatDate(timestamp string) string {
+	t, err := time.Parse(time.RFC3339, timestamp)
+	if err != nil {
+		return ""
+	}
+	return t.Format(time.DateOnly)
 }
 
 // SerializeAdvisories saves the current advisories map to a file

--- a/pkg/vulnsrc/redhat-csaf/parse.go
+++ b/pkg/vulnsrc/redhat-csaf/parse.go
@@ -310,8 +310,12 @@ func (p *Parser) parseVulnerability(adv CSAFAdvisory, vuln *csaf.Vulnerability) 
 				alias = cveID
 				// Store the RHSA release date (once per vulnID) from Remediation.Date.
 				if _, exists := p.releaseDates[vulnID]; !exists {
-					if remediation != nil && remediation.Date != nil {
-						p.releaseDates[vulnID] = p.formatDate(*remediation.Date)
+					if remediation.Date != nil {
+						formatted, err := formatDate(*remediation.Date)
+						if err != nil {
+							return oops.With("cve_id", cveID).With("vulnerability_id", vulnID).Wrapf(err, "remediation date")
+						}
+						p.releaseDates[vulnID] = formatted
 					}
 				}
 			} else {
@@ -449,12 +453,12 @@ func (p *Parser) ReleaseDate(vulnID VulnerabilityID) string {
 }
 
 // formatDate extracts the date portion (YYYY-MM-DD) from an RFC3339 timestamp.
-func (p *Parser) formatDate(timestamp string) string {
+func formatDate(timestamp string) (string, error) {
 	t, err := time.Parse(time.RFC3339, timestamp)
 	if err != nil {
-		return ""
+		return "", oops.With("raw", timestamp).Wrapf(err, "parse RFC3339")
 	}
-	return t.Format(time.DateOnly)
+	return t.Format(time.DateOnly), nil
 }
 
 // SerializeAdvisories saves the current advisories map to a file

--- a/pkg/vulnsrc/redhat-csaf/parse.go
+++ b/pkg/vulnsrc/redhat-csaf/parse.go
@@ -32,9 +32,9 @@ type Parser struct {
 	nvrToCPE   map[string][]string
 	advisories map[Package]map[VulnerabilityID]RawEntries
 	cpeSet     set.Ordered[string]
-	// releaseDates: advisory release date (YYYY-MM-DD) per RHSA ID. Only set for fixed
-	// advisories; unpatched (CVE-only) entries do not need it for PutInput.ReleaseDate.
-	releaseDates map[VulnerabilityID]string
+	// releaseDates: RHSA vendor_fix remediation time per advisory ID. Only set for fixed
+	// advisories; unpatched (CVE-only) entries leave PutInput.ReleaseDate as zero.
+	releaseDates map[VulnerabilityID]time.Time
 }
 
 func NewParser() Parser {
@@ -50,7 +50,7 @@ func NewParser() Parser {
 		nvrToCPE:     map[string][]string{},
 		advisories:   map[Package]map[VulnerabilityID]RawEntries{},
 		cpeSet:       set.NewOrdered[string](),
-		releaseDates: map[VulnerabilityID]string{},
+		releaseDates: map[VulnerabilityID]time.Time{},
 	}
 }
 
@@ -311,11 +311,16 @@ func (p *Parser) parseVulnerability(adv CSAFAdvisory, vuln *csaf.Vulnerability) 
 				// Store the RHSA release date (once per vulnID) from Remediation.Date.
 				if _, exists := p.releaseDates[vulnID]; !exists {
 					if remediation.Date != nil {
-						formatted, err := formatDate(*remediation.Date)
+						t, err := parseRemediationDateTime(*remediation.Date)
 						if err != nil {
-							return oops.With("cve_id", cveID).With("vulnerability_id", vulnID).Wrapf(err, "remediation date")
+							log.Warn("Skipping invalid RHSA remediation date",
+								log.String("cve_id", string(cveID)),
+								log.String("vulnerability_id", string(vulnID)),
+								log.String("raw", *remediation.Date),
+								log.Err(err))
+						} else {
+							p.releaseDates[vulnID] = t
 						}
-						p.releaseDates[vulnID] = formatted
 					}
 				}
 			} else {
@@ -447,18 +452,15 @@ func (p *Parser) NVRToCPE() iter.Seq2[string, []string] {
 	return maps.All(p.nvrToCPE)
 }
 
-// ReleaseDate returns the advisory release date (YYYY-MM-DD) for a given vulnerability ID.
-func (p *Parser) ReleaseDate(vulnID VulnerabilityID) string {
+// ReleaseDate returns the RHSA vendor_fix remediation instant for a vulnerability ID, or
+// the zero value if unknown or not applicable.
+func (p *Parser) ReleaseDate(vulnID VulnerabilityID) time.Time {
 	return p.releaseDates[vulnID]
 }
 
-// formatDate extracts the date portion (YYYY-MM-DD) from an RFC3339 timestamp.
-func formatDate(timestamp string) (string, error) {
-	t, err := time.Parse(time.RFC3339, timestamp)
-	if err != nil {
-		return "", oops.With("raw", timestamp).Wrapf(err, "parse RFC3339")
-	}
-	return t.Format(time.DateOnly), nil
+// parseRemediationDateTime parses CSAF remediation date strings (expected RFC3339).
+func parseRemediationDateTime(s string) (time.Time, error) {
+	return time.Parse(time.RFC3339, s)
 }
 
 // SerializeAdvisories saves the current advisories map to a file

--- a/pkg/vulnsrc/redhat-csaf/parse.go
+++ b/pkg/vulnsrc/redhat-csaf/parse.go
@@ -32,8 +32,8 @@ type Parser struct {
 	nvrToCPE   map[string][]string
 	advisories map[Package]map[VulnerabilityID]RawEntries
 	cpeSet     set.Ordered[string]
-	// releaseDates: RHSA vendor_fix remediation time per advisory ID. Only set for fixed
-	// advisories; unpatched (CVE-only) entries leave PutInput.ReleaseDate as zero.
+	// releaseDates holds the vendor_fix remediation timestamp per RHSA ID.
+	// CVE-only (unpatched) entries are not stored here.
 	releaseDates map[VulnerabilityID]time.Time
 }
 
@@ -452,8 +452,8 @@ func (p *Parser) NVRToCPE() iter.Seq2[string, []string] {
 	return maps.All(p.nvrToCPE)
 }
 
-// ReleaseDate returns the RHSA vendor_fix remediation instant for a vulnerability ID, or
-// the zero value if unknown or not applicable.
+// ReleaseDate returns the vendor_fix remediation timestamp for the given RHSA ID,
+// or the zero value when no timestamp was recorded for it.
 func (p *Parser) ReleaseDate(vulnID VulnerabilityID) time.Time {
 	return p.releaseDates[vulnID]
 }

--- a/pkg/vulnsrc/redhat-csaf/parse_test.go
+++ b/pkg/vulnsrc/redhat-csaf/parse_test.go
@@ -111,11 +111,12 @@ func TestParser_Parse(t *testing.T) {
 	}
 }
 
-func TestParser_FormatDate(t *testing.T) {
+func TestFormatDate(t *testing.T) {
 	tests := []struct {
 		name      string
 		timestamp string
 		wantDate  string
+		wantErr   bool
 	}{
 		{
 			name:      "valid RFC3339 with Z",
@@ -130,23 +131,27 @@ func TestParser_FormatDate(t *testing.T) {
 		{
 			name:      "invalid timestamp",
 			timestamp: "not-a-date",
-			wantDate:  "",
+			wantErr:   true,
 		},
 		{
 			name:      "empty string",
 			timestamp: "",
-			wantDate:  "",
+			wantErr:   true,
 		},
 		{
 			name:      "wrong format (date only)",
 			timestamp: "2024-12-18",
-			wantDate:  "",
+			wantErr:   true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := NewParser()
-			got := p.formatDate(tt.timestamp)
+			got, err := formatDate(tt.timestamp)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
 			assert.Equal(t, tt.wantDate, got)
 		})
 	}

--- a/pkg/vulnsrc/redhat-csaf/parse_test.go
+++ b/pkg/vulnsrc/redhat-csaf/parse_test.go
@@ -111,6 +111,47 @@ func TestParser_Parse(t *testing.T) {
 	}
 }
 
+func TestParser_FormatDate(t *testing.T) {
+	tests := []struct {
+		name      string
+		timestamp string
+		wantDate  string
+	}{
+		{
+			name:      "valid RFC3339 with Z",
+			timestamp: "2024-12-18T09:14:23Z",
+			wantDate:  "2024-12-18",
+		},
+		{
+			name:      "valid RFC3339 with timezone offset",
+			timestamp: "2025-01-01T00:00:00+00:00",
+			wantDate:  "2025-01-01",
+		},
+		{
+			name:      "invalid timestamp",
+			timestamp: "not-a-date",
+			wantDate:  "",
+		},
+		{
+			name:      "empty string",
+			timestamp: "",
+			wantDate:  "",
+		},
+		{
+			name:      "wrong format (date only)",
+			timestamp: "2024-12-18",
+			wantDate:  "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewParser()
+			got := p.formatDate(tt.timestamp)
+			assert.Equal(t, tt.wantDate, got)
+		})
+	}
+}
+
 func TestParser_DetectStatus(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/vulnsrc/redhat-csaf/parse_test.go
+++ b/pkg/vulnsrc/redhat-csaf/parse_test.go
@@ -114,10 +114,10 @@ func TestParser_Parse(t *testing.T) {
 
 func TestParseRemediationDateTime(t *testing.T) {
 	tests := []struct {
-		name      string
-		input     string
-		wantRFC   string // expected instant in UTC as RFC3339
-		wantErr   bool
+		name    string
+		input   string
+		wantRFC string // expected instant in UTC as RFC3339
+		wantErr bool
 	}{
 		{
 			name:    "valid RFC3339 with Z",

--- a/pkg/vulnsrc/redhat-csaf/parse_test.go
+++ b/pkg/vulnsrc/redhat-csaf/parse_test.go
@@ -116,18 +116,18 @@ func TestParseRemediationDateTime(t *testing.T) {
 	tests := []struct {
 		name    string
 		input   string
-		wantRFC string // expected instant in UTC as RFC3339
+		want    time.Time
 		wantErr bool
 	}{
 		{
-			name:    "valid RFC3339 with Z",
-			input:   "2024-12-18T09:14:23Z",
-			wantRFC: "2024-12-18T09:14:23Z",
+			name:  "valid RFC3339 with Z",
+			input: "2024-12-18T09:14:23Z",
+			want:  time.Date(2024, 12, 18, 9, 14, 23, 0, time.UTC),
 		},
 		{
-			name:    "valid RFC3339 with timezone offset",
-			input:   "2025-01-01T00:00:00+00:00",
-			wantRFC: "2025-01-01T00:00:00Z",
+			name:  "valid RFC3339 with timezone offset",
+			input: "2025-01-01T00:00:00+00:00",
+			want:  time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
 		},
 		{
 			name:    "invalid timestamp",
@@ -153,9 +153,7 @@ func TestParseRemediationDateTime(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-			want, err := time.Parse(time.RFC3339, tt.wantRFC)
-			require.NoError(t, err)
-			assert.True(t, got.Equal(want), "got %v want %v", got, want)
+			assert.True(t, got.Equal(tt.want), "got %v want %v", got, tt.want)
 		})
 	}
 }

--- a/pkg/vulnsrc/redhat-csaf/parse_test.go
+++ b/pkg/vulnsrc/redhat-csaf/parse_test.go
@@ -4,6 +4,7 @@ import (
 	"maps"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/gocsaf/csaf/v3/csaf"
 	"github.com/stretchr/testify/assert"
@@ -111,48 +112,50 @@ func TestParser_Parse(t *testing.T) {
 	}
 }
 
-func TestFormatDate(t *testing.T) {
+func TestParseRemediationDateTime(t *testing.T) {
 	tests := []struct {
 		name      string
-		timestamp string
-		wantDate  string
+		input     string
+		wantRFC   string // expected instant in UTC as RFC3339
 		wantErr   bool
 	}{
 		{
-			name:      "valid RFC3339 with Z",
-			timestamp: "2024-12-18T09:14:23Z",
-			wantDate:  "2024-12-18",
+			name:    "valid RFC3339 with Z",
+			input:   "2024-12-18T09:14:23Z",
+			wantRFC: "2024-12-18T09:14:23Z",
 		},
 		{
-			name:      "valid RFC3339 with timezone offset",
-			timestamp: "2025-01-01T00:00:00+00:00",
-			wantDate:  "2025-01-01",
+			name:    "valid RFC3339 with timezone offset",
+			input:   "2025-01-01T00:00:00+00:00",
+			wantRFC: "2025-01-01T00:00:00Z",
 		},
 		{
-			name:      "invalid timestamp",
-			timestamp: "not-a-date",
-			wantErr:   true,
+			name:    "invalid timestamp",
+			input:   "not-a-date",
+			wantErr: true,
 		},
 		{
-			name:      "empty string",
-			timestamp: "",
-			wantErr:   true,
+			name:    "empty string",
+			input:   "",
+			wantErr: true,
 		},
 		{
-			name:      "wrong format (date only)",
-			timestamp: "2024-12-18",
-			wantErr:   true,
+			name:    "wrong format (date only)",
+			input:   "2024-12-18",
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := formatDate(tt.timestamp)
+			got, err := parseRemediationDateTime(tt.input)
 			if tt.wantErr {
 				require.Error(t, err)
 				return
 			}
 			require.NoError(t, err)
-			assert.Equal(t, tt.wantDate, got)
+			want, err := time.Parse(time.RFC3339, tt.wantRFC)
+			require.NoError(t, err)
+			assert.True(t, got.Equal(want), "got %v want %v", got, want)
 		})
 	}
 }


### PR DESCRIPTION
parse and format csaf Publish Date with unit tests

Custom Store implementations (e.g. premium) can now use input.ReleaseDate in their Put implementation (e.g. for PublishDate). The default OSS store does not use it but receives it in PutInput.

addition to #648 