### PR TITLE
Fix err bucket not found

### DIFF
--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -284,7 +284,8 @@ func (dbc Config) forEach(bktNames []string) (map[string]Value, error) {
 
 func (dbc Config) deleteBucket(bucketName string) error {
 	return db.Update(func(tx *bolt.Tx) error {
-		if err := tx.DeleteBucket([]byte(bucketName)); err != nil {
+		err := tx.DeleteBucket([]byte(bucketName))
+		if err != nil && !errors.Is(err, bolt.ErrBucketNotFound) {
 			return oops.With("bucket_name", bucketName).Wrapf(err, "failed to delete bucket")
 		}
 		return nil

--- a/pkg/vulndb/db_test.go
+++ b/pkg/vulndb/db_test.go
@@ -179,7 +179,6 @@ func TestTrivyDB_Build(t *testing.T) {
 				"testdata/fixtures/happy/vulnid.yaml",
 				"testdata/fixtures/happy/vulnerability-detail.yaml",
 			},
-			wantErr: "failed to delete advisory detail bucket",
 		},
 	}
 


### PR DESCRIPTION
    fix(db): Ignore missing buckets during cleanup
    
    The cleanup deletes all buckets after a build completes.  When building
    with --only-update for a set of sources, some of the buckets in the
    overall set are never created because the sources that populate them are
    skipped.  Then cleanup fails with "bucket not found" even though the data
    update completed.
    
    Ignore bolt.ErrBucketNotFound.  This is safe to do since a bucket that
    doesn't exist doesn't have to be cleaned up.
    
    Signed-off-by: Prarit Bhargava <prarit@redhat.com>
