### PR TITLE
fix(db): handle missing vulnerability bucket in GetVulnerability

### DIFF
--- a/pkg/db/vulnerability.go
+++ b/pkg/db/vulnerability.go
@@ -24,9 +24,12 @@ func (dbc Config) GetVulnerability(cveID string) (vuln types.Vulnerability, err 
 	eb := oops.With("vuln_id", cveID)
 	err = db.View(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket([]byte(vulnerabilityBucket))
+		if bucket == nil {
+			return nil
+		}
 		value := bucket.Get([]byte(cveID))
 		if value == nil {
-			return eb.Errorf("no vulnerability details")
+			return nil
 		}
 		if err = json.Unmarshal(value, &vuln); err != nil {
 			return eb.Wrapf(err, "json unmarshal error")


### PR DESCRIPTION
GetVulnerability panics with a nil pointer dereference when the vulnerability bucket does not exist in the database. This occurs when building with --only-update for a subset of sources, since the vulnerability bucket is populated by sources like NVD that may have been skipped.

Return an empty Vulnerability instead of panicking when the bucket is missing, consistent with how other read operations should handle partial databases.

Signed-off-by: Prarit Bhargava <prarit@redhat.com>