### PR TITLE
ci: use large runner for cron workflow

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -11,7 +11,7 @@ env:
 jobs:
   build:
     name: Build DB
-    runs-on: ubuntu-24.04
+    runs-on: trivy-large-1
     steps:
       # vuln-list dirs + language repositories use more than 31GB of storage
       - name: Maximize build space


### PR DESCRIPTION
## Description
Switch the Build DB workflow runner from `ubuntu-24.04` to the self-hosted `trivy-large-1` runner.

The job requires more than 31GB of disk space (vuln-list dirs + language repositories), which exceeded the capacity of the standard GitHub-hosted runner. The `trivy-large-1` runner has enough disk space, so the `Maximize build space` step  is no longer needed and has been disabled. It is kept as a comment for easy re-enabling if the runner changes in the future.                                                                                                                                     
