### PR TITLE
feat(echo): add echo language package advisories

### DIFF
--- a/pkg/vulnsrc/echo-osv/bucket.go
+++ b/pkg/vulnsrc/echo-osv/bucket.go
@@ -1,0 +1,40 @@
+package echoosv
+
+import (
+	"fmt"
+
+	"github.com/aquasecurity/trivy-db/pkg/ecosystem"
+	"github.com/aquasecurity/trivy-db/pkg/types"
+	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/bucket"
+)
+
+// echoBucket wraps a standard language bucket and prepends "echo " to its name.
+// This ensures advisories are stored under "echo pip::Echo OSV" rather than
+// "pip::Echo OSV", matching the trivy scanner's "echo pip::" prefix query.
+type echoBucket struct {
+	base       bucket.Bucket
+	dataSource types.DataSource
+}
+
+func (e echoBucket) Name() string {
+	return fmt.Sprintf("echo %s", e.base.Name())
+}
+
+func (e echoBucket) Ecosystem() ecosystem.Type {
+	return e.base.Ecosystem()
+}
+
+func (e echoBucket) DataSource() types.DataSource {
+	return e.dataSource
+}
+
+func newPipBucket(dataSource types.DataSource) (bucket.Bucket, error) {
+	base, err := bucket.NewPyPI(dataSource)
+	if err != nil {
+		return nil, err
+	}
+	return echoBucket{
+		base:       base,
+		dataSource: dataSource,
+	}, nil
+}

--- a/pkg/vulnsrc/echo-osv/echo_osv.go
+++ b/pkg/vulnsrc/echo-osv/echo_osv.go
@@ -1,0 +1,64 @@
+package echoosv
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/samber/oops"
+
+	"github.com/aquasecurity/trivy-db/pkg/ecosystem"
+	"github.com/aquasecurity/trivy-db/pkg/types"
+	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/osv"
+	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/vulnerability"
+)
+
+var (
+	vulnsDir = filepath.Join("vuln-list", "echo-osv")
+
+	source = types.DataSource{
+		ID:   vulnerability.EchoOSV,
+		Name: "Echo OSV",
+		URL:  "https://advisory.echohq.com/osv",
+	}
+
+	dataSources = map[ecosystem.Type]types.DataSource{
+		ecosystem.Pip: source,
+	}
+)
+
+type VulnSrc struct{}
+
+func NewVulnSrc() VulnSrc {
+	return VulnSrc{}
+}
+
+func (VulnSrc) Name() types.SourceID {
+	return source.ID
+}
+
+func (VulnSrc) Update(root string) error {
+	o := osv.New(vulnsDir, source.ID, dataSources, osv.WithTransformer(&transformer{}))
+	if err := o.Update(root); err != nil {
+		return oops.In("echo-osv").Wrapf(err, "failed to update Echo OSV vulnerability data")
+	}
+	return nil
+}
+
+// transformer filters out advisories that didn't resolve to a CVE ID.
+// The Echo OSV feed contains both ECHO-ID and CVE-ID entries for the same
+// vulnerability; keeping only CVE-keyed advisories avoids duplicates.
+type transformer struct{}
+
+func (t *transformer) PostParseAffected(adv osv.Advisory, _ osv.Affected) (osv.Advisory, error) {
+	return adv, nil
+}
+
+func (t *transformer) TransformAdvisories(advisories []osv.Advisory, _ osv.Entry) ([]osv.Advisory, error) {
+	var filtered []osv.Advisory
+	for _, adv := range advisories {
+		if strings.HasPrefix(adv.VulnerabilityID, "CVE-") {
+			filtered = append(filtered, adv)
+		}
+	}
+	return filtered, nil
+}

--- a/pkg/vulnsrc/echo-osv/echo_osv.go
+++ b/pkg/vulnsrc/echo-osv/echo_osv.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/aquasecurity/trivy-db/pkg/ecosystem"
 	"github.com/aquasecurity/trivy-db/pkg/types"
+	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/bucket"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/osv"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/vulnerability"
 )
@@ -19,10 +20,6 @@ var (
 		ID:   vulnerability.EchoOSV,
 		Name: "Echo OSV",
 		URL:  "https://advisory.echohq.com/osv",
-	}
-
-	dataSources = map[ecosystem.Type]types.DataSource{
-		ecosystem.Pip: source,
 	}
 )
 
@@ -37,11 +34,21 @@ func (VulnSrc) Name() types.SourceID {
 }
 
 func (VulnSrc) Update(root string) error {
-	o := osv.New(vulnsDir, source.ID, dataSources, osv.WithTransformer(&transformer{}))
+	dataSources := map[ecosystem.Type]types.DataSource{
+		ecosystem.Pip: source,
+	}
+	o := osv.New(vulnsDir, source.ID, dataSources,
+		osv.WithTransformer(&transformer{}),
+		osv.WithBucketResolver("pypi", resolvePyPI),
+	)
 	if err := o.Update(root); err != nil {
 		return oops.In("echo-osv").Wrapf(err, "failed to update Echo OSV vulnerability data")
 	}
 	return nil
+}
+
+func resolvePyPI(_ string) (bucket.Bucket, error) {
+	return newPipBucket(source)
 }
 
 // transformer filters out advisories that didn't resolve to a CVE ID.

--- a/pkg/vulnsrc/echo-osv/echo_osv.go
+++ b/pkg/vulnsrc/echo-osv/echo_osv.go
@@ -39,7 +39,7 @@ func (VulnSrc) Update(root string) error {
 	}
 	o := osv.New(vulnsDir, source.ID, dataSources,
 		osv.WithTransformer(&transformer{}),
-		osv.WithBucketResolver("pypi", resolvePyPI),
+		osv.WithBucketResolver("echo", resolveEcho),
 	)
 	if err := o.Update(root); err != nil {
 		return oops.In("echo-osv").Wrapf(err, "failed to update Echo OSV vulnerability data")
@@ -47,8 +47,20 @@ func (VulnSrc) Update(root string) error {
 	return nil
 }
 
-func resolvePyPI(_ string) (bucket.Bucket, error) {
-	return newPipBucket(source)
+// resolveEcho dispatches Echo OSV ecosystems to the matching bucket.
+// The Echo OSV feed namespaces every entry under "Echo:*" (e.g. "Echo:PyPi"),
+// plus plain "Echo" for OS packages. resolveBucket lowercases and splits on ':',
+// so this is invoked with eco="echo" and the original suffix.
+func resolveEcho(suffix string) (bucket.Bucket, error) {
+	switch suffix {
+	case "pypi":
+		return newPipBucket(source)
+	default:
+		// Plain "Echo" entries are OS packages and are handled by the
+		// existing `echo` source from vuln-list/echo/. Skip them here so
+		// we don't double-store them under a language bucket.
+		return nil, oops.Errorf("unsupported Echo ecosystem suffix: %q", suffix)
+	}
 }
 
 // transformer filters out advisories that didn't resolve to a CVE ID.

--- a/pkg/vulnsrc/echo-osv/echo_osv_test.go
+++ b/pkg/vulnsrc/echo-osv/echo_osv_test.go
@@ -24,10 +24,10 @@ func TestVulnSrc_Update(t *testing.T) {
 			dir:  filepath.Join("testdata", "happy"),
 			wantValues: []vulnsrctest.WantValues{
 				{
-					Key: []string{
-						"data-source",
-						"pip::Echo OSV",
-					},
+				Key: []string{
+					"data-source",
+					"echo pip::Echo OSV",
+				},
 					Value: types.DataSource{
 						ID:   vulnerability.EchoOSV,
 						Name: "Echo OSV",
@@ -35,19 +35,19 @@ func TestVulnSrc_Update(t *testing.T) {
 					},
 				},
 				{
-					Key: []string{
-						"advisory-detail",
-						"CVE-2024-99999",
-						"pip::Echo OSV",
-						"requests",
+				Key: []string{
+					"advisory-detail",
+					"CVE-2024-99999",
+					"echo pip::Echo OSV",
+					"requests",
+				},
+				Value: types.Advisory{
+					VendorIDs: []string{
+						"ECHO-2024-1234",
 					},
-					Value: types.Advisory{
-						VendorIDs: []string{
-							"ECHO-2024-1234",
-						},
-						PatchedVersions:    []string{"2.32.0"},
-						VulnerableVersions: []string{">=2.0.0, <2.32.0"},
-					},
+					PatchedVersions:    []string{"2.14.2+echo.999"},
+					VulnerableVersions: []string{">=2.14.2+echo.1, <2.14.2+echo.999"},
+				},
 				},
 				{
 					Key: []string{
@@ -57,7 +57,7 @@ func TestVulnSrc_Update(t *testing.T) {
 					},
 					Value: types.VulnerabilityDetail{
 						Title:        "Example vulnerability in requests library",
-						Description:  "The requests library before 2.32.0 has a vulnerability that allows an attacker to perform SSRF attacks.",
+						Description:  "The requests library before 2.14.2+echo.999 has a vulnerability that allows an attacker to perform SSRF attacks.",
 						CvssVectorV3: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
 						CvssScoreV3:  7.5,
 						References: []string{

--- a/pkg/vulnsrc/echo-osv/echo_osv_test.go
+++ b/pkg/vulnsrc/echo-osv/echo_osv_test.go
@@ -1,0 +1,116 @@
+package echoosv_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/aquasecurity/trivy-db/pkg/types"
+	"github.com/aquasecurity/trivy-db/pkg/utils"
+	echoosv "github.com/aquasecurity/trivy-db/pkg/vulnsrc/echo-osv"
+	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/vulnerability"
+	"github.com/aquasecurity/trivy-db/pkg/vulnsrctest"
+)
+
+func TestVulnSrc_Update(t *testing.T) {
+	tests := []struct {
+		name       string
+		dir        string
+		wantValues []vulnsrctest.WantValues
+		noBuckets  [][]string
+		wantErr    string
+	}{
+		{
+			name: "happy path",
+			dir:  filepath.Join("testdata", "happy"),
+			wantValues: []vulnsrctest.WantValues{
+				{
+					Key: []string{
+						"data-source",
+						"pip::Echo OSV",
+					},
+					Value: types.DataSource{
+						ID:   vulnerability.EchoOSV,
+						Name: "Echo OSV",
+						URL:  "https://advisory.echohq.com/osv",
+					},
+				},
+				{
+					Key: []string{
+						"advisory-detail",
+						"CVE-2024-99999",
+						"pip::Echo OSV",
+						"requests",
+					},
+					Value: types.Advisory{
+						VendorIDs: []string{
+							"ECHO-2024-1234",
+						},
+						PatchedVersions:    []string{"2.32.0"},
+						VulnerableVersions: []string{">=2.0.0, <2.32.0"},
+					},
+				},
+				{
+					Key: []string{
+						"vulnerability-detail",
+						"CVE-2024-99999",
+						string(vulnerability.EchoOSV),
+					},
+					Value: types.VulnerabilityDetail{
+						Title:        "Example vulnerability in requests library",
+						Description:  "The requests library before 2.32.0 has a vulnerability that allows an attacker to perform SSRF attacks.",
+						CvssVectorV3: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+						CvssScoreV3:  7.5,
+						References: []string{
+							"https://nvd.nist.gov/vuln/detail/CVE-2024-99999",
+							"https://github.com/psf/requests",
+						},
+						LastModifiedDate: utils.MustTimeParse("2024-10-15T12:00:00Z"),
+						PublishedDate:    utils.MustTimeParse("2024-09-01T08:00:00Z"),
+					},
+				},
+				{
+					Key: []string{
+						"vulnerability-id",
+						"CVE-2024-99999",
+					},
+					Value: map[string]any{},
+				},
+			},
+			noBuckets: [][]string{
+				{
+					"advisory-detail",
+					"ECHO-2024-5678",
+				},
+				{
+					"vulnerability-detail",
+					"ECHO-2024-5678",
+				},
+				{
+					"vulnerability-id",
+					"ECHO-2024-5678",
+				},
+			},
+		},
+		{
+			name:    "sad path (dir doesn't exist)",
+			dir:     filepath.Join("testdata", "badPath"),
+			wantErr: "no such file or directory",
+		},
+		{
+			name:    "sad path (failed to decode)",
+			dir:     filepath.Join("testdata", "sad"),
+			wantErr: "json decode error",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vs := echoosv.NewVulnSrc()
+			vulnsrctest.TestUpdate(t, vs, vulnsrctest.TestUpdateArgs{
+				Dir:        tt.dir,
+				WantValues: tt.wantValues,
+				NoBuckets:  tt.noBuckets,
+				WantErr:    tt.wantErr,
+			})
+		})
+	}
+}

--- a/pkg/vulnsrc/echo-osv/echo_osv_test.go
+++ b/pkg/vulnsrc/echo-osv/echo_osv_test.go
@@ -24,10 +24,10 @@ func TestVulnSrc_Update(t *testing.T) {
 			dir:  filepath.Join("testdata", "happy"),
 			wantValues: []vulnsrctest.WantValues{
 				{
-				Key: []string{
-					"data-source",
-					"echo pip::Echo OSV",
-				},
+					Key: []string{
+						"data-source",
+						"echo pip::Echo OSV",
+					},
 					Value: types.DataSource{
 						ID:   vulnerability.EchoOSV,
 						Name: "Echo OSV",
@@ -35,19 +35,19 @@ func TestVulnSrc_Update(t *testing.T) {
 					},
 				},
 				{
-				Key: []string{
-					"advisory-detail",
-					"CVE-2024-99999",
-					"echo pip::Echo OSV",
-					"requests",
-				},
-				Value: types.Advisory{
-					VendorIDs: []string{
-						"ECHO-2024-1234",
+					Key: []string{
+						"advisory-detail",
+						"CVE-2024-99999",
+						"echo pip::Echo OSV",
+						"requests",
 					},
-					PatchedVersions:    []string{"2.14.2+echo.999"},
-					VulnerableVersions: []string{">=2.14.2+echo.1, <2.14.2+echo.999"},
-				},
+					Value: types.Advisory{
+						VendorIDs: []string{
+							"ECHO-2024-1234",
+						},
+						PatchedVersions:    []string{"2.14.2+echo.999"},
+						VulnerableVersions: []string{">=2.14.2+echo.1, <2.14.2+echo.999"},
+					},
 				},
 				{
 					Key: []string{

--- a/pkg/vulnsrc/echo-osv/echo_osv_test.go
+++ b/pkg/vulnsrc/echo-osv/echo_osv_test.go
@@ -89,6 +89,20 @@ func TestVulnSrc_Update(t *testing.T) {
 					"vulnerability-id",
 					"ECHO-2024-5678",
 				},
+				// Plain "Echo" ecosystem entries are OS packages, owned by
+				// the `echo` source. They must not leak into echo-osv buckets.
+				{
+					"advisory-detail",
+					"CVE-2024-77777",
+				},
+				{
+					"vulnerability-detail",
+					"CVE-2024-77777",
+				},
+				{
+					"vulnerability-id",
+					"CVE-2024-77777",
+				},
 			},
 		},
 		{

--- a/pkg/vulnsrc/echo-osv/testdata/happy/vuln-list/echo-osv/ECHO-2024-1234.json
+++ b/pkg/vulnsrc/echo-osv/testdata/happy/vuln-list/echo-osv/ECHO-2024-1234.json
@@ -7,7 +7,7 @@
     "CVE-2024-99999"
   ],
   "summary": "Example vulnerability in requests library",
-  "details": "The requests library before 2.32.0 has a vulnerability that allows an attacker to perform SSRF attacks.",
+  "details": "The requests library before 2.14.2+echo.999 has a vulnerability that allows an attacker to perform SSRF attacks.",
   "severity": [
     {
       "type": "CVSS_V3",
@@ -25,10 +25,10 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "2.0.0"
+              "introduced": "2.14.2+echo.1"
             },
             {
-              "fixed": "2.32.0"
+              "fixed": "2.14.2+echo.999"
             }
           ]
         }

--- a/pkg/vulnsrc/echo-osv/testdata/happy/vuln-list/echo-osv/ECHO-2024-1234.json
+++ b/pkg/vulnsrc/echo-osv/testdata/happy/vuln-list/echo-osv/ECHO-2024-1234.json
@@ -1,0 +1,48 @@
+{
+  "schema_version": "1.4.0",
+  "id": "ECHO-2024-1234",
+  "modified": "2024-10-15T12:00:00Z",
+  "published": "2024-09-01T08:00:00Z",
+  "aliases": [
+    "CVE-2024-99999"
+  ],
+  "summary": "Example vulnerability in requests library",
+  "details": "The requests library before 2.32.0 has a vulnerability that allows an attacker to perform SSRF attacks.",
+  "severity": [
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
+    }
+  ],
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "requests"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "2.0.0"
+            },
+            {
+              "fixed": "2.32.0"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ADVISORY",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-99999"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/psf/requests"
+    }
+  ]
+}

--- a/pkg/vulnsrc/echo-osv/testdata/happy/vuln-list/echo-osv/ECHO-2024-1234.json
+++ b/pkg/vulnsrc/echo-osv/testdata/happy/vuln-list/echo-osv/ECHO-2024-1234.json
@@ -3,7 +3,7 @@
   "id": "ECHO-2024-1234",
   "modified": "2024-10-15T12:00:00Z",
   "published": "2024-09-01T08:00:00Z",
-  "aliases": [
+  "upstream": [
     "CVE-2024-99999"
   ],
   "summary": "Example vulnerability in requests library",
@@ -17,8 +17,9 @@
   "affected": [
     {
       "package": {
-        "ecosystem": "PyPI",
-        "name": "requests"
+        "ecosystem": "Echo:PyPi",
+        "name": "requests",
+        "purl": "pkg:pypi/requests"
       },
       "ranges": [
         {

--- a/pkg/vulnsrc/echo-osv/testdata/happy/vuln-list/echo-osv/ECHO-2024-5678.json
+++ b/pkg/vulnsrc/echo-osv/testdata/happy/vuln-list/echo-osv/ECHO-2024-5678.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": "1.4.0",
+  "id": "ECHO-2024-5678",
+  "modified": "2024-11-01T10:00:00Z",
+  "published": "2024-10-01T08:00:00Z",
+  "summary": "Vulnerability without CVE alias",
+  "details": "This entry has no CVE alias and should be filtered out.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "flask"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.0.0"
+            },
+            {
+              "fixed": "2.0.0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/vulnsrc/echo-osv/testdata/happy/vuln-list/echo-osv/ECHO-2024-5678.json
+++ b/pkg/vulnsrc/echo-osv/testdata/happy/vuln-list/echo-osv/ECHO-2024-5678.json
@@ -8,8 +8,9 @@
   "affected": [
     {
       "package": {
-        "ecosystem": "PyPI",
-        "name": "flask"
+        "ecosystem": "Echo:PyPi",
+        "name": "flask",
+        "purl": "pkg:pypi/flask"
       },
       "ranges": [
         {

--- a/pkg/vulnsrc/echo-osv/testdata/happy/vuln-list/echo-osv/ECHO-2024-9999.json
+++ b/pkg/vulnsrc/echo-osv/testdata/happy/vuln-list/echo-osv/ECHO-2024-9999.json
@@ -1,0 +1,32 @@
+{
+  "schema_version": "1.4.0",
+  "id": "ECHO-2024-9999",
+  "modified": "2024-12-01T10:00:00Z",
+  "published": "2024-11-01T08:00:00Z",
+  "upstream": [
+    "CVE-2024-77777"
+  ],
+  "summary": "OS-level Echo vulnerability that should be skipped",
+  "details": "This entry uses the plain Echo ecosystem and is handled by the `echo` source, not by `echo-osv`.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "Echo",
+        "name": "openssl"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "3.0.2-1+e1"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/vulnsrc/echo-osv/testdata/sad/vuln-list/echo-osv/bad.json
+++ b/pkg/vulnsrc/echo-osv/testdata/sad/vuln-list/echo-osv/bad.json
@@ -1,0 +1,1 @@
+{invalid json

--- a/pkg/vulnsrc/osv/osv.go
+++ b/pkg/vulnsrc/osv/osv.go
@@ -29,6 +29,7 @@ type Advisory struct {
 	PkgName         string
 	VulnerabilityID string
 	Aliases         []string
+	Upstream        []string
 
 	// Advisory detail
 	VulnerableVersions []string
@@ -283,6 +284,7 @@ func (o OSV) parseAffected(entry Entry, vulnIDs, aliases, references []string) (
 					PkgName:            pkgName,
 					VulnerabilityID:    vulnID,
 					Aliases:            aliases,
+					Upstream:           entry.Upstream,
 					VulnerableVersions: vulnerableVersions,
 					PatchedVersions:    patchedVersions,
 					Title:              entry.Summary,

--- a/pkg/vulnsrc/vulnerability/const.go
+++ b/pkg/vulnsrc/vulnerability/const.go
@@ -39,6 +39,7 @@ const (
 	Seal                  types.SourceID = "seal"
 	Aqua                  types.SourceID = "aqua"
 	Echo                  types.SourceID = "echo"
+	EchoOSV               types.SourceID = "echo-osv"
 	MinimOS               types.SourceID = "minimos"
 	RootIO                types.SourceID = "rootio"
 )
@@ -78,6 +79,7 @@ var AllSourceIDs = []types.SourceID{
 	GoVulnDB,
 	Julia,
 	Echo,
+	EchoOSV,
 	MinimOS,
 	RootIO,
 }

--- a/pkg/vulnsrc/vulnsrc.go
+++ b/pkg/vulnsrc/vulnsrc.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/composer"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/debian"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/echo"
+	echoosv "github.com/aquasecurity/trivy-db/pkg/vulnsrc/echo-osv"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/ghsa"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/glad"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/govulndb"
@@ -63,6 +64,7 @@ var (
 		chainguard.NewVulnSrc(),
 		bitnami.NewVulnSrc(),
 		echo.NewVulnSrc(),
+		echoosv.NewVulnSrc(),
 		minimos.NewVulnSrc(),
 
 		rootio.NewVulnSrc(),


### PR DESCRIPTION
Add support for downloading Echo's OSV advisory.

Issue: https://github.com/aquasecurity/trivy/discussions/10519

This PR relies on [this](https://github.com/aquasecurity/vuln-list-update/pull/436) PR to be merged first: