### PR TITLE
fix(osv): warn on invalid CVSS vectors instead of failing

### DIFF
--- a/pkg/vulnsrc/osv/osv.go
+++ b/pkg/vulnsrc/osv/osv.go
@@ -405,14 +405,16 @@ func parseSeverities(severities []Severity) (severityResult, error) {
 		case "CVSS_V3":
 			vec, score, err := parseSeverityV3(s.Score)
 			if err != nil {
-				return severityResult{}, err
+				log.Warn("Failed to parse CVSSv3 vector", log.String("vector", s.Score), log.Err(err))
+				continue
 			}
 			result.VectorV3 = vec
 			result.ScoreV3 = score
 		case "CVSS_V4":
 			vec, score, err := parseSeverityV40(s.Score)
 			if err != nil {
-				return severityResult{}, err
+				log.Warn("Failed to parse CVSSv4.0 vector", log.String("vector", s.Score), log.Err(err))
+				continue
 			}
 			result.VectorV40 = vec
 			result.ScoreV40 = score

--- a/pkg/vulnsrc/osv/osv.go
+++ b/pkg/vulnsrc/osv/osv.go
@@ -240,10 +240,7 @@ func (o OSV) parseAffected(entry Entry, vulnIDs, aliases, references []string) (
 	eb := oops.With("entry_id", entry.ID).With("vuln_ids", vulnIDs).With("aliases", aliases)
 
 	// Severities can be found both in severity and affected[].severity fields.
-	sev, err := parseSeverities(entry.Severities)
-	if err != nil {
-		return nil, eb.Wrapf(err, "failed to decode CVSS vector")
-	}
+	sev := parseSeverities(entry.Severities)
 
 	uniqAdvisories := map[string]Advisory{}
 	for _, affected := range entry.Affected {
@@ -261,10 +258,7 @@ func (o OSV) parseAffected(entry Entry, vulnIDs, aliases, references []string) (
 		}
 
 		// Parse affected[].severity
-		affSev, err := parseSeverities(affected.Severities)
-		if err != nil {
-			return nil, eb.Wrapf(err, "failed to decode CVSS vector")
-		}
+		affSev := parseSeverities(affected.Severities)
 		if affSev.VectorV3 != "" {
 			sev.VectorV3, sev.ScoreV3 = affSev.VectorV3, affSev.ScoreV3
 		}
@@ -395,7 +389,7 @@ type severityResult struct {
 // cf.
 // - https://ossf.github.io/osv-schema/#severity-field
 // - https://ossf.github.io/osv-schema/#affectedseverity-field
-func parseSeverities(severities []Severity) (severityResult, error) {
+func parseSeverities(severities []Severity) severityResult {
 	var result severityResult
 	for _, s := range severities {
 		if s.Score == "" {
@@ -405,7 +399,9 @@ func parseSeverities(severities []Severity) (severityResult, error) {
 		case "CVSS_V3":
 			vec, score, err := parseSeverityV3(s.Score)
 			if err != nil {
-				log.Warn("Failed to parse CVSSv3 vector", log.String("vector", s.Score), log.Err(err))
+				log.WithPrefix("osv").Warn(
+					"Failed to parse CVSSv3 vector",
+					log.String("vector", s.Score), log.Err(err))
 				continue
 			}
 			result.VectorV3 = vec
@@ -413,14 +409,16 @@ func parseSeverities(severities []Severity) (severityResult, error) {
 		case "CVSS_V4":
 			vec, score, err := parseSeverityV40(s.Score)
 			if err != nil {
-				log.Warn("Failed to parse CVSSv4.0 vector", log.String("vector", s.Score), log.Err(err))
+				log.WithPrefix("osv").Warn(
+					"Failed to parse CVSSv4.0 vector",
+					log.String("vector", s.Score), log.Err(err))
 				continue
 			}
 			result.VectorV40 = vec
 			result.ScoreV40 = score
 		}
 	}
-	return result, nil
+	return result
 }
 
 // parseSeverityV3 parses a CVSSv3 vector string and returns the vector and score

--- a/pkg/vulnsrc/osv/osv_test.go
+++ b/pkg/vulnsrc/osv/osv_test.go
@@ -145,6 +145,45 @@ func TestVulnSrc_Update(t *testing.T) {
 					},
 					Value: map[string]any{},
 				},
+				// CVSSv4 with invalid metric order: skipped with warn, V3 still parsed
+				{
+					Key: []string{
+						"advisory-detail",
+						"CVE-2026-99999",
+						"pip::Python Packaging Advisory Database",
+						"somepackage",
+					},
+					Value: types.Advisory{
+						VendorIDs:          []string{"PYSEC-2026-2"},
+						PatchedVersions:    []string{"1.2.3"},
+						VulnerableVersions: []string{"<1.2.3"},
+					},
+				},
+				{
+					Key: []string{
+						"vulnerability-detail",
+						"CVE-2026-99999",
+						string(vulnerability.OSV),
+					},
+					Value: types.VulnerabilityDetail{
+						Title:        "Test advisory with invalid CVSSv4.0 metric order",
+						Description:  "Some vulnerability details.",
+						CvssVectorV3: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+						CvssScoreV3:  9.8,
+						References: []string{
+							"https://example.com/advisory",
+						},
+						LastModifiedDate: utils.MustTimeParse("2026-04-01T00:00:00Z"),
+						PublishedDate:    utils.MustTimeParse("2026-03-01T00:00:00Z"),
+					},
+				},
+				{
+					Key: []string{
+						"vulnerability-id",
+						"CVE-2026-99999",
+					},
+					Value: map[string]any{},
+				},
 			},
 			noBuckets: [][]string{
 				// skip withdrawn

--- a/pkg/vulnsrc/osv/testdata/happy/vuln-list/osv/python/PYSEC-2026-2.json
+++ b/pkg/vulnsrc/osv/testdata/happy/vuln-list/osv/python/PYSEC-2026-2.json
@@ -1,0 +1,47 @@
+{
+  "id": "PYSEC-2026-2",
+  "modified": "2026-04-01T00:00:00Z",
+  "published": "2026-03-01T00:00:00Z",
+  "aliases": [
+    "CVE-2026-99999"
+  ],
+  "summary": "Test advisory with invalid CVSSv4.0 metric order",
+  "details": "Some vulnerability details.",
+  "severity": [
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+    },
+    {
+      "type": "CVSS_V4",
+      "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:H/SC:N/VI:H/SI:N/VA:H/SA:N"
+    }
+  ],
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "somepackage"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.2.3"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://example.com/advisory"
+    }
+  ]
+}


### PR DESCRIPTION
Some OSV/GHSA advisories contain CVSS vectors with invalid data (e.g. [GHSA-28g4-38q8-3cwc](https://github.com/github/advisory-database/blob/698cd61816ed58197835a773126febb543473c9e/advisories/github-reviewed/2026/04/GHSA-28g4-38q8-3cwc/GHSA-28g4-38q8-3cwc.json#L3) has CVSSv4.0 metrics in wrong order). Instead of failing the build, the parser now logs a warning and skips the malformed vector, matching the existing NVD parser behavior.

Test run - https://github.com/nikpivkin/trivy-db/actions/runs/24667488113/job/72128842110

An advisory with an incorrect CVSSv4 vector has been skipped:
```
2026/04/20 13:17:33 WARN Failed to parse CVSSv4.0 vector vector=CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:H/SC:N/VI:H/SI:N/VA:H/SA:N error.message="failed to parse CVSSv4.0 vector" error.err="failed to parse CVSSv4.0 vector: invalid metric order" error.time=2026-04-20T13:17:33.145Z error.trace=01KPNGM0JSMSX2NKYC460KD648 error.context.cvss_vector_v40=CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:H/SC:N/VI:H/SI:N/VA:H/SA:N error.stacktrace="Oops: failed to parse CVSSv4.0 vector\n  --- at /home/runner/work/trivy-db/trivy-db/pkg/vulnsrc/osv/osv.go:456 parseSeverityV40()\n  --- at /home/runner/work/trivy-db/trivy-db/pkg/vulnsrc/osv/osv.go:414 parseSeverities()\n  --- at /home/runner/work/trivy-db/trivy-db/pkg/vulnsrc/osv/osv.go:243 OSV.parseAffected()\n  --- at /home/runner/work/trivy-db/trivy-db/pkg/vulnsrc/osv/osv.go:174 OSV.commit()\n  --- at /home/runner/work/trivy-db/trivy-db/pkg/vulnsrc/osv/osv.go:147 OSV.save.func1()\n  --- at /home/runner/go/pkg/mod/go.etcd.io/bbolt@v1.4.3/db.go:1074 safelyCall()\n  --- at /home/runner/go/pkg/mod/go.etcd.io/bbolt@v1.4.3/db.go:1025 batch.run.func1()\n  --- at /home/runner/go/pkg/mod/go.etcd.io/bbolt@v1.4.3/db.go:908 DB.Update()\n  --- at /home/runner/go/pkg/mod/go.etcd.io/bbolt@v1.4.3/db.go:1023 batch.run()\n  --- at /home/runner/go/pkg/mod/go.etcd.io/bbolt@v1.4.3/db.go:1005 batch.trigger()"
```