### PR TITLE
feat(vulnsrc): add advisories for Ubuntu 26.04 LTS

### DIFF
--- a/pkg/vulnsrc/ubuntu/ubuntu.go
+++ b/pkg/vulnsrc/ubuntu/ubuntu.go
@@ -50,6 +50,7 @@ var (
 		"oracular": "24.10",
 		"plucky":   "25.04",
 		"questing": "25.10",
+		"resolute": "26.04",
 		// ESM versions:
 		"precise/esm": "12.04-ESM",
 		"trusty/esm":  "14.04-ESM",


### PR DESCRIPTION
Ubuntu 26.04's code name is Resolute Raccoon - ingest advisories for that release from Ubuntu's CVE tracker.