### PR TITLE
fix(ci): pass GITHUB_TOKEN to wget and enable verbose errors on download

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -38,6 +38,8 @@ jobs:
         run: go install go.etcd.io/bbolt/cmd/bbolt@v1.3.5
 
       - name: Download vuln-list and advisories
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: make db-fetch-langs db-fetch-vuln-list
 
       - name: Build the binary

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ ASSET_DIR ?= assets
 define download_and_extract
 	@echo "Downloading $(1)..." && \
 	TMP_FILE=$$(mktemp) && \
-	wget -q $(1) -O "$$TMP_FILE" && \
+	wget --no-verbose $(if $(GITHUB_TOKEN),--header="Authorization: token $(GITHUB_TOKEN)",) $(1) -O "$$TMP_FILE" && \
 	tar xzf "$$TMP_FILE" -C $(2) --strip-components=1 && \
 	rm -f "$$TMP_FILE"
 endef

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ ASSET_DIR ?= assets
 # Download and extract function - separates download from extraction for stability
 # Usage: $(call download_and_extract,URL,TARGET_DIR)
 # This approach prevents pipe failures when wget encounters recoverable errors
+# GITHUB_TOKEN is optional but recommended to avoid rate limiting on archive downloads
 define download_and_extract
 	@echo "Downloading $(1)..." && \
 	TMP_FILE=$$(mktemp) && \


### PR DESCRIPTION
Pass `GITHUB_TOKEN` to wget when downloading vuln-list archives to avoid GitHub rate limiting. Replace `-q` with `--no-verbose` so server errors are visible in CI logs. Probably fixes https://github.com/aquasecurity/trivy-db/actions/runs/26007249741/job/76440880599

Test run - https://github.com/nikpivkin/trivy-db/actions/runs/26014658576/job/76462134037