### PR TITLE
fix(ubuntu): include "pending" status in vulnerability tracking

### DIFF
--- a/pkg/vulnsrc/ubuntu/testdata/vuln-list/ubuntu/CVE-2020-1234.json
+++ b/pkg/vulnsrc/ubuntu/testdata/vuln-list/ubuntu/CVE-2020-1234.json
@@ -23,6 +23,10 @@
       "focal": {
         "Status": "needs-triage",
         "Note": ""
+      },
+      "jammy": {
+        "Status": "pending",
+        "Note": "1.2.4"
       }
     }
   },

--- a/pkg/vulnsrc/ubuntu/ubuntu.go
+++ b/pkg/vulnsrc/ubuntu/ubuntu.go
@@ -20,7 +20,7 @@ import (
 const ubuntuDir = "ubuntu"
 
 var (
-	targetStatuses        = []string{"needed", "deferred", "released"}
+	targetStatuses        = []string{"needed", "deferred", "pending", "released"}
 	UbuntuReleasesMapping = map[string]string{
 		"precise":  "12.04",
 		"quantal":  "12.10",

--- a/pkg/vulnsrc/ubuntu/ubuntu_test.go
+++ b/pkg/vulnsrc/ubuntu/ubuntu_test.go
@@ -48,6 +48,24 @@ func TestVulnSrc_Update(t *testing.T) {
 				{"advisory-detail", "CVE-2020-1234", "ubuntu 20.04"},
 			},
 		},
+		{
+			name: "pending status is included",
+			dir:  "testdata",
+			wantValues: []vulnsrctest.WantValues{
+				{
+					Key: []string{"data-source", "ubuntu 22.04"},
+					Value: types.DataSource{
+						ID:   vulnerability.Ubuntu,
+						Name: "Ubuntu CVE Tracker",
+						URL:  "https://git.launchpad.net/ubuntu-cve-tracker",
+					},
+				},
+				{
+					Key: []string{"advisory-detail", "CVE-2020-1234", "ubuntu 22.04", "xen"},
+					Value: types.Advisory{},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/vulnsrc/ubuntu/ubuntu_test.go
+++ b/pkg/vulnsrc/ubuntu/ubuntu_test.go
@@ -61,7 +61,7 @@ func TestVulnSrc_Update(t *testing.T) {
 					},
 				},
 				{
-					Key: []string{"advisory-detail", "CVE-2020-1234", "ubuntu 22.04", "xen"},
+					Key:   []string{"advisory-detail", "CVE-2020-1234", "ubuntu 22.04", "xen"},
 					Value: types.Advisory{},
 				},
 			},


### PR DESCRIPTION
## Summary

- CVEs with Ubuntu status `"pending"` (fix committed upstream but not yet released as an update) were silently dropped because `"pending"` was missing from the `targetStatuses` list in `pkg/vulnsrc/ubuntu/ubuntu.go`
- This meant Trivy users were not alerted to vulnerabilities that have known fixes in progress
- Added `"pending"` to `targetStatuses` alongside the existing `"needed"`, `"deferred"`, and `"released"` values

## References

Ubuntu CVE Tracker status definitions: https://wiki.ubuntu.com/SecurityTeam/FAQ#CVE_Statuses

- **needed** — fix is needed but not yet available
- **deferred** — fix is deferred to a later release
- **pending** — fix is committed upstream but not yet released as an update
- **released** — fix has been released

## Test plan

- [x] Added `"pending"` status entry to existing test fixture (`CVE-2020-1234.json`)
- [x] Added new test case `"pending status is included"` verifying the advisory is stored
- [x] All existing tests continue to pass