### PR TITLE
fix: make Severity and VendorSeverity use consistent advisory first priority

### DIFF
--- a/pkg/vulnsrc/vulnerability/vulnerability.go
+++ b/pkg/vulnsrc/vulnerability/vulnerability.go
@@ -76,19 +76,8 @@ func getCVSS(details map[types.SourceID]types.VulnerabilityDetail) types.VendorC
 func getVendorSeverity(details map[types.SourceID]types.VulnerabilityDetail) types.VendorSeverity {
 	vs := make(types.VendorSeverity)
 	for vendor, detail := range details {
-		switch {
-		case detail.SeverityV40 != types.SeverityUnknown:
-			vs[vendor] = detail.SeverityV40
-		case detail.SeverityV3 != types.SeverityUnknown:
-			vs[vendor] = detail.SeverityV3
-		case detail.Severity != types.SeverityUnknown:
-			vs[vendor] = detail.Severity
-		case detail.CvssScoreV40 > 0:
-			vs[vendor] = scoreToSeverity(detail.CvssScoreV40)
-		case detail.CvssScoreV3 > 0:
-			vs[vendor] = scoreToSeverity(detail.CvssScoreV3)
-		case detail.CvssScore > 0:
-			vs[vendor] = scoreToSeverity(detail.CvssScore)
+		if s := detailToSeverity(detail); s != types.SeverityUnknown {
+			vs[vendor] = s
 		}
 	}
 	return vs
@@ -96,24 +85,34 @@ func getVendorSeverity(details map[types.SourceID]types.VulnerabilityDetail) typ
 
 func getSeverity(details map[types.SourceID]types.VulnerabilityDetail) types.Severity {
 	for _, source := range AllSourceIDs {
-		switch d, ok := details[source]; {
-		case !ok:
+		d, ok := details[source]
+		if !ok {
 			continue
-		case d.CvssScoreV40 > 0:
-			return scoreToSeverity(d.CvssScoreV40)
-		case d.CvssScoreV3 > 0:
-			return scoreToSeverity(d.CvssScoreV3)
-		case d.CvssScore > 0:
-			return scoreToSeverity(d.CvssScore)
-		case d.SeverityV40 != 0:
-			return d.SeverityV40
-		case d.SeverityV3 != 0:
-			return d.SeverityV3
-		case d.Severity != 0:
-			return d.Severity
+		}
+		if s := detailToSeverity(d); s != types.SeverityUnknown {
+			return s
 		}
 	}
 	return types.SeverityUnknown
+}
+
+func detailToSeverity(d types.VulnerabilityDetail) types.Severity {
+	switch {
+	case d.SeverityV40 != types.SeverityUnknown:
+		return d.SeverityV40
+	case d.SeverityV3 != types.SeverityUnknown:
+		return d.SeverityV3
+	case d.Severity != types.SeverityUnknown:
+		return d.Severity
+	case d.CvssScoreV40 > 0:
+		return scoreToSeverity(d.CvssScoreV40)
+	case d.CvssScoreV3 > 0:
+		return scoreToSeverity(d.CvssScoreV3)
+	case d.CvssScore > 0:
+		return scoreToSeverity(d.CvssScore)
+	default:
+		return types.SeverityUnknown
+	}
 }
 
 func getTitle(details map[types.SourceID]types.VulnerabilityDetail) string {

--- a/pkg/vulnsrc/vulnerability/vulnerability_test.go
+++ b/pkg/vulnsrc/vulnerability/vulnerability_test.go
@@ -254,7 +254,7 @@ func TestNormalize(t *testing.T) {
 			want: types.Vulnerability{
 				Title:       "test vulnerability",
 				Description: "a test vulnerability where vendor rates it lower than NVD",
-				Severity:    types.SeverityMedium.String(), // from Red Hat
+				Severity:    types.SeverityCritical.String(), // from Red Hat advisory
 				VendorSeverity: types.VendorSeverity{
 					vulnerability.RedHat: types.SeverityCritical,
 					vulnerability.Ubuntu: types.SeverityMedium,
@@ -366,6 +366,56 @@ func TestNormalize(t *testing.T) {
 				Severity:         types.SeverityUnknown.String(),
 				VendorSeverity:   types.VendorSeverity{},
 				CVSS:             types.VendorCVSS{},
+			},
+		},
+		{
+			name:   "cvss-only fallback: no advisory severity, severity derived from CVSS score",
+			vulnID: "CVE-2020-1234",
+			details: map[types.SourceID]types.VulnerabilityDetail{
+				vulnerability.NVD: {
+					CvssScoreV3:  7.5,
+					CvssVectorV3: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+					Description:  "no advisory severity, only cvss score",
+				},
+			},
+			want: types.Vulnerability{
+				Description: "no advisory severity, only cvss score",
+				Severity:    types.SeverityHigh.String(),
+				VendorSeverity: types.VendorSeverity{
+					vulnerability.NVD: types.SeverityHigh,
+				},
+				CVSS: types.VendorCVSS{
+					vulnerability.NVD: types.CVSS{
+						V3Vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+						V3Score:  7.5,
+					},
+				},
+			},
+		},
+		{
+			// advisory severity must win over CVSS-derived severity in both Severity and VendorSeverity
+			name:   "advisory-first: vendor LOW advisory beats HIGH CVSS score",
+			vulnID: "CVE-2020-1234",
+			details: map[types.SourceID]types.VulnerabilityDetail{
+				vulnerability.RedHat: {
+					CvssScoreV3:  8.1,
+					CvssVectorV3: "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H",
+					SeverityV3:   types.SeverityLow,
+					Description:  "vendor rates this LOW despite high CVSS score",
+				},
+			},
+			want: types.Vulnerability{
+				Description: "vendor rates this LOW despite high CVSS score",
+				Severity:    types.SeverityLow.String(),
+				VendorSeverity: types.VendorSeverity{
+					vulnerability.RedHat: types.SeverityLow,
+				},
+				CVSS: types.VendorCVSS{
+					vulnerability.RedHat: types.CVSS{
+						V3Vector: "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H",
+						V3Score:  8.1,
+					},
+				},
 			},
 		},
 		{


### PR DESCRIPTION
Extracted a `detailToSeverity` helper with advisory-first priority (advisory severity → CVSS fallback). Both `getSeverity` and `getVendorSeverity` now delegate to it, giving consistent results.

- Added a CVSS-only fallback test (no advisory severity set)
- Added a regression test for the exact scenario from issue (vendor LOW advisory vs HIGH CVSS score)

Related issues:
- #650