### PR TITLE
ci: declare workflow-level `contents: read` on cron and go workflows

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -10,6 +10,7 @@ env:
   VERSION: 2
 permissions:
   contents: read
+  packages: write  # for pushing to ghcr.io
 
 jobs:
   build:

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -8,6 +8,9 @@ env:
   REPO_OWNER: ${{ github.repository_owner }} # used in 'make db-build'
   GH_USER: aqua-bot
   VERSION: 2
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build DB

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,6 +1,9 @@
 ---
 name: Go
 on: [push, pull_request, merge_group]
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test


### PR DESCRIPTION
Both workflows are scheduled / test steps; no GitHub API writes from the workflows. Workflow-level `contents: read` is the right cap for the default `GITHUB_TOKEN`.

Same post-CVE-2025-30066 (`tj-actions/changed-files`) hardening pattern. YAML validated locally.