### PR TITLE
chore(types): deprecate Vulnerability.Severity field

### DIFF
--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -181,9 +181,16 @@ type Advisories struct {
 }
 
 type Vulnerability struct {
-	Title            string         `json:",omitempty"`
-	Description      string         `json:",omitempty"`
-	Severity         string         `json:",omitempty"` // Selected from VendorSeverity, depending on a scan target
+	Title       string `json:",omitempty"`
+	Description string `json:",omitempty"`
+
+	// Severity is the severity selected from VendorSeverity, depending on a scan target.
+	//
+	// Deprecated: Use VendorSeverity instead of Severity.
+	// Severity isn't related to a SourceID, so consumers can't tell the source of this severity.
+	// Kept for backward compatibility and will be removed at the next schema bump (Trivy DB v3).
+	Severity string `json:",omitempty"`
+
 	CweIDs           []string       `json:",omitempty"` // e.g. CWE-78, CWE-89
 	VendorSeverity   VendorSeverity `json:",omitempty"`
 	CVSS             VendorCVSS     `json:",omitempty"`


### PR DESCRIPTION
## Description

Follow-up to aquasecurity/trivy#10411 (see https://github.com/aquasecurity/trivy/pull/10411#discussion_r3372329900).

With severity selection now living entirely on the Trivy side (`VendorSeverity` + scan-context-aware selection), trivy-db's top-level `Vulnerability.Severity` becomes redundant for consumers.
The value also discards the `SourceID` of the selected severity, so consumers can't tell which source it came from.

This marks `Vulnerability.Severity` as `Deprecated:`, pointing consumers to `VendorSeverity`.
The field is kept for output and backward compatibility and is planned for removal at the next schema bump (Trivy DB v3).
.
