### PR TITLE
feat(oracle-oval): add CVE metadata fields to Cve struct

### DIFF
--- a/pkg/vulnsrc/oracle-oval/types.go
+++ b/pkg/vulnsrc/oracle-oval/types.go
@@ -22,7 +22,12 @@ type Reference struct {
 type Cve struct {
 	Impact string
 	Href   string
-	ID     string
+	Public string
+	// Oracle encodes cvss2 and cvss3 as "score/vector" (e.g. cvss3="7.3/CVSS:3.1/AV:N/...").
+	// Stored verbatim; downstream consumers split into score/vector themselves.
+	CVSS2 string
+	CVSS3 string
+	ID    string
 }
 
 type Criteria struct {


### PR DESCRIPTION
## Summary
- Add `Public`, `CVSS2`, and `CVSS3` fields to the Oracle OVAL `Cve` struct to align with [vuln-list-update #441](https://github.com/aquasecurity/vuln-list-update/pull/441)
- Prepare trivy-db for upcoming Oracle advisory CVE metadata from vuln-list-update without changing parsing or ingestion logic yet

## Test plan
- [x] `go build ./pkg/vulnsrc/oracle-oval/...`
- [x] `go test ./pkg/vulnsrc/oracle-oval/...`
