### PR TITLE
fix: source golang.org/x/* advisories from go-vulndb only

### DIFF
--- a/pkg/vulnsrc/ghsa/ghsa.go
+++ b/pkg/vulnsrc/ghsa/ghsa.go
@@ -149,8 +149,10 @@ func (t *transformer) TransformAdvisories(advisories []osv.Advisory, entry osv.E
 				advisories = append(advisories, adv)
 			}
 		case ecosystem.Go:
-			// Skip a standard Go package as we use the Go Vulnerability Database (govulndb) for standard packages.
-			if isStandardGoPackage(adv.PkgName) {
+			// Skip standard library and golang.org/x/* packages, as we use
+			// the Go Vulnerability Database (govulndb) for those.
+			// cf. https://github.com/aquasecurity/trivy-db/issues/675
+			if isStandardGoPackage(adv.PkgName) || strings.HasPrefix(adv.PkgName, "golang.org/x/") {
 				advisories[i].Bucket = nil // Set nil bucket to skip later
 			}
 		case ecosystem.NuGet:

--- a/pkg/vulnsrc/ghsa/ghsa_test.go
+++ b/pkg/vulnsrc/ghsa/ghsa_test.go
@@ -507,6 +507,19 @@ func TestVulnSrc_Update(t *testing.T) {
 					"vulnerability-id",
 					"CVE-2023-45288",
 				},
+				// We shouldn't save golang.org/x/* vulnerabilities (sourced from govulndb)
+				{
+					"advisory-detail",
+					"CVE-2024-45337",
+				},
+				{
+					"vulnerability-detail",
+					"CVE-2024-45337",
+				},
+				{
+					"vulnerability-id",
+					"CVE-2024-45337",
+				},
 			},
 		},
 		{

--- a/pkg/vulnsrc/ghsa/testdata/happy/ghsa/advisories/github-reviewed/2024/12/GHSA-v778-237x-gjrc/GHSA-v778-237x-gjrc.json
+++ b/pkg/vulnsrc/ghsa/testdata/happy/ghsa/advisories/github-reviewed/2024/12/GHSA-v778-237x-gjrc/GHSA-v778-237x-gjrc.json
@@ -1,0 +1,57 @@
+{
+  "schema_version": "1.4.0",
+  "id": "GHSA-v778-237x-gjrc",
+  "modified": "2024-12-12T13:13:13Z",
+  "published": "2024-12-11T21:30:32Z",
+  "aliases": [
+    "CVE-2024-45337"
+  ],
+  "summary": "Misuse of ServerConfig.PublicKeyCallback may cause authorization bypass in golang.org/x/crypto",
+  "details": "Applications and libraries which misuse the ServerConfig.PublicKeyCallback callback may be susceptible to an authorization bypass.",
+  "severity": [
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N"
+    }
+  ],
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "golang.org/x/crypto"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0.31.0"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ADVISORY",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-45337"
+    },
+    {
+      "type": "WEB",
+      "url": "https://pkg.go.dev/vuln/GO-2024-3321"
+    }
+  ],
+  "database_specific": {
+    "cwe_ids": [
+      "CWE-287"
+    ],
+    "severity": "HIGH",
+    "github_reviewed": true,
+    "github_reviewed_at": "2024-12-12T13:13:13Z",
+    "nvd_published_at": "2024-12-11T21:15:16Z"
+  }
+}

--- a/pkg/vulnsrc/govulndb/govulndb.go
+++ b/pkg/vulnsrc/govulndb/govulndb.go
@@ -3,6 +3,7 @@ package govulndb
 import (
 	"encoding/json"
 	"path/filepath"
+	"strings"
 
 	"github.com/samber/lo"
 	"github.com/samber/oops"
@@ -67,8 +68,10 @@ func (t *transformer) TransformAdvisories(advisories []osv.Advisory, entry osv.E
 
 	var filtered []osv.Advisory
 	for _, adv := range advisories {
-		// Insert only stdlib advisories
-		if adv.PkgName != "stdlib" {
+		// Keep only stdlib and golang.org/x/* advisories. Other third-party modules
+		// come from GHSA; toolchain advisories are out of scope.
+		// cf. https://github.com/aquasecurity/trivy-db/issues/675
+		if adv.PkgName != "stdlib" && !strings.HasPrefix(adv.PkgName, "golang.org/x/") {
 			continue
 		}
 		// Add a reference

--- a/pkg/vulnsrc/govulndb/govulndb_test.go
+++ b/pkg/vulnsrc/govulndb/govulndb_test.go
@@ -86,9 +86,51 @@ func TestVulnSrc_Update(t *testing.T) {
 					},
 					Value: map[string]any{},
 				},
+				// golang.org/x/* modules are also sourced from go-vulndb
+				{
+					Key: []string{
+						"advisory-detail",
+						"CVE-2025-22869",
+						"go::The Go Vulnerability Database",
+						"golang.org/x/crypto",
+					},
+					Value: types.Advisory{
+						VendorIDs: []string{
+							"GO-2025-3487",
+						},
+						PatchedVersions: []string{
+							"0.35.0",
+						},
+						VulnerableVersions: []string{
+							"<0.35.0",
+						},
+					},
+				},
+				{
+					Key: []string{
+						"vulnerability-detail",
+						"CVE-2025-22869",
+						"govulndb",
+					},
+					Value: types.VulnerabilityDetail{
+						Title:       "Potential denial of service in golang.org/x/crypto",
+						Description: "SSH servers which implement file transfer protocols are vulnerable to a denial of service attack from clients which complete the key exchange slowly, or not at all, causing pending content to be read into memory, but never transmitted.",
+						References: []string{
+							"https://go.dev/cl/652135",
+							"https://pkg.go.dev/vuln/GO-2025-3487",
+						},
+					},
+				},
+				{
+					Key: []string{
+						"vulnerability-id",
+						"CVE-2025-22869",
+					},
+					Value: map[string]any{},
+				},
 			},
 			noBuckets: [][]string{
-				// We should save only stdlib packages
+				// We should not save third-party modules other than golang.org/x/*
 				{
 					"advisory-detail",
 					"CVE-2021-41803",

--- a/pkg/vulnsrc/govulndb/testdata/happy/govulndb/data/osv/GO-2025-3487.json
+++ b/pkg/vulnsrc/govulndb/testdata/happy/govulndb/data/osv/GO-2025-3487.json
@@ -1,0 +1,51 @@
+{
+  "schema_version": "1.3.1",
+  "id": "GO-2025-3487",
+  "modified": "0001-01-01T00:00:00Z",
+  "published": "0001-01-01T00:00:00Z",
+  "aliases": [
+    "CVE-2025-22869"
+  ],
+  "summary": "Potential denial of service in golang.org/x/crypto",
+  "details": "SSH servers which implement file transfer protocols are vulnerable to a denial of service attack from clients which complete the key exchange slowly, or not at all, causing pending content to be read into memory, but never transmitted.",
+  "affected": [
+    {
+      "package": {
+        "name": "golang.org/x/crypto",
+        "ecosystem": "Go"
+      },
+      "ranges": [
+        {
+          "type": "SEMVER",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0.35.0"
+            }
+          ]
+        }
+      ],
+      "ecosystem_specific": {
+        "imports": [
+          {
+            "path": "golang.org/x/crypto/ssh",
+            "symbols": [
+              "NewServerConn"
+            ]
+          }
+        ]
+      }
+    }
+  ],
+  "references": [
+    {
+      "type": "FIX",
+      "url": "https://go.dev/cl/652135"
+    }
+  ],
+  "database_specific": {
+    "url": "https://pkg.go.dev/vuln/GO-2025-3487"
+  }
+}


### PR DESCRIPTION
## Description

GHSA lags behind go-vulndb for `golang.org/x/*` modules, so fresh advisories published there are missing from Trivy DB.
For example, several `golang.org/x/crypto` and `golang.org/x/net` CVE-2026 advisories exist in go-vulndb but have no GitHub-reviewed GHSA entry yet.

This PR ingests `golang.org/x/*` advisories from go-vulndb (in addition to `stdlib`), and excludes those modules from GHSA to avoid duplicates.
Toolchain advisories remain out of scope.

A detailed comparison of the two databases is available in https://github.com/aquasecurity/trivy-db/issues/675.

## Changes

- `govulndb`: keep `stdlib` and `golang.org/x/*` advisories (previously `stdlib` only).
- `ghsa`: skip `golang.org/x/*` packages (in addition to the standard library) since they now come from go-vulndb.
- Tests and testdata for both sources.

## Known limitation

`golang.org/x/*` advisories are now sourced exclusively from go-vulndb.
If an advisory for such a module exists in GHSA but not yet in go-vulndb, it will not be ingested.
This is an intentional trade-off — go-vulndb is the authoritative, faster source for Go-team modules.

cf. https://github.com/aquasecurity/trivy-db/issues/675
