### PR TITLE
fix(utils): skip dotfiles in FileWalk so .DS_Store does not break the DB build

### DIFF
--- a/pkg/utils/file.go
+++ b/pkg/utils/file.go
@@ -8,6 +8,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/samber/oops"
 
@@ -29,6 +30,13 @@ func FileWalk(root string, walkFn func(r io.Reader, path string) error) error {
 		if err != nil {
 			return eb.Wrapf(err, "walk dir error")
 		} else if d.IsDir() {
+			return nil
+		}
+
+		// Skip dotfiles such as .DS_Store. They are not vulnerability data
+		// and most vulnsrc parsers json.Decode every file handed to walkFn,
+		// which fails on a binary .DS_Store with "invalid character".
+		if strings.HasPrefix(d.Name(), ".") {
 			return nil
 		}
 

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -34,10 +34,14 @@ func TestFileWalk(t *testing.T) {
 	touch(t, filepath.Join(td, "dir", "foo1"))
 	touch(t, filepath.Join(td, "dir", "foo2"))
 	write(t, filepath.Join(td, "dir", "foo3"), "foo3")
+	// A non-empty dotfile, like the .DS_Store macOS creates, must be skipped
+	// before it reaches walkFn so parsers never try to decode it.
+	write(t, filepath.Join(td, "dir", ".DS_Store"), "\x00\x00\x01")
 
 	sawDir := false
 	sawFoo1 := false
 	sawFoo2 := false
+	sawDSStore := false
 	var contentFoo3 []byte
 	var err error
 
@@ -57,6 +61,9 @@ func TestFileWalk(t *testing.T) {
 				t.Fatal(err)
 			}
 		}
+		if strings.HasSuffix(path, ".DS_Store") {
+			sawDSStore = true
+		}
 		return nil
 	}
 
@@ -69,6 +76,9 @@ func TestFileWalk(t *testing.T) {
 	}
 	if sawFoo1 || sawFoo2 {
 		t.Error("an empty file must not be passed to walkFn")
+	}
+	if sawDSStore {
+		t.Error("a dotfile such as .DS_Store must not be passed to walkFn")
 	}
 	if string(contentFoo3) != "foo3" {
 		t.Error("The file content is wrong")


### PR DESCRIPTION
Fixes #247.

On macOS a stray `.DS_Store` can end up inside a cloned vuln-list data dir. FileWalk hands every non-empty file to its callback, and most vulnsrc parsers then run it through json.Decode, so the binary `.DS_Store` fails with an "invalid character" error and the whole DB build aborts. A few sources (redhat-oval, debian, osv, wolfi, chainguard) already guard with a `.json` suffix check, but most (alpine, amazon, photon, etc.) decode whatever they're given, so one dotfile is enough to break them.

Rather than add a filter to each unguarded parser, I skip dotfiles once in the WalkDir callback. Dotfiles are never legitimate vulnerability data, so dropping them up front is safe for every caller. I avoided a `.json`-only filter on purpose: TestFileWalk asserts that the extensionless file foo3 still gets passed through, and skipping by leading dot keeps that working.

I extended TestFileWalk with a non-empty `.DS_Store` and an assertion that it never reaches the callback; that fails on main and passes here. `go test ./pkg/utils/...` and `go vet` are clean.

The issue is a few years old with no recent maintainer note, so I kept this minimal and focused on the concrete crash. Happy to push the filter into the callers instead if you'd prefer.
