### PR TITLE
feat: parse description for redhat csaf advisory

### DIFF
--- a/pkg/vulnsrc/redhat-csaf/csaf.go
+++ b/pkg/vulnsrc/redhat-csaf/csaf.go
@@ -60,6 +60,8 @@ type PutInput struct {
 	// no RHSA (CVE-only rows) or when the feed omits Remediation.Date. Intended for
 	// Store implementations that want to expose an advisory publish date.
 	ReleaseDate time.Time
+	// Description is the vulnerability description from CSAF notes[category=description].
+	Description string
 }
 
 // defaultStore is the OSS default implementation of Store.
@@ -205,6 +207,7 @@ func (vs VulnSrc) update(tx *bolt.Tx, dir string) error {
 			Advisory:    advisory,
 			CPEList:     cpeList,
 			ReleaseDate: vs.parser.ReleaseDate(bkt.VulnerabilityID),
+			Description: vs.parser.Description(bkt.VulnerabilityID),
 		}
 		if err := vs.store.Put(vs.dbc, tx, input); err != nil {
 			return eb.Wrapf(err, "failed to put advisory")

--- a/pkg/vulnsrc/redhat-csaf/csaf_test.go
+++ b/pkg/vulnsrc/redhat-csaf/csaf_test.go
@@ -316,6 +316,12 @@ func TestVulnSrc_Update_WithCustomStore(t *testing.T) {
 	// Verify the custom store was called with Put
 	assert.NotEmpty(t, store.putInputs, "custom Store.Put should have been called")
 
+	mustTime := func(s string) time.Time {
+		ts, err := time.Parse(time.RFC3339, s)
+		require.NoError(t, err)
+		return ts
+	}
+
 	// Verify the extra CPE was merged
 	// The merged list should contain both CSAF CPEs and the extra one
 	for _, input := range store.putInputs {
@@ -324,29 +330,25 @@ func TestVulnSrc_Update_WithCustomStore(t *testing.T) {
 
 		vid := string(input.Bucket.VulnerabilityID)
 		switch vid {
-		case "RHSA-2024:9941", "RHSA-2024:9999":
-			want, err := time.Parse(time.RFC3339, "2024-11-19T04:46:55Z")
-			require.NoError(t, err)
-			assert.True(t, input.ReleaseDate.Equal(want), "ReleaseDate for %s", vid)
+		case "RHSA-2024:9941":
+			assert.True(t, input.ReleaseDate.Equal(mustTime("2024-11-19T04:46:55Z")), "ReleaseDate for %s", vid)
+			assert.Equal(t, "A vulnerability was found in PAM. The secret information is stored in memory, where the attacker can trigger the victim program to execute.", input.Description)
+		case "RHSA-2024:9999":
+			assert.True(t, input.ReleaseDate.Equal(mustTime("2024-11-19T04:46:55Z")), "ReleaseDate for %s", vid)
+			assert.Equal(t, "Description from CVE-2024-11111 (stored for RHSA-2024:9999)", input.Description)
 		case "RHSA-2025:0001":
-			want, err := time.Parse(time.RFC3339, "2025-01-01T00:00:00Z")
-			require.NoError(t, err)
-			assert.True(t, input.ReleaseDate.Equal(want), "ReleaseDate for %s", vid)
+			assert.True(t, input.ReleaseDate.Equal(mustTime("2025-01-01T00:00:00Z")), "ReleaseDate for %s", vid)
+			assert.Equal(t, "Test vulnerability for new rpmmod qualifier format", input.Description)
+		case "CVE-2024-11111":
+			// Unpatched rows use the CVE as bucket ID; there is no RHSA remediation date.
+			assert.True(t, input.ReleaseDate.IsZero(), "ReleaseDate for %q", vid)
+			assert.Equal(t, "Description from CVE-2024-11111 (stored for RHSA-2024:9999)", input.Description)
+		case "CVE-2024-22222":
+			assert.True(t, input.ReleaseDate.IsZero(), "ReleaseDate for %q", vid)
+			assert.Equal(t, "Description from CVE-2024-22222 (not stored for RHSA-2024:9999)", input.Description)
 		default:
 			// Unpatched rows use the CVE as bucket ID; there is no RHSA remediation date.
 			assert.True(t, input.ReleaseDate.IsZero(), "ReleaseDate for %q", vid)
-		}
-
-		switch vid {
-		case "RHSA-2024:9941":
-			assert.Equal(t, "A vulnerability was found in PAM. The secret information is stored in memory, where the attacker can trigger the victim program to execute.", input.Description)
-		case "RHSA-2024:9999":
-			assert.Equal(t, "Test vulnerability description", input.Description)
-		case "RHSA-2025:0001":
-			assert.Equal(t, "Test vulnerability for new rpmmod qualifier format", input.Description)
-		case "CVE-2024-11111", "CVE-2024-22222":
-			assert.Equal(t, "Test vulnerability description", input.Description)
-		default:
 			assert.Empty(t, input.Description, "Description for %q", vid)
 		}
 	}

--- a/pkg/vulnsrc/redhat-csaf/csaf_test.go
+++ b/pkg/vulnsrc/redhat-csaf/csaf_test.go
@@ -336,6 +336,19 @@ func TestVulnSrc_Update_WithCustomStore(t *testing.T) {
 			// Unpatched rows use the CVE as bucket ID; there is no RHSA remediation date.
 			assert.True(t, input.ReleaseDate.IsZero(), "ReleaseDate for %q", vid)
 		}
+
+		switch vid {
+		case "RHSA-2024:9941":
+			assert.Equal(t, "A vulnerability was found in PAM. The secret information is stored in memory, where the attacker can trigger the victim program to execute.", input.Description)
+		case "RHSA-2024:9999":
+			assert.Equal(t, "Test vulnerability description", input.Description)
+		case "RHSA-2025:0001":
+			assert.Equal(t, "Test vulnerability for new rpmmod qualifier format", input.Description)
+		case "CVE-2024-11111", "CVE-2024-22222":
+			assert.Equal(t, "Test vulnerability description", input.Description)
+		default:
+			assert.Empty(t, input.Description, "Description for %q", vid)
+		}
 	}
 
 	// Verify repo/NVR mappings were NOT written (custom store skips them)

--- a/pkg/vulnsrc/redhat-csaf/parse.go
+++ b/pkg/vulnsrc/redhat-csaf/parse.go
@@ -35,6 +35,8 @@ type Parser struct {
 	// releaseDates holds the vendor_fix remediation timestamp per RHSA ID.
 	// CVE-only (unpatched) entries are not stored here.
 	releaseDates map[VulnerabilityID]time.Time
+	// descriptions holds vulnerability description from notes[category=description].
+	descriptions map[VulnerabilityID]string
 }
 
 func NewParser() Parser {
@@ -51,6 +53,7 @@ func NewParser() Parser {
 		advisories:   map[Package]map[VulnerabilityID]RawEntries{},
 		cpeSet:       set.NewOrdered[string](),
 		releaseDates: map[VulnerabilityID]time.Time{},
+		descriptions: map[VulnerabilityID]string{},
 	}
 }
 
@@ -208,6 +211,7 @@ func (p *Parser) parseVulnerability(adv CSAFAdvisory, vuln *csaf.Vulnerability) 
 	if cveID == "" {
 		return oops.Errorf("empty CVE ID")
 	}
+	desc := parseDescriptionNotes(vuln.Notes)
 	eb := oops.With("cve_id", cveID)
 
 	// Process remediations
@@ -325,6 +329,12 @@ func (p *Parser) parseVulnerability(adv CSAFAdvisory, vuln *csaf.Vulnerability) 
 				}
 			} else {
 				vulnID = cveID
+			}
+
+			if desc != "" {
+				if _, exists := p.descriptions[vulnID]; !exists {
+					p.descriptions[vulnID] = desc
+				}
 			}
 
 			fixedVersion := product.Package.Version
@@ -456,6 +466,23 @@ func (p *Parser) NVRToCPE() iter.Seq2[string, []string] {
 // or the zero value when no timestamp was recorded for it.
 func (p *Parser) ReleaseDate(vulnID VulnerabilityID) time.Time {
 	return p.releaseDates[vulnID]
+}
+
+// Description returns the vulnerability description from CSAF notes[category=description].
+func (p *Parser) Description(vulnID VulnerabilityID) string {
+	return p.descriptions[vulnID]
+}
+
+func parseDescriptionNotes(notes csaf.Notes) string {
+	for _, note := range notes {
+		if note == nil {
+			continue
+		}
+		if lo.FromPtr(note.NoteCategory) == csaf.CSAFNoteCategoryDescription {
+			return strings.TrimSpace(lo.FromPtr(note.Text))
+		}
+	}
+	return ""
 }
 
 // parseRemediationDateTime parses CSAF remediation date strings (expected RFC3339).

--- a/pkg/vulnsrc/redhat-csaf/parse.go
+++ b/pkg/vulnsrc/redhat-csaf/parse.go
@@ -340,6 +340,7 @@ func (p *Parser) parseRemediation(
 		}
 
 		if desc != "" {
+			// One RHSA can fix multiple CVEs; keep the description from the first CVE document processed.
 			if _, exists := p.descriptions[vulnID]; !exists {
 				p.descriptions[vulnID] = desc
 			}

--- a/pkg/vulnsrc/redhat-csaf/parse.go
+++ b/pkg/vulnsrc/redhat-csaf/parse.go
@@ -204,7 +204,6 @@ func (p *Parser) parseVulnerability(adv CSAFAdvisory, vuln *csaf.Vulnerability) 
 		return nil
 	}
 
-	// Extract severities from Threats
 	severities := p.parseThreats(vuln.Threats)
 
 	cveID := VulnerabilityID(lo.FromPtr(vuln.CVE))
@@ -212,162 +211,169 @@ func (p *Parser) parseVulnerability(adv CSAFAdvisory, vuln *csaf.Vulnerability) 
 		return oops.Errorf("empty CVE ID")
 	}
 	desc := parseDescriptionNotes(vuln.Notes)
-	eb := oops.With("cve_id", cveID)
 
-	// Process remediations
 	// cf. https://redhatproductsecurity.github.io/security-data-guidelines/csaf-vex/#remediations
 	for _, remediation := range vuln.Remediations {
-		if remediation == nil {
-			continue
-		}
-
-		status := p.detectStatus(remediation)
-		if status == types.StatusUnknown {
-			continue
-		}
-		eb = eb.With("status", status)
-
-		// Note on CPE deduplication:
-		// Different product_ids within a single remediation may resolve to identical pairs of PURLs and CPEs.
-		// In such cases, we need to eliminate duplicate records to avoid redundancy.
-		//
-		// For example:
-		// - Product ID: 6Server-RHSCL-2.0-6.5.Z:rh-mariadb100-mariadb-1:10.0.20-1.el6.src
-		//    -> PURL: pkg:rpm/redhat/rh-mariadb100-mariadb@10.0.20-1.el6?arch=src\u0026epoch=1
-		//       CPE: cpe:/a:redhat:rhel_software_collections:2::el6
-		// - Product ID: 6Workstation-RHSCL-2.0:rh-mariadb100-mariadb-1:10.0.20-1.el6.src
-		//    -> PURL: pkg:rpm/redhat/rh-mariadb100-mariadb@10.0.20-1.el6?arch=src\u0026epoch=1
-		//       CPE: cpe:/a:redhat:rhel_software_collections:2::el6
-		//
-		// In this case, we only need to keep one record since they represent the same affected component.
-		type uniqKey struct {
-			Package
-			RawEntry
-		}
-		uniq := set.New[uniqKey]()
-
-		// For each remediation, iterate over product_ids
-		for _, productID := range lo.FromPtr(remediation.ProductIds) {
-			if productID == nil {
-				continue
-			}
-			product := adv.LookUpProduct(*productID)
-			if product == nil {
-				continue
-			}
-			if product.Package.Type != packageurl.TypeRPM {
-				// OCI images are not supported
-				// e.g.
-				//    Product: CERT-MANAGER-1.11-RHEL-9
-				//    Component: cert-manager/cert-manager-operator-rhel9
-				// cf. https://access.redhat.com/security/cve/CVE-2023-39325
-				continue
-			}
-
-			// Add CPEs to the set
-			p.cpeSet.Append(string(product.Stream))
-
-			// PURL format differs between patched and unpatched vulnerabilities:
-			//
-			// Patched (vendor_fix):
-			//   - Binary packages have version and arch: pkg:rpm/redhat/pam@1.5.1-21.el9_5?arch=x86_64
-			//   - Source packages have version and arch=src: pkg:rpm/redhat/pam@1.5.1-21.el9_5?arch=src
-			//
-			// Unpatched (none_available: "Affected"/"Fix deferred", no_fix_planned: "Out of support scope"/"Will not fix"):
-			//   - Binary packages have NO version and NO arch: pkg:rpm/redhat/vim-X11
-			//   - Source packages have arch=src only: pkg:rpm/redhat/vim?arch=src
-			//
-			// cf. https://security.access.redhat.com/data/csaf/v2/vex/2024/cve-2024-10041.json (patched)
-			// cf. https://security.access.redhat.com/data/csaf/v2/vex/2023/cve-2023-5344.json (unpatched)
-			arch := product.Package.Qualifiers.Map()["arch"]
-			if arch == "src" {
-				// Skip source packages to maintain backward compatibility with OVALv2,
-				// which only included binary package names.
-				// Now that SECDATA-1097 has been resolved, binary package names are also
-				// included for unpatched vulnerabilities, so we can safely skip source packages.
-				// cf. https://issues.redhat.com/browse/SECDATA-1097
-				//
-				// TODO(v3): In Trivy DB v3, consider storing only source package names instead
-				// of binary package names for better storage efficiency, as one source package
-				// typically produces multiple binary packages.
-				continue
-			}
-
-			// Log unexpected case: unpatched vulnerability with arch specified
-			// Based on investigation, unpatched binary packages should not have arch in PURL.
-			// If this happens, it may indicate a format change that needs attention.
-			if status != types.StatusFixed && arch != "" {
-				log.Warn("Unexpected arch for unpatched vulnerability",
-					log.String("arch", arch),
-					log.String("cve_id", string(cveID)),
-					log.String("package", product.Package.Name))
-			}
-
-			pkg := Package{
-				Module: product.Module,
-				Name:   product.Package.Name,
-			}
-
-			var vulnID, alias VulnerabilityID
-			if status == types.StatusFixed {
-				vulnID = p.extractRHSAID(remediation)
-				alias = cveID
-				// Store the RHSA release date (once per vulnID) from Remediation.Date.
-				if _, exists := p.releaseDates[vulnID]; !exists {
-					if remediation.Date != nil {
-						t, err := parseRemediationDateTime(*remediation.Date)
-						if err != nil {
-							log.Warn("Skipping invalid RHSA remediation date",
-								log.String("cve_id", string(cveID)),
-								log.String("vulnerability_id", string(vulnID)),
-								log.String("raw", *remediation.Date),
-								log.Err(err))
-						} else {
-							p.releaseDates[vulnID] = t
-						}
-					}
-				}
-			} else {
-				vulnID = cveID
-			}
-
-			if desc != "" {
-				if _, exists := p.descriptions[vulnID]; !exists {
-					p.descriptions[vulnID] = desc
-				}
-			}
-
-			fixedVersion := product.Package.Version
-			if epoch, ok := product.Package.Qualifiers.Map()["epoch"]; ok {
-				fixedVersion = epoch + ":" + fixedVersion
-			}
-
-			rawEntry := RawEntry{
-				FixedVersion: fixedVersion,
-				Severity:     severities[*productID],
-				Arch:         arch,
-				CPE:          product.Stream,
-				Alias:        alias,
-
-				// If the package has a non-empty FixedVersion, we omit the status
-				// to reduce DB size, because it's obviously "fixed".
-				Status: lo.Ternary(product.Package.Version == "", status, 0),
-			}
-
-			// Deduplicate raw entries
-			key := uniqKey{
-				Package:  pkg,
-				RawEntry: rawEntry,
-			}
-			if uniq.Contains(key) {
-				continue
-			}
-			uniq.Append(key)
-
-			p.addRawEntry(pkg, vulnID, rawEntry)
-		}
+		p.parseRemediation(adv, remediation, cveID, desc, severities)
 	}
 	return nil
+}
+
+func (p *Parser) parseRemediation(
+	adv CSAFAdvisory,
+	remediation *csaf.Remediation,
+	cveID VulnerabilityID,
+	desc string,
+	severities map[csaf.ProductID]types.Severity,
+) {
+	if remediation == nil {
+		return
+	}
+
+	status := p.detectStatus(remediation)
+	if status == types.StatusUnknown {
+		return
+	}
+
+	// Note on CPE deduplication:
+	// Different product_ids within a single remediation may resolve to identical pairs of PURLs and CPEs.
+	// In such cases, we need to eliminate duplicate records to avoid redundancy.
+	//
+	// For example:
+	// - Product ID: 6Server-RHSCL-2.0-6.5.Z:rh-mariadb100-mariadb-1:10.0.20-1.el6.src
+	//    -> PURL: pkg:rpm/redhat/rh-mariadb100-mariadb@10.0.20-1.el6?arch=src\u0026epoch=1
+	//       CPE: cpe:/a:redhat:rhel_software_collections:2::el6
+	// - Product ID: 6Workstation-RHSCL-2.0:rh-mariadb100-mariadb-1:10.0.20-1.el6.src
+	//    -> PURL: pkg:rpm/redhat/rh-mariadb100-mariadb@10.0.20-1.el6?arch=src\u0026epoch=1
+	//       CPE: cpe:/a:redhat:rhel_software_collections:2::el6
+	//
+	// In this case, we only need to keep one record since they represent the same affected component.
+	type uniqKey struct {
+		Package
+		RawEntry
+	}
+	uniq := set.New[uniqKey]()
+
+	// For each remediation, iterate over product_ids
+	for _, productID := range lo.FromPtr(remediation.ProductIds) {
+		if productID == nil {
+			continue
+		}
+		product := adv.LookUpProduct(*productID)
+		if product == nil {
+			continue
+		}
+		if product.Package.Type != packageurl.TypeRPM {
+			// OCI images are not supported
+			// e.g.
+			//    Product: CERT-MANAGER-1.11-RHEL-9
+			//    Component: cert-manager/cert-manager-operator-rhel9
+			// cf. https://access.redhat.com/security/cve/CVE-2023-39325
+			continue
+		}
+
+		// Add CPEs to the set
+		p.cpeSet.Append(string(product.Stream))
+
+		// PURL format differs between patched and unpatched vulnerabilities:
+		//
+		// Patched (vendor_fix):
+		//   - Binary packages have version and arch: pkg:rpm/redhat/pam@1.5.1-21.el9_5?arch=x86_64
+		//   - Source packages have version and arch=src: pkg:rpm/redhat/pam@1.5.1-21.el9_5?arch=src
+		//
+		// Unpatched (none_available: "Affected"/"Fix deferred", no_fix_planned: "Out of support scope"/"Will not fix"):
+		//   - Binary packages have NO version and NO arch: pkg:rpm/redhat/vim-X11
+		//   - Source packages have arch=src only: pkg:rpm/redhat/vim?arch=src
+		//
+		// cf. https://security.access.redhat.com/data/csaf/v2/vex/2024/cve-2024-10041.json (patched)
+		// cf. https://security.access.redhat.com/data/csaf/v2/vex/2023/cve-2023-5344.json (unpatched)
+		arch := product.Package.Qualifiers.Map()["arch"]
+		if arch == "src" {
+			// Skip source packages to maintain backward compatibility with OVALv2,
+			// which only included binary package names.
+			// Now that SECDATA-1097 has been resolved, binary package names are also
+			// included for unpatched vulnerabilities, so we can safely skip source packages.
+			// cf. https://issues.redhat.com/browse/SECDATA-1097
+			//
+			// TODO(v3): In Trivy DB v3, consider storing only source package names instead
+			// of binary package names for better storage efficiency, as one source package
+			// typically produces multiple binary packages.
+			continue
+		}
+
+		// Log unexpected case: unpatched vulnerability with arch specified
+		// Based on investigation, unpatched binary packages should not have arch in PURL.
+		// If this happens, it may indicate a format change that needs attention.
+		if status != types.StatusFixed && arch != "" {
+			log.Warn("Unexpected arch for unpatched vulnerability",
+				log.String("arch", arch),
+				log.String("cve_id", string(cveID)),
+				log.String("package", product.Package.Name))
+		}
+
+		pkg := Package{
+			Module: product.Module,
+			Name:   product.Package.Name,
+		}
+
+		var vulnID, alias VulnerabilityID
+		if status == types.StatusFixed {
+			vulnID = p.extractRHSAID(remediation)
+			alias = cveID
+			// Store the RHSA release date (once per vulnID) from Remediation.Date.
+			if _, exists := p.releaseDates[vulnID]; !exists {
+				if remediation.Date != nil {
+					t, err := parseRemediationDateTime(*remediation.Date)
+					if err != nil {
+						log.Warn("Skipping invalid RHSA remediation date",
+							log.String("cve_id", string(cveID)),
+							log.String("vulnerability_id", string(vulnID)),
+							log.String("raw", *remediation.Date),
+							log.Err(err))
+					} else {
+						p.releaseDates[vulnID] = t
+					}
+				}
+			}
+		} else {
+			vulnID = cveID
+		}
+
+		if desc != "" {
+			if _, exists := p.descriptions[vulnID]; !exists {
+				p.descriptions[vulnID] = desc
+			}
+		}
+
+		fixedVersion := product.Package.Version
+		if epoch, ok := product.Package.Qualifiers.Map()["epoch"]; ok {
+			fixedVersion = epoch + ":" + fixedVersion
+		}
+
+		rawEntry := RawEntry{
+			FixedVersion: fixedVersion,
+			Severity:     severities[*productID],
+			Arch:         arch,
+			CPE:          product.Stream,
+			Alias:        alias,
+
+			// If the package has a non-empty FixedVersion, we omit the status
+			// to reduce DB size, because it's obviously "fixed".
+			Status: lo.Ternary(product.Package.Version == "", status, 0),
+		}
+
+		// Deduplicate raw entries
+		key := uniqKey{
+			Package:  pkg,
+			RawEntry: rawEntry,
+		}
+		if uniq.Contains(key) {
+			continue
+		}
+		uniq.Append(key)
+
+		p.addRawEntry(pkg, vulnID, rawEntry)
+	}
 }
 
 func (p *Parser) detectStatus(remediation *csaf.Remediation) types.Status {

--- a/pkg/vulnsrc/redhat-csaf/parse_test.go
+++ b/pkg/vulnsrc/redhat-csaf/parse_test.go
@@ -214,3 +214,15 @@ func TestParser_DetectStatus(t *testing.T) {
 		})
 	}
 }
+
+func TestParser_Description(t *testing.T) {
+	parser := NewParser()
+	require.NoError(t, parser.Parse(filepath.Join("testdata", "happy")))
+
+	assert.Equal(t,
+		"A vulnerability was found in PAM. The secret information is stored in memory, where the attacker can trigger the victim program to execute.",
+		parser.Description("RHSA-2024:9941"),
+	)
+	assert.Equal(t, "Test vulnerability description", parser.Description("RHSA-2024:9999"))
+	assert.Empty(t, parser.Description("CVE-NONEXISTENT"))
+}

--- a/pkg/vulnsrc/redhat-csaf/parse_test.go
+++ b/pkg/vulnsrc/redhat-csaf/parse_test.go
@@ -217,12 +217,15 @@ func TestParser_DetectStatus(t *testing.T) {
 
 func TestParser_Description(t *testing.T) {
 	parser := NewParser()
-	require.NoError(t, parser.Parse(filepath.Join("testdata", "happy")))
+	require.NoError(t, parser.Parse(filepath.Join("testdata", "vuln-list-redhat")))
 
 	assert.Equal(t,
 		"A vulnerability was found in PAM. The secret information is stored in memory, where the attacker can trigger the victim program to execute.",
 		parser.Description("RHSA-2024:9941"),
 	)
-	assert.Equal(t, "Test vulnerability description", parser.Description("RHSA-2024:9999"))
+	// RHSA-2024:9999 is fixed by multiple CVEs; keep the description from the first document processed.
+	assert.Equal(t, "Description from CVE-2024-11111 (stored for RHSA-2024:9999)", parser.Description("RHSA-2024:9999"))
+	assert.Equal(t, "Description from CVE-2024-11111 (stored for RHSA-2024:9999)", parser.Description("CVE-2024-11111"))
+	assert.Equal(t, "Description from CVE-2024-22222 (not stored for RHSA-2024:9999)", parser.Description("CVE-2024-22222"))
 	assert.Empty(t, parser.Description("CVE-NONEXISTENT"))
 }

--- a/pkg/vulnsrc/redhat-csaf/testdata/vuln-list-redhat/csaf-vex/cve-2024-11111.json
+++ b/pkg/vulnsrc/redhat-csaf/testdata/vuln-list-redhat/csaf-vex/cve-2024-11111.json
@@ -264,7 +264,7 @@
       "notes": [
         {
           "category": "description",
-          "text": "Test vulnerability description",
+          "text": "Description from CVE-2024-11111 (stored for RHSA-2024:9999)",
           "title": "Vulnerability description"
         }
       ],

--- a/pkg/vulnsrc/redhat-csaf/testdata/vuln-list-redhat/csaf-vex/cve-2024-22222.json
+++ b/pkg/vulnsrc/redhat-csaf/testdata/vuln-list-redhat/csaf-vex/cve-2024-22222.json
@@ -264,7 +264,7 @@
       "notes": [
         {
           "category": "description",
-          "text": "Test vulnerability description",
+          "text": "Description from CVE-2024-22222 (not stored for RHSA-2024:9999)",
           "title": "Vulnerability description"
         }
       ],


### PR DESCRIPTION
We are missing parsing description for redhat csaf advisory.
Adding this to be available at Aqua side.