### PR TITLE
fix(osv): guard version range parsing against a leading fixed event

### DIFF
--- a/pkg/vulnsrc/osv/osv.go
+++ b/pkg/vulnsrc/osv/osv.go
@@ -337,7 +337,21 @@ func parseAffectedVersions(affected Affected) ([]string, []string, error) {
 			continue
 		}
 
-		var index int
+		// index points at the range opened by the most recent "introduced"
+		// event. -1 means no range is open yet in this events list.
+		index := -1
+		// ensureRange opens a range when a "fixed"/"last_affected" event arrives
+		// without a preceding "introduced". Per the OSV schema an "introduced"
+		// event should come first, but some feeds ship malformed ranges. Treat a
+		// leading "fixed"/"last_affected" as introduced at "0" so we neither
+		// panic on an out-of-range index nor clobber a range from a prior events
+		// list.
+		ensureRange := func() {
+			if index < 0 {
+				affectedRanges = append(affectedRanges, NewVersionRange(affected.Package.Ecosystem, "0"))
+				index = len(affectedRanges) - 1
+			}
+		}
 		for _, event := range affects.Events {
 			switch {
 			// Each "introduced" event implies a new version range
@@ -347,10 +361,12 @@ func parseAffectedVersions(affected Affected) ([]string, []string, error) {
 				index = len(affectedRanges) - 1
 			// e.g. {"introduced": "1.2.0"}, {"fixed": "1.2.5"}
 			case event.Fixed != "":
+				ensureRange()
 				affectedRanges[index].SetFixed(event.Fixed)
 				patchedVersions = append(patchedVersions, event.Fixed)
 			// e.g. {"introduced": "1.2.0"}, {"last_affected": "1.2.5"}
 			case event.LastAffected != "":
+				ensureRange()
 				affectedRanges[index].SetLastAffected(event.LastAffected)
 			}
 		}

--- a/pkg/vulnsrc/osv/parse_internal_test.go
+++ b/pkg/vulnsrc/osv/parse_internal_test.go
@@ -1,0 +1,85 @@
+package osv
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A range's events should start with an "introduced" event, but some feeds ship
+// malformed ranges that start with a "fixed" or "last_affected" event. Make sure
+// the parser handles those without panicking on an out-of-range index.
+func TestParseAffectedVersions_LeadingFixedEvent(t *testing.T) {
+	tests := []struct {
+		name           string
+		affected       Affected
+		wantVulnerable []string
+		wantPatched    []string
+	}{
+		{
+			name: "range starts with a fixed event",
+			affected: Affected{
+				Package: Package{Ecosystem: "npm", Name: "example"},
+				Ranges: []Range{
+					{
+						Type: "ECOSYSTEM",
+						Events: []RangeEvent{
+							{Fixed: "1.2.5"},
+						},
+					},
+				},
+			},
+			wantVulnerable: []string{"<1.2.5"},
+			wantPatched:    []string{"1.2.5"},
+		},
+		{
+			name: "range starts with a last_affected event",
+			affected: Affected{
+				Package: Package{Ecosystem: "npm", Name: "example"},
+				Ranges: []Range{
+					{
+						Type: "ECOSYSTEM",
+						Events: []RangeEvent{
+							{LastAffected: "2.0.0"},
+						},
+					},
+				},
+			},
+			wantVulnerable: []string{"<=2.0.0"},
+			wantPatched:    nil,
+		},
+		{
+			name: "fixed-first range following a complete range keeps both ranges",
+			affected: Affected{
+				Package: Package{Ecosystem: "npm", Name: "example"},
+				Ranges: []Range{
+					{
+						Type: "ECOSYSTEM",
+						Events: []RangeEvent{
+							{Introduced: "1.0.0"},
+							{Fixed: "1.5.0"},
+						},
+					},
+					{
+						Type: "ECOSYSTEM",
+						Events: []RangeEvent{
+							{Fixed: "2.0.0"},
+						},
+					},
+				},
+			},
+			wantVulnerable: []string{">=1.0.0, <1.5.0", "<2.0.0"},
+			wantPatched:    []string{"1.5.0", "2.0.0"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vulnerable, patched, err := parseAffectedVersions(tt.affected)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantVulnerable, vulnerable)
+			assert.Equal(t, tt.wantPatched, patched)
+		})
+	}
+}


### PR DESCRIPTION
While reading the OSV parser I ran into a range shape that makes the DB build panic.

`parseAffectedVersions` walks each range's events and indexes `affectedRanges[index]`, where `index` starts at 0 and is only advanced by an `introduced` event. If a range's first event is `fixed` (or `last_affected`), `affectedRanges` is still empty when the code reads `affectedRanges[0]`:

```json
"ranges": [
  {
    "type": "ECOSYSTEM",
    "events": [
      {"fixed": "1.2.5"}
    ]
  }
]
```

```
panic: runtime error: index out of range [0] with length 0
  .../pkg/vulnsrc/osv/osv.go:350 parseAffectedVersions
```

The OSV schema says an `introduced` event should come first, so this is malformed input, but one bad entry in a feed shouldn't take down the whole build.

There is a quieter variant of the same gap: when a fixed-first range follows a well-formed range, `index` has already been reset to 0 for the new events list, so the `fixed` overwrites the previous range's upper bound instead of opening a new range. That case is silently wrong rather than a crash.

The fix keeps the existing switch and opens an implicit `introduced: "0"` range when a `fixed`/`last_affected` event has no preceding `introduced`, which matches how `"0"` is already treated as "from the beginning" elsewhere in this file. Well-formed input is unchanged.

Added `TestParseAffectedVersions_LeadingFixedEvent` covering a fixed-first range, a last_affected-first range, and a fixed-first range that follows a complete range. It panics on `main` and passes with the change.

```
$ go test ./pkg/vulnsrc/osv/
ok  github.com/aquasecurity/trivy-db/pkg/vulnsrc/osv
```
